### PR TITLE
Fixed complication error for old version of Eigen3. Implicit cast som…

### DIFF
--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -107,7 +107,7 @@ void Hamiltonian::computeGroundEnergy()
     RealVectorType LEV(size_t(S.NumberOfBlocks()));
     BlockNumber NumberOfBlocks = parts.size();
     for (BlockNumber CurrentBlock=0; CurrentBlock<NumberOfBlocks; CurrentBlock++) {
-	    LEV(CurrentBlock,0) = parts[CurrentBlock]->getMinimumEigenvalue();
+	    LEV(static_cast<int>(CurrentBlock),0) = parts[CurrentBlock]->getMinimumEigenvalue();
     }
     GroundEnergy=LEV.minCoeff();
 }


### PR DESCRIPTION
This is a workaround for old versions of Eigen3.
Implicit cast to int somehow fails.