### PR TITLE
TermList: new approach to term storage and reduction

### DIFF
--- a/include/pomerol/GreensFunctionPart.h
+++ b/include/pomerol/GreensFunctionPart.h
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2011 Andrey Antipov <Andrey.E.Antipov@gmail.com>
 // Copyright (C) 2010-2011 Igor Krivenko <Igor.S.Krivenko@gmail.com>
@@ -36,6 +36,7 @@
 #include"HamiltonianPart.h"
 #include"FieldOperator.h"
 #include"DensityMatrixPart.h"
+#include"TermList.h"
 
 namespace Pomerol{
 
@@ -59,16 +60,61 @@ class GreensFunctionPart : public Thermal
     /** A reference to a part of a creation operator. */
     const CreationOperatorPart& CX;
 
-    struct Term;
+    /** Every term is a fraction \f$ \frac{R}{z - P} \f$. */
+    struct Term {
+        /** Residue at the pole (\f$ R \f$). */
+        ComplexType Residue;
+        /** Position of the pole (\f$ P \f$). */
+        RealType Pole;
 
+        /** Comparator object for terms */
+        struct Compare {
+            const double Tolerance;
+            Compare(double Tolerance) : Tolerance(Tolerance) {}
+            bool operator()(Term const& t1, Term const& t2) const {
+                return t2.Pole - t1.Pole >= Tolerance;
+            }
+        };
+
+        /** Does term have a negligible residue? */
+        struct IsNegligible {
+            const double Tolerance;
+            IsNegligible(double Tolerance) : Tolerance(Tolerance) {}
+            bool operator()(Term const& t, size_t ToleranceDivisor) const {
+                return std::abs(t.Residue) < Tolerance / ToleranceDivisor;
+            }
+        };
+
+        /** Constructor.
+        * \param[in] Residue Value of the residue.
+        * \param[in] Pole Position of the pole.
+        */
+        Term(ComplexType Residue, RealType Pole);
+        /** Returns a contribution to the Green's function made by this term.
+        * \param[in] Frequency Complex frequency \f$ z \f$ to substitute into this term.
+        */
+        ComplexType operator()(ComplexType Frequency) const;
+
+        /** Returns a contribution to the imaginary-time Green's function made by this term.
+        * \param[in] tau Imaginary time point.
+        * \param[in] beta Inverse temperature.
+        */
+        ComplexType operator()(RealType tau, RealType beta) const;
+
+        /** This operator add a term to this one.
+        * It does not check the similarity of the terms!
+        * \param[in] AnotherTerm Another term to add to this.
+        */
+        Term& operator+=(const Term& AnotherTerm);
+    };
     /** A stream insertion operator for type GreensTerm.
      * \param[in] out An output stream to insert to.
      * \param[in] Term A term to be inserted.
      */
-    friend std::ostream& operator<< (std::ostream& out, const GreensFunctionPart::Term& T);
+    friend std::ostream& operator<< (std::ostream& out, const Term& T);
 
     /** A list of all terms. */
-    std::list<Term> Terms;
+    TermList<Term> Terms;
 
     /** A matrix element with magnitude less than this value is treated as zero. */
     const RealType MatrixElementTolerance; // 1e-8;
@@ -83,7 +129,7 @@ public:
      * \param[in] DMpartInner A reference to a part of the density matrix (inner index).
      * \param[in] DMpartOuter A reference to a part of the density matrix (outer index).
      */
-    GreensFunctionPart(const AnnihilationOperatorPart& C, const CreationOperatorPart& CX, 
+    GreensFunctionPart(const AnnihilationOperatorPart& C, const CreationOperatorPart& CX,
                        const HamiltonianPart& HpartInner, const HamiltonianPart& HpartOuter,
                        const DensityMatrixPart& DMpartInner, const DensityMatrixPart& DMpartOuter);
 
@@ -104,51 +150,10 @@ public:
      */
     ComplexType of_tau(RealType tau) const;
 
-    /** Reduces the number of calculated terms 
-    * \param[in] Tolerance The tolerance for the terms cutoff.
-    * \param[in] ResonantTerms The list of terms.
-    */
-    void reduceTerms(const RealType Tolerance, std::list<Term>& Terms);
-
     /** A difference in energies with magnitude less than this value is treated as zero. */
     const RealType ReduceResonanceTolerance;
     /** Minimal magnitude of the coefficient of a term to take it into account with respect to amount of terms. */
     const RealType ReduceTolerance;
-};
-
-/** Every term is a fraction \f$ \frac{R}{z - P} \f$. */
-struct GreensFunctionPart::Term {
-    /** Residue at the pole (\f$ R \f$). */
-    ComplexType Residue;
-    /** Position of the pole (\f$ P \f$). */
-    RealType Pole;
-
-    /** Constructor.
-     * \param[in] Residue Value of the residue.
-     * \param[in] Pole Position of the pole.
-     */
-    Term(ComplexType Residue, RealType Pole);
-    /** Returns a contribution to the Green's function made by this term.
-     * \param[in] Frequency Complex frequency \f$ z \f$ to substitute into this term.
-     */
-    ComplexType operator()(ComplexType Frequency) const;
-
-    /** Returns a contribution to the imaginary-time Green's function made by this term.
-     * \param[in] tau Imaginary time point.
-     * \param[in] beta Inverse temperature.
-     */
-    ComplexType of_tau(RealType tau, RealType beta) const;
-
-    /** This operator add a term to this one.
-    * It does not check the similarity of the terms! 
-    * \param[in] AnotherTerm Another term to add to this.
-    */
-    Term& operator+=(const Term& AnotherTerm);
-
-    /** Returns true if another term is similar to this
-     * (sum of the terms is again a correct term).
-    */
-    bool isSimilarTo(const Term& T, RealType ReduceResonanceTolerance) const;
 };
 
 std::ostream& operator<< (std::ostream& out, const GreensFunctionPart::Term& T);
@@ -158,15 +163,11 @@ inline ComplexType GreensFunctionPart::operator()(long MatsubaraNumber) const {
     return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber+1)); }
 
 inline ComplexType GreensFunctionPart::operator()(ComplexType z) const {
-    ComplexType G = 0; 
-    for(std::list<Term>::const_iterator pTerm = Terms.begin(); pTerm != Terms.end(); ++pTerm) G += (*pTerm)(z);
-    return G;
+    return Terms(z);
 }
 
 inline ComplexType GreensFunctionPart::of_tau(RealType tau) const {
-    ComplexType G = 0; 
-    for(std::list<Term>::const_iterator pTerm = Terms.begin(); pTerm != Terms.end(); ++pTerm) G += pTerm->of_tau(tau,beta);
-    return G;
+    return Terms(tau, beta);
 }
 
 } // end of namespace Pomerol

--- a/include/pomerol/GreensFunctionPart.h
+++ b/include/pomerol/GreensFunctionPart.h
@@ -78,10 +78,14 @@ class GreensFunctionPart : public Thermal
 
         /** Does term have a negligible residue? */
         struct IsNegligible {
-            const double Tolerance;
+            double Tolerance;
             IsNegligible(double Tolerance) : Tolerance(Tolerance) {}
             bool operator()(Term const& t, size_t ToleranceDivisor) const {
                 return std::abs(t.Residue) < Tolerance / ToleranceDivisor;
+            }
+            friend class boost::serialization::access;
+            template<class Archive> void serialize(Archive & ar, const unsigned int version) {
+                ar & Tolerance;
             }
         };
 

--- a/include/pomerol/TermList.h
+++ b/include/pomerol/TermList.h
@@ -1,0 +1,87 @@
+//
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
+//
+// Copyright (C) 2010-2017 Andrey Antipov <Andrey.E.Antipov@gmail.com>
+// Copyright (C) 2010-2017 Igor Krivenko <Igor.S.Krivenko@gmail.com>
+//
+// pomerol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// pomerol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with pomerol.  If not, see <http://www.gnu.org/licenses/>.
+
+/** \file include/TermList.h
+** \brief List of terms in Lehmann representation
+**
+** \author Igor Krivenko (Igor.S.Krivenko@gmail.com)
+*/
+#ifndef __INCLUDE_TERMLIST_H
+#define __INCLUDE_TERMLIST_H
+
+#include <set>
+
+#include "Misc.h"
+
+namespace Pomerol {
+
+template<typename TermType> class TermList {
+
+    typedef typename TermType::Compare Compare;
+    typedef typename TermType::IsNegligible IsNegligible;
+
+    std::set<TermType, Compare> data;
+    IsNegligible is_negligible;
+
+public:
+
+    TermList(Compare const& compare, IsNegligible const& is_negligible) :
+        data(compare), is_negligible(is_negligible) {}
+
+    void add_term(TermType const& term) {
+        typename std::set<TermType, Compare>::iterator it = data.find(term);
+        if(it == data.end()) { // new term
+            data.insert(term);
+        } else {               // similar term
+            TermType sum = *it;
+            sum += term;
+            data.erase(*it);
+            if(!is_negligible(sum, data.size()))
+                data.insert(sum);
+        }
+    }
+
+    // Some pre-C++11 ugliness ...
+    template<typename Arg1>
+    ComplexType operator()(Arg1 arg1) const {
+        ComplexType res = 0;
+        for(typename std::set<TermType>::const_iterator it = data.begin();
+            it != data.end(); ++it) {
+            res += (*it)(arg1);
+        }
+        return res;
+    }
+
+    template<typename Arg1, typename Arg2>
+    ComplexType operator()(Arg1 arg1, Arg2 arg2) const {
+        ComplexType res = 0;
+        for(typename std::set<TermType>::const_iterator it = data.begin();
+            it != data.end(); ++it) {
+            res += (*it)(arg1, arg2);
+        }
+        return res;
+    }
+
+    void clear() { data.clear(); }
+
+};
+
+}
+#endif // endif :: #ifndef __INCLUDE_TERMLIST_H

--- a/src/pomerol/GreensFunctionPart.cpp
+++ b/src/pomerol/GreensFunctionPart.cpp
@@ -105,6 +105,8 @@ void GreensFunctionPart::compute(void)
             }
         }
     }
+
+    assert(Terms.check_terms());
 }
 
 } // end of namespace Pomerol

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <Andrey.E.Antipov@gmail.com>
 // Copyright (C) 2010-2012 Igor Krivenko <Igor.S.Krivenko@gmail.com>
@@ -34,15 +34,15 @@
 namespace Pomerol{
 
 TwoParticleGF::TwoParticleGF(const StatesClassification& S, const Hamiltonian& H,
-                const AnnihilationOperator& C1, const AnnihilationOperator& C2, 
+                const AnnihilationOperator& C1, const AnnihilationOperator& C2,
                 const CreationOperator& CX3, const CreationOperator& CX4,
                 const DensityMatrix& DM) :
     Thermal(DM.beta), ComputableObject(),
     S(S), H(H), C1(C1), C2(C2), CX3(CX3), CX4(CX4), DM(DM),
     parts(0), Vanishing(true),
-    KroneckerSymbolTolerance (std::numeric_limits<RealType>::epsilon()), 
+    KroneckerSymbolTolerance (std::numeric_limits<RealType>::epsilon()),
     ReduceResonanceTolerance (1e-8),
-    CoefficientTolerance (1e-16), 
+    CoefficientTolerance (1e-16),
     ReduceInvocationThreshold (1e5)
 {
 }
@@ -105,7 +105,7 @@ void TwoParticleGF::prepare()
                   // Select a relevant 'world stripe' (sequence of blocks).
                   if(getRightIndex(p,1,LeftIndices[1]) == LeftIndices[2] && LeftIndices[1].isCorrect() && LeftIndices[2].isCorrect()){
                       // DEBUG
-                      /*DEBUG("new part: "  << S.getBlockInfo(LeftIndices[0]) << " " 
+                      /*DEBUG("new part: "  << S.getBlockInfo(LeftIndices[0]) << " "
                                           << S.getBlockInfo(LeftIndices[1]) << " "
                                           << S.getBlockInfo(LeftIndices[2]) << " "
                                           << S.getBlockInfo(LeftIndices[3]) << " "
@@ -123,12 +123,11 @@ void TwoParticleGF::prepare()
                       (*parts.rbegin())->KroneckerSymbolTolerance = KroneckerSymbolTolerance;
                       (*parts.rbegin())->ReduceResonanceTolerance = ReduceResonanceTolerance;
                       (*parts.rbegin())->CoefficientTolerance = CoefficientTolerance;
-                      (*parts.rbegin())->ReduceInvocationThreshold = ReduceInvocationThreshold;
                       (*parts.rbegin())->MultiTermCoefficientTolerance = MultiTermCoefficientTolerance;
                       }
             }
-    } 
-    if ( parts.size() > 0 ) { 
+    }
+    if ( parts.size() > 0 ) {
         Vanishing = false;
         INFO("TwoParticleGF(" << getIndex(0) << getIndex(1) << getIndex(2) << getIndex(3) << "): " << parts.size() << " parts will be calculated");
         }
@@ -147,21 +146,21 @@ typedef std::vector<freq_tuple> freq_vec_t;
 struct ComputeAndClearWrap
 {
     void run(){
-        p->compute(); 
+        p->compute();
         if (fill_) {
-            int wsize = freqs_->size(); 
+            int wsize = freqs_->size();
             #ifdef POMEROL_USE_OPENMP
             #pragma omp parallel for
             #endif
-            for (int w = 0; w < wsize; ++w) { 
+            for (int w = 0; w < wsize; ++w) {
                 (*data_)[w] += (*p)(boost::get<0>((*freqs_)[w]), boost::get<1>((*freqs_)[w]), boost::get<2>((*freqs_)[w]));
-                } 
+                }
             #ifdef POMEROL_USE_OPENMP
             #pragma omp barrier
             #endif
             }
         if (clear_) p->clear();
-    }; 
+    };
     ComputeAndClearWrap(freq_vec_t const* freqs, std::vector<ComplexType> *data,  TwoParticleGFPart *p, bool clear, bool fill, int complexity = 1):
         freqs_(freqs), data_(data), p(p),clear_(clear), fill_(fill), complexity(complexity){};
     int complexity;
@@ -184,12 +183,12 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, std::vector<boost::t
         bool fill_container = freqs.size() > 0;
         skel.parts.reserve(parts.size());
         m_data.resize(freqs.size(), 0.0);
-        for (size_t i=0; i<parts.size(); i++) { 
+        for (size_t i=0; i<parts.size(); i++) {
             skel.parts.push_back(ComputeAndClearWrap(&freqs, &m_data, parts[i], clear, fill_container, 1));
             };
         std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, true); // actual running - very costly
         int rank = comm.rank();
-        int comm_size = comm.size(); 
+        int comm_size = comm.size();
 
         // Start distributing data
         //DEBUG(comm.rank() << getIndex(0) << getIndex(1) << getIndex(2) << getIndex(3) << " Start distributing data");
@@ -198,11 +197,11 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, std::vector<boost::t
         std::vector<ComplexType> m_data2(m_data.size(), 0.0);
         boost::mpi::reduce(comm, &m_data[0], m_data.size(), &m_data2[0], std::plus<ComplexType>(), 0);
         std::swap(m_data, m_data2);
-        if (!clear) { 
+        if (!clear) {
             for (size_t p = 0; p<parts.size(); p++) {
                 boost::mpi::broadcast(comm, parts[p]->NonResonantTerms, job_map[p]);
                 boost::mpi::broadcast(comm, parts[p]->ResonantTerms, job_map[p]);
-                if (rank == job_map[p]) { 
+                if (rank == job_map[p]) {
                     parts[p]->Status = TwoParticleGFPart::Computed;
                      };
                 };
@@ -220,7 +219,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, std::vector<boost::t
 //         num += (*iter)->getNumResonantTerms();
 //     return num;
 // }
-// 
+//
 // size_t TwoParticleGF::getNumNonResonantTerms() const
 // {
 //     size_t num = 0;

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -188,6 +188,9 @@ void TwoParticleGFPart::compute()
     std::cout << "Total " << NonResonantTerms.size() << "+" << ResonantTerms.size() << "="
               << NonResonantTerms.size() + ResonantTerms.size() << " terms" << std::endl << std::flush;
 
+    assert(NonResonantTerms.check_terms());
+    assert(ResonantTerms.check_terms());
+
     Status = Computed;
 }
 


### PR DESCRIPTION
`TermList` is a new container (template class) for Lehmann representation terms based on `std::set`.

It effectively performs term reduction every time a new term is added to the container. Since element lookups/insertions in `std::set` require only `O(log(size))` operations, this approach is significantly faster than running reduction operations (`O(size^2)` complexity) when a size threshold is reached.

`TermList` also provides a call operator with 1, 2, 3 or 4 arguments, which forwards the arguments to each stored term, and accumulates the sum of the return values.

I did some testing of the new container, and could clearly see a massive performance gain, as well as  reduced memory consumption.