### PR TITLE
[cmake] Consider relevant environment variables in FindEigen3.cmake

### DIFF
--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -63,6 +63,9 @@ else (EIGEN3_INCLUDE_DIR)
 
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
       PATHS
+      $ENV{EIGEN_ROOT}/include
+      ENV CPATH
+      ENV CPLUS_INCLUDE_PATH
       ${CMAKE_INSTALL_PREFIX}/include
       ${KDE4_INCLUDE_DIR}
       PATH_SUFFIXES eigen3 eigen


### PR DESCRIPTION
Just adding a few relevant environment variables to the search paths for FindEigen3.cmake