### PR TITLE
Truncate blocks having negligible density matrix

### DIFF
--- a/include/pomerol/DensityMatrix.h
+++ b/include/pomerol/DensityMatrix.h
@@ -29,6 +29,8 @@ class DensityMatrix : public Thermal, public ComputableObject
     const Hamiltonian &H;
     /** A vector of pointers to parts (every part corresponds to a part of the Hamiltonian). */
     std::vector<DensityMatrixPart*> parts;
+    /** A vector of bool: true if the block has not been truncated. */
+    std::vector<bool> block_retained;
 
 public:
     /** Constructor.
@@ -69,6 +71,12 @@ public:
 
     /** Returns an averaged value of the double occupancy. */
     RealType getAverageDoubleOccupancy(ParticleIndex i, ParticleIndex j) const;
+
+    /** Truncate such blocks that do not include any states having larger weight than Tolerance. */
+    void truncateBlocks(RealType Tolerance, bool verbose=true);
+
+    /** Return true if the block has not been truncated. Always true if function truncateBlocks has not been called. */
+    bool isRetained(BlockNumber in) const;
 };
 
 }; // end of namespace Pomerol

--- a/include/pomerol/DensityMatrix.h
+++ b/include/pomerol/DensityMatrix.h
@@ -29,8 +29,6 @@ class DensityMatrix : public Thermal, public ComputableObject
     const Hamiltonian &H;
     /** A vector of pointers to parts (every part corresponds to a part of the Hamiltonian). */
     std::vector<DensityMatrixPart*> parts;
-    /** A vector of bool: true if the block has not been truncated. */
-    std::vector<bool> block_retained;
 
 public:
     /** Constructor.

--- a/include/pomerol/DensityMatrixPart.h
+++ b/include/pomerol/DensityMatrixPart.h
@@ -37,6 +37,9 @@ class DensityMatrixPart : public Thermal
     /** The contribution to the partition function. */
     RealType Z_part;
 
+    /** It is true if this part has not been truncated. */
+    bool retained;
+
 public:
     /** Constructor.
      * \param[in] hpart A reference to a part of the Hamiltonian.
@@ -73,6 +76,12 @@ public:
 
     /** Returns the partition function of this part. */
     RealType getPartialZ(void) const;
+
+    /** Truncates this part if it does not include any states having larger weight than Tolerance. */
+    void truncate(RealType Tolerance);
+
+    /** Returns true if this part has not been truncated. */
+    bool isRetained() const;
 };
 
 } // end of namespace Pomerol

--- a/src/pomerol/DensityMatrix.cpp
+++ b/src/pomerol/DensityMatrix.cpp
@@ -94,5 +94,47 @@ RealType DensityMatrix::getAverageDoubleOccupancy(ParticleIndex i, ParticleIndex
     NN += (*iter)->getAverageDoubleOccupancy(i,j);
     return NN;
 };
- 
+
+void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose)
+{
+    // init vector<bool> at false
+    block_retained.resize(S.NumberOfBlocks());
+    for(int i=0; i<block_retained.size(); i++)  block_retained[i]=false;
+
+    // check if each state has weight larger than Tolerance,
+    // and set true for the corresponding block
+    RealType sum=0;  // sum of weights (to be 1.0)
+    int n_states_relevant=0;  // count states having weight larger than Tolerance
+    for (QuantumState i=0; i<S.getNumberOfStates(); i++){
+        RealType w = getWeight(i);
+        if ( w > Tolerance ){
+            block_retained[S.getBlockNumber(i)] = true;
+            sum += w;
+            ++n_states_relevant;
+        }
+    }
+
+    if(verbose){
+        // count blocks and states retained
+        int n_blocks_retained=0, n_states_retained=0;
+        for(BlockNumber i=0; i<S.NumberOfBlocks(); i++)
+            if(isRetained(i)){
+                ++n_blocks_retained;
+                n_states_retained += S.getBlockSize(i);
+            }
+        INFO("Number of blocks retained: " << n_blocks_retained);
+        INFO("Number of states retained: " << n_states_retained);
+        INFO("Number of states having weight larger than Tolerance: " << n_states_relevant);
+        INFO("Total weight of the trucated states: " << sum-1.0);
+    }
+}
+
+bool DensityMatrix::isRetained(BlockNumber in) const
+{
+    if (int(in) < block_retained.size())  // if function truncateBlocks has been called
+        return block_retained[in];
+    else
+        return true;
+}
+
 } // end of namespace Pomerol

--- a/src/pomerol/DensityMatrix.cpp
+++ b/src/pomerol/DensityMatrix.cpp
@@ -3,7 +3,7 @@
 namespace Pomerol{
 
 DensityMatrix::DensityMatrix(const StatesClassification& S, const Hamiltonian& H, RealType beta) : 
-    Thermal(beta), ComputableObject(), S(S), H(H)
+    Thermal(beta), ComputableObject(), S(S), H(H), block_retained(S.NumberOfBlocks(),true)
 {}
 
 DensityMatrix::~DensityMatrix()
@@ -97,9 +97,8 @@ RealType DensityMatrix::getAverageDoubleOccupancy(ParticleIndex i, ParticleIndex
 
 void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose)
 {
-    // init vector<bool> at false
-    block_retained.resize(S.NumberOfBlocks());
-    for(int i=0; i<block_retained.size(); i++)  block_retained[i]=false;
+    // fill vector block_retained with false, and assign true later
+    std::fill(block_retained.begin(), block_retained.end(), false);
 
     // check if each state has weight larger than Tolerance,
     // and set true for the corresponding block
@@ -131,10 +130,7 @@ void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose)
 
 bool DensityMatrix::isRetained(BlockNumber in) const
 {
-    if (int(in) < block_retained.size())  // if function truncateBlocks has been called
-        return block_retained[in];
-    else
-        return true;
+    return block_retained[in];
 }
 
 } // end of namespace Pomerol

--- a/src/pomerol/DensityMatrixPart.cpp
+++ b/src/pomerol/DensityMatrixPart.cpp
@@ -2,7 +2,7 @@
 
 namespace Pomerol{
 DensityMatrixPart::DensityMatrixPart(const StatesClassification &S, const HamiltonianPart& hpart, RealType beta, RealType GroundEnergy) :
-    Thermal(beta), S(S), hpart(hpart), GroundEnergy(GroundEnergy), weights(hpart.getSize())
+    Thermal(beta), S(S), hpart(hpart), GroundEnergy(GroundEnergy), weights(hpart.getSize()), retained(true)
 {}
 
 RealType DensityMatrixPart::computeUnnormalized(void)
@@ -86,6 +86,22 @@ RealType DensityMatrixPart::getAverageDoubleOccupancy(ParticleIndex i, ParticleI
 RealType DensityMatrixPart::getWeight(InnerQuantumState s) const
 {
     return weights(s);
+}
+
+void DensityMatrixPart::truncate(RealType Tolerance)
+{
+    retained = false;
+    InnerQuantumState partSize = weights.size();
+    for(InnerQuantumState s = 0; s < partSize; ++s)
+        if ( weights(s) > Tolerance ){
+            retained = true;
+            break;
+        }
+}
+
+bool DensityMatrixPart::isRetained() const
+{
+    return retained;
 }
 
 } // end of namespace Pomerol

--- a/src/pomerol/GreensFunction.cpp
+++ b/src/pomerol/GreensFunction.cpp
@@ -44,7 +44,9 @@ void GreensFunction::prepare(void)
         // Select a relevant 'world stripe' (sequence of blocks).
         if(Cleft == CXright && Cright == CXleft){
         //DEBUG(S.getQuantumNumbers(Cleft) << "|" << S.getQuantumNumbers(Cright) << "||" << S.getQuantumNumbers(CXleft) << "|" << S.getQuantumNumbers(CXright) );
-            parts.push_back(new GreensFunctionPart(
+            // check if retained blocks are included. If not, do not push.
+            if ( DM.isRetained(Cleft) || DM.isRetained(Cright) )
+                parts.push_back(new GreensFunctionPart(
                               (AnnihilationOperatorPart&)C.getPartFromLeftIndex(Cleft),
                               (CreationOperatorPart&)CX.getPartFromRightIndex(CXright),
                               H.getPart(Cright), H.getPart(Cleft),

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -77,6 +77,12 @@ void TwoParticleGF::prepare()
                   // < LeftIndices[3] | CX4 | LeftIndices[0] >
                   // Select a relevant 'world stripe' (sequence of blocks).
                   if(getRightIndex(p,1,LeftIndices[1]) == LeftIndices[2] && LeftIndices[1].isCorrect() && LeftIndices[2].isCorrect()){
+                      { // check if retained blocks are included. If not, do not push.
+                          bool include_block_retained=false;
+                          for(int k=0; k<4; k++)
+                              if (DM.isRetained(LeftIndices[k]))  include_block_retained=true;
+                          if(!include_block_retained)  continue;
+                      }
                       // DEBUG
                       /*DEBUG("new part: "  << S.getBlockInfo(LeftIndices[0]) << " "
                                           << S.getBlockInfo(LeftIndices[1]) << " "
@@ -202,4 +208,3 @@ unsigned short TwoParticleGF::getPermutationNumber ( const Permutation3& in )
 }
 
 } // end of namespace Pomerol
-

--- a/tutorial/example2site.cpp
+++ b/tutorial/example2site.cpp
@@ -222,6 +222,8 @@ int main(int argc, char* argv[])
     rho.prepare();
     // Actually compute the density matrix.
     rho.compute();
+    // Truncate blocks that have only small contributions
+    // rho.truncateBlocks(1e-15);
 
     /* Lehmanns representation of the Green's function required creation and
      * annihilation operators, calculated in the basis of eigenstates of the
@@ -287,4 +289,3 @@ void print_section (const std::string& str)
   std::cout << std::string(str.size(),'=') << std::endl;
     };
 }
-


### PR DESCRIPTION
Dear Andrey,

Here is my proposal of improvement.

I'm using pomerol library for a multiorbital model, and found that there are a lot of parts which give no contribution in two-particle GF. It is shown on the output like
```
[543/1096] P0 : part 542 [1] run;
Total 0+0=0 terms
```
It decreases the performance especially for multiorbital models (e.g. 7 orbitals for l=3).

To settle this issue, I introduced truncation of blocks according to the density matrix. Those which result in `0+0=0 terms` are thrown away in function prepare, and do not evaluated in function compute. I found that this modification yields considerable improvement of performance for two-particle GF in a 7 orbital model.

I showed how to use this functionality in tutorial (commented out), although it does not improve performance in that simple model.

I hope you review my modification and if no problem, please merge into your repository.

Best regards,
Junya otsuki