### PR TITLE
[v2.0] Reduce usage of Boost libraries

### DIFF
--- a/include/mpi_dispatcher/mpi_skel.hpp
+++ b/include/mpi_dispatcher/mpi_skel.hpp
@@ -6,7 +6,6 @@
 #define __INCLUDE_MPISKEL_H
 
 #include <boost/mpi.hpp>
-#include <boost/local_function.hpp>
 #include <boost/serialization/vector.hpp>
 
 //#include <type_traits>
@@ -57,8 +56,9 @@ std::map<pMPI::JobId, pMPI::WorkerId> mpi_skel<WrapType>::run(const boost::mpi::
         // prepare one Master on a root process for distributing parts.size() jobs
         std::vector<pMPI::JobId> job_order(parts.size());
         for (size_t i=0; i<job_order.size(); i++) job_order[i] = i;
-        int BOOST_LOCAL_FUNCTION_TPL(bind this_, std::size_t l, std::size_t r) {
-            return (this_->parts[l].complexity > this_->parts[r].complexity); } BOOST_LOCAL_FUNCTION_NAME_TPL(comp1)
+        auto comp1 = [this](std::size_t l, std::size_t r) -> int {
+          return (parts[l].complexity > parts[r].complexity);
+        };
         std::sort(job_order.begin(), job_order.end(), comp1);
         disp.reset(new pMPI::MPIMaster(comm,job_order,true));
     };

--- a/include/mpi_dispatcher/mpi_skel.hpp
+++ b/include/mpi_dispatcher/mpi_skel.hpp
@@ -7,11 +7,12 @@
 
 #include <boost/mpi.hpp>
 #include <boost/local_function.hpp>
-#include <boost/scoped_ptr.hpp>
 #include <boost/serialization/vector.hpp>
 
 //#include <type_traits>
 #include "mpi_dispatcher.hpp"
+
+#include <memory>
 
 namespace pMPI {
 
@@ -20,7 +21,7 @@ struct ComputeWrap {
     PartType *x;
     int complexity;
     ComputeWrap(PartType &y, int complexity = 1):x(&y),complexity(complexity){};
-    void run(){x->compute();}; 
+    void run(){x->compute();};
     ComputeWrap(){};
 };
 
@@ -29,7 +30,7 @@ struct PrepareWrap {
     PartType *x;
     int complexity;
     PrepareWrap(PartType &y, int complexity = 1):x(&y),complexity(complexity){};
-    void run(){x->prepare();}; 
+    void run(){x->prepare();};
     PrepareWrap(){};
 };
 
@@ -45,19 +46,19 @@ template <typename WrapType>
 std::map<pMPI::JobId, pMPI::WorkerId> mpi_skel<WrapType>::run(const boost::mpi::communicator& comm, bool VerboseOutput)
 {
     int rank = comm.rank();
-    int comm_size = comm.size(); 
+    int comm_size = comm.size();
     comm.barrier();
     if (rank==0) { std::cout << "Calculating " << parts.size() << " jobs using " << comm_size << " procs." << std::endl; };
 
     size_t ROOT = 0;
-    boost::scoped_ptr<pMPI::MPIMaster> disp;
+    std::unique_ptr<pMPI::MPIMaster> disp;
 
-    if (comm.rank() == ROOT) { 
+    if (comm.rank() == ROOT) {
         // prepare one Master on a root process for distributing parts.size() jobs
         std::vector<pMPI::JobId> job_order(parts.size());
         for (size_t i=0; i<job_order.size(); i++) job_order[i] = i;
         int BOOST_LOCAL_FUNCTION_TPL(bind this_, std::size_t l, std::size_t r) {
-            return (this_->parts[l].complexity > this_->parts[r].complexity); } BOOST_LOCAL_FUNCTION_NAME_TPL(comp1) 
+            return (this_->parts[l].complexity > this_->parts[r].complexity); } BOOST_LOCAL_FUNCTION_NAME_TPL(comp1)
         std::sort(job_order.begin(), job_order.end(), comp1);
         disp.reset(new pMPI::MPIMaster(comm,job_order,true));
     };
@@ -66,16 +67,16 @@ std::map<pMPI::JobId, pMPI::WorkerId> mpi_skel<WrapType>::run(const boost::mpi::
 
     // Start calculating data
     for (pMPI::MPIWorker worker(comm,ROOT);!worker.is_finished();) {
-        if (rank == ROOT) disp->order(); 
-        worker.receive_order(); 
+        if (rank == ROOT) disp->order();
+        worker.receive_order();
         if (worker.is_working()) { // for a specific worker
             JobId p = worker.current_job();
-            if (VerboseOutput) std::cout << "["<<p+1<<"/"<<parts.size()<< "] P" << comm.rank() 
+            if (VerboseOutput) std::cout << "["<<p+1<<"/"<<parts.size()<< "] P" << comm.rank()
                                          << " : part " << p << " [" << parts[p].complexity << "] run;" << std::endl;
-            parts[p].run(); 
-            worker.report_job_done(); 
+            parts[p].run();
+            worker.report_job_done();
         };
-        if (rank == ROOT) disp->check_workers(); // check if there are free workers 
+        if (rank == ROOT) disp->check_workers(); // check if there are free workers
     };
     // at this moment all communication is finished
     //comm.barrier();
@@ -84,26 +85,26 @@ std::map<pMPI::JobId, pMPI::WorkerId> mpi_skel<WrapType>::run(const boost::mpi::
 	if (VerboseOutput && rank==ROOT) std::cout << "done." << std::endl;
     comm.barrier();
     std::map<pMPI::JobId, pMPI::WorkerId> job_map;
-    if (rank == ROOT) { 
-        job_map = disp -> DispatchMap; 
+    if (rank == ROOT) {
+        job_map = disp -> DispatchMap;
         std::vector<pMPI::JobId> jobs(job_map.size());
         std::vector<pMPI::WorkerId> workers(job_map.size());
 
-        std::map<pMPI::JobId, pMPI::WorkerId>::const_iterator it = job_map.begin(); 
-        for (int i=0; i<workers.size(); i++) { 
+        std::map<pMPI::JobId, pMPI::WorkerId>::const_iterator it = job_map.begin();
+        for (int i=0; i<workers.size(); i++) {
             jobs[i] = it->first;
-            workers[i] = it->second; 
+            workers[i] = it->second;
             ++it;
         }
         boost::mpi::broadcast(comm, jobs, ROOT);
         boost::mpi::broadcast(comm, workers, ROOT);
-    } 
+    }
     else {
         std::vector<pMPI::JobId> jobs(parts.size());
         boost::mpi::broadcast(comm, jobs, ROOT);
         std::vector<pMPI::WorkerId> workers(parts.size());
         boost::mpi::broadcast(comm, workers, ROOT);
-        for (size_t i=0; i<jobs.size(); i++) job_map[jobs[i]] = workers[i]; 
+        for (size_t i=0; i<jobs.size(); i++) job_map[jobs[i]] = workers[i];
     }
     return job_map;
 }

--- a/include/pomerol/GFContainer.h
+++ b/include/pomerol/GFContainer.h
@@ -14,9 +14,11 @@
 #include"FieldOperatorContainer.h"
 #include"IndexContainer2.h"
 
+#include <memory>
+
 namespace Pomerol{
 
-typedef boost::shared_ptr<GreensFunction> GFPointer;
+typedef std::shared_ptr<GreensFunction> GFPointer;
 
 class GFContainer: public IndexContainer2<GreensFunction,GFContainer>, public Thermal
 {

--- a/include/pomerol/Hamiltonian.h
+++ b/include/pomerol/Hamiltonian.h
@@ -1,6 +1,6 @@
 /** \file include/pomerol/Hamiltonian.h
 ** \brief A storage of the matrix elements of the hamiltonian in Fock basis, provides eigenvalues and eigenfunctions
-** 
+**
 ** \author Andrey Antipov(Andrey.E.Antipov@gmail.com)
 ** \author Igor Krivenko (Igor.S.Krivenko@gmail.com)
 */
@@ -13,6 +13,8 @@
 #include "StatesClassification.h"
 #include "HamiltonianPart.h"
 
+#include <memory>
+
 #ifdef ENABLE_SAVE_PLAINTEXT
 #include <boost/filesystem/path.hpp>
 #endif
@@ -20,14 +22,14 @@
 namespace Pomerol{
 
 /** This class represents a Hamiltonian, written as a matrix of matrix elements in a Fock basis.
- * It is a container for several hamiltonian parts, each for single defined QuantumNumbers and a corresponding BlockNumber. 
- * It provides eigenvalues and eigenfunctions of any of its parts once they are obtained within its parts. 
+ * It is a container for several hamiltonian parts, each for single defined QuantumNumbers and a corresponding BlockNumber.
+ * It provides eigenvalues and eigenfunctions of any of its parts once they are obtained within its parts.
  * The diagonalization and entering routines are done inside of HamiltonianPart instances.
  */
 class Hamiltonian : public ComputableObject
 {
     /** Array of pointers to the Hamiltonian Parts */
-    std::vector<boost::shared_ptr<HamiltonianPart> > parts;
+    std::vector<std::shared_ptr<HamiltonianPart> > parts;
     /** A reference to the IndexClassification object. */
     const IndexClassification &IndexInfo;
     /** A reference to the IndexHamiltonian object. */

--- a/include/pomerol/IndexClassification.h
+++ b/include/pomerol/IndexClassification.h
@@ -1,6 +1,6 @@
 /** \file IndexClassification.h
 **  \brief Declaration of IndexClassification class.
-** 
+**
 **  \author    Andrey Antipov (Andrey.E.Antipov@gmail.com)
 */
 
@@ -29,35 +29,34 @@ private:
     /** A vector of IndexInfo - each element corresponds to its number. */
     std::vector<IndexInfo*> IndicesToInfo;
 public:
-    /** Returns a list of indices, which belong to a current site. 
-     * \param[in] SiteLabel Label of the Site. 
+    /** Returns a list of indices, which belong to a current site.
+     * \param[in] SiteLabel Label of the Site.
      */
    // std::list<ParticleIndex>& findIndices(const std::string &SiteLabel);
-    /** Returns a list of indices, which belong to a current site. 
+    /** Returns a list of indices, which belong to a current site.
      * \param[in] A Lattice::Site to match.
      */
     //std::list<ParticleIndex>& findIndices(const Lattice::Site &Site);
-    
+
     /** Checks if the index belongs to the space of indices
      * \param[in] in Index to check. */
     bool checkIndex(ParticleIndex in);
 
-    /** Returns a ParticleIndex, which corresponds to a given site, orbital and spin. */ 
+    /** Returns a ParticleIndex, which corresponds to a given site, orbital and spin. */
     ParticleIndex getIndex(const IndexClassification::IndexInfo& ) const;
     /** Returns a ParticleIndex, which corresponds to a IndexClassification::IndexInfo. */
-    ParticleIndex getIndex(const std::string &Site, const unsigned short &Orbital, const unsigned short &Spin) const; 
+    ParticleIndex getIndex(const std::string &Site, const unsigned short &Orbital, const unsigned short &Spin) const;
     /** Return all information about the given index. */
-    //boost::tuple<std::string, unsigned short, unsigned short> getInfo(ParticleIndex in) const;
     IndexInfo getInfo(ParticleIndex in) const;
     /** Returns total number of ParticleIndices. */
     const ParticleIndex getIndexSize() const;
 
-    /** Constructor 
-     * \param[in] L A pointer to a Lattice Object. 
+    /** Constructor
+     * \param[in] L A pointer to a Lattice Object.
      */
     IndexClassification (const Lattice::SiteMap &Sites);
-    
-    /** Define the index space 
+
+    /** Define the index space
      * \param[in] order_spins Group indices by spins
     */
     void prepare(bool order_spins = false);
@@ -71,7 +70,7 @@ public:
 };
 
 /** This structure holds the site label, the orbital and spin of a ParticleIndex */
-struct IndexClassification::IndexInfo 
+struct IndexClassification::IndexInfo
 {
 private:
     /** Site label hash */

--- a/include/pomerol/IndexContainer2.h
+++ b/include/pomerol/IndexContainer2.h
@@ -9,8 +9,8 @@
 
 #include"IndexClassification.h"
 
-#include<set>
-#include<boost/shared_ptr.hpp>
+#include <memory>
+#include <set>
 
 namespace Pomerol {
 
@@ -19,7 +19,7 @@ template<typename ElementType, typename SourceObject>
 class IndexContainer2 {
 protected:
     const IndexClassification& IndexInfo;
-    std::map<IndexCombination2,boost::shared_ptr<ElementType> > ElementsMap;
+    std::map<IndexCombination2,std::shared_ptr<ElementType> > ElementsMap;
 
     SourceObject* pSource;
 
@@ -72,7 +72,7 @@ void IndexContainer2<ElementType,SourceObject>::fill(std::set<IndexCombination2>
 
     std::set<IndexCombination2> II;
     if(InitialIndices.size()==0)           // If there are no indices provided,
-        II = enumerateInitialIndices(); // Enumerate all possible combinations. 
+        II = enumerateInitialIndices(); // Enumerate all possible combinations.
     else
         II = InitialIndices;    // Otherwise use provided indices.
 
@@ -87,7 +87,7 @@ void IndexContainer2<ElementType,SourceObject>::fill(std::set<IndexCombination2>
 template<typename ElementType, typename SourceObject>
 ElementType& IndexContainer2<ElementType,SourceObject>::set(const IndexCombination2& Indices)
 {
-    boost::shared_ptr<ElementType> pElement(pSource->createElement(Indices));
+    std::shared_ptr<ElementType> pElement(pSource->createElement(Indices));
     ElementsMap[Indices] = pElement;
 
     DEBUG("IndexContainer2::set() at " << this << ": "
@@ -99,7 +99,7 @@ ElementType& IndexContainer2<ElementType,SourceObject>::set(const IndexCombinati
 template<typename ElementType, typename SourceObject>
 ElementType& IndexContainer2<ElementType,SourceObject>::operator()(const IndexCombination2& Indices)
 {
-    typename std::map<IndexCombination2,boost::shared_ptr<ElementType> >::iterator
+    typename std::map<IndexCombination2,std::shared_ptr<ElementType> >::iterator
         iter = ElementsMap.find(Indices);
 
     if(iter == ElementsMap.end()){

--- a/include/pomerol/IndexContainer4.h
+++ b/include/pomerol/IndexContainer4.h
@@ -1,6 +1,6 @@
  //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <Andrey.E.Antipov@gmail.com>
 // Copyright (C) 2010-2012 Igor Krivenko <Igor.S.Krivenko@gmail.com>
@@ -29,8 +29,8 @@
 
 #include"IndexClassification.h"
 
-#include<set>
-#include<boost/shared_ptr.hpp>
+#include <memory>
+#include <set>
 
 namespace Pomerol {
 
@@ -38,10 +38,10 @@ namespace Pomerol {
 template<typename ElementType>
 struct ElementWithPermFreq
 {
-    boost::shared_ptr<ElementType> pElement;
+    std::shared_ptr<ElementType> pElement;
     const Permutation4 FrequenciesPermutation;
 
-    ElementWithPermFreq(boost::shared_ptr<ElementType> pElement, Permutation4 FrequenciesPermutation);
+    ElementWithPermFreq(std::shared_ptr<ElementType> pElement, Permutation4 FrequenciesPermutation);
 
     ComplexType operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const;
     operator ElementType&();
@@ -59,7 +59,7 @@ protected:
 
 public:
     std::map<IndexCombination4,ElementWithPermFreq<ElementType> > ElementsMap;
-    std::map<IndexCombination4, boost::shared_ptr<ElementType>  > NonTrivialElements;
+    std::map<IndexCombination4, std::shared_ptr<ElementType>  > NonTrivialElements;
     IndexContainer4<ElementType,SourceObject>(SourceObject* pSource, const IndexClassification& IndexInfo);
 
     void fill(std::set<IndexCombination4> InitialIndices = std::set<IndexCombination4>());
@@ -79,7 +79,7 @@ public:
 /////////////////////////
 template<typename ElementType> inline
 ElementWithPermFreq<ElementType>::ElementWithPermFreq(
-    boost::shared_ptr<ElementType> pElement, Permutation4 FrequenciesPermutation) :
+    std::shared_ptr<ElementType> pElement, Permutation4 FrequenciesPermutation) :
     pElement(pElement), FrequenciesPermutation(FrequenciesPermutation)
 {}
 
@@ -139,7 +139,7 @@ void IndexContainer4<ElementType,SourceObject>::fill(std::set<IndexCombination4>
 
     std::set<IndexCombination4> II;
     if(InitialIndices.size()==0)           // If there are no indices provided,
-        II = enumerateInitialIndices(); // Enumerate all possible combinations. 
+        II = enumerateInitialIndices(); // Enumerate all possible combinations.
     else
         II = InitialIndices;    // Otherwise use provided indices.
 
@@ -155,12 +155,12 @@ inline
 ElementWithPermFreq<ElementType>& IndexContainer4<ElementType,SourceObject>::set(const IndexCombination4& Indices)
 {
     // TODO: rewrite this method entirely (merge with fill()?)
-    boost::shared_ptr<ElementType> pElement(pSource->createElement(Indices));
+    std::shared_ptr<ElementType> pElement(pSource->createElement(Indices));
     typename std::map<IndexCombination4,ElementWithPermFreq<ElementType> >::iterator iter =
         ElementsMap.insert(
             std::pair<IndexCombination4,ElementWithPermFreq<ElementType> >
                 (Indices,ElementWithPermFreq<ElementType>(pElement,permutations4[0]))).first;
-    
+
     DEBUG("IndexContainer4::fill() at " << this << ": " <<
         "added an element with indices " << Indices <<
         " and frequency permutation " << permutations4[0] <<
@@ -168,8 +168,8 @@ ElementWithPermFreq<ElementType>& IndexContainer4<ElementType,SourceObject>::set
 
     bool SameCIndices = (Indices.Index1==Indices.Index2);
     bool SameCXIndices = (Indices.Index3==Indices.Index4);
-    
-    NonTrivialElements.insert(std::make_pair(Indices,pElement)); 
+
+    NonTrivialElements.insert(std::make_pair(Indices,pElement));
 
     if(!SameCIndices){
         IndexCombination4 Indices2134(Indices.Index2,Indices.Index1,Indices.Index3,Indices.Index4);

--- a/include/pomerol/IndexHamiltonian.h
+++ b/include/pomerol/IndexHamiltonian.h
@@ -1,6 +1,6 @@
 /** \file IndexHamiltonian.h
 **  \brief Declaration of the IndexHamiltonian class - the Hamiltonian written in Index space.
-** 
+**
 **  \author    Andrey Antipov (Andrey.E.Antipov@gmail.com)
 */
 
@@ -12,11 +12,10 @@
 #include "IndexClassification.h"
 #include "Lattice.h"
 #include "Operator.h"
-#include <boost/shared_ptr.hpp>
 
 namespace Pomerol{
 
-/* This class stores all matrix elements of a Hamiltonian in the index space. All terms have the ordering, 
+/* This class stores all matrix elements of a Hamiltonian in the index space. All terms have the ordering,
  * defined at the TERM_DEFAULT_SEQUENCE, which is by default taken as \f$ c^{\dagger} c c^{\dagger} c ... \f$. */
 class IndexHamiltonian : public Operator
 {
@@ -38,7 +37,7 @@ public:
     //void printTerms(unsigned int order) const;
 };
 
-/** This function is used in the IndexHamiltonian prepare method. 
+/** This function is used in the IndexHamiltonian prepare method.
  * This defines the default sequence of elements to be used in IndexHamiltonian OpTerm storage.. */
 inline std::vector<bool>& TERM_DEFAULT_SEQUENCE(unsigned int N)
 {

--- a/include/pomerol/Misc.h
+++ b/include/pomerol/Misc.h
@@ -18,10 +18,7 @@
 #include<map>
 #include<iomanip>
 
-
-#include<boost/make_shared.hpp>
 #include<boost/dynamic_bitset.hpp>
-#include<boost/utility.hpp>
 #include<boost/serialization/complex.hpp>
 
 

--- a/include/pomerol/Misc.h
+++ b/include/pomerol/Misc.h
@@ -19,8 +19,6 @@
 #include<iomanip>
 
 
-#include<boost/shared_ptr.hpp>
-#include<boost/scoped_ptr.hpp>
 #include<boost/make_shared.hpp>
 #include<boost/dynamic_bitset.hpp>
 #include<boost/tuple/tuple.hpp>

--- a/include/pomerol/Misc.h
+++ b/include/pomerol/Misc.h
@@ -21,7 +21,6 @@
 
 #include<boost/make_shared.hpp>
 #include<boost/dynamic_bitset.hpp>
-#include<boost/tuple/tuple.hpp>
 #include<boost/utility.hpp>
 #include<boost/serialization/complex.hpp>
 
@@ -69,10 +68,6 @@ typedef RealType MelemType;
 /** Index represents a combination of spin, orbital, and lattice indices **/
 typedef unsigned int ParticleIndex;
 
-//enum Statistics { fermion, boson };
-//typedef boost::tuple<bool,Statistics,ParticleIndex> AtomicOp;
-//typedef AtomicOp<1,fermion,ParticleIndex> AtomicCdag;
-
 /** Fock State representation. */
 typedef boost::dynamic_bitset<> FockState;
 const FockState ERROR_FOCK_STATE = FockState(); // A state with the size==0 is an error state
@@ -87,11 +82,6 @@ typedef unsigned long QuantumState;
 typedef unsigned int ParticleIndex;
 
 enum OperatorStatistics {fermion, boson};
-/** A creation and annihilation operators */
-//typedef boost::tuple<bool,OperatorStatistics,ModeIndex,ParticleIndex> ElementaryOperator;
-//typedef std::tuple<bool,OperatorStatistics,ParticleIndex> ElementaryOperator;
-//template<ParticleIndex P> using ElemCreatOpFermion = typename ElementaryOperator<1,0,P>;
-//template<ParticleIndex> typedef boost::tuple<0,0,ParticleIndex> ElemAnnihOpFermion;
 
 /** Dense complex matrix. */
 typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor> ComplexMatrixType;

--- a/include/pomerol/Operator.h
+++ b/include/pomerol/Operator.h
@@ -1,6 +1,6 @@
 /** \file Operator.h
 **  \brief Declaration of the Operator, Operator::Term classes
-** 
+**
 **  \author    Igor Krivenko (Igor.S.Krivenko@gmail.com)
 */
 
@@ -10,6 +10,7 @@
 
 #include <ostream>
 #include <istream>
+#include <tuple>
 #include <vector>
 #include <map>
 #include <limits>
@@ -18,14 +19,13 @@
 #include <boost/foreach.hpp>
 #include <boost/operators.hpp>
 #include <boost/type_traits/has_less.hpp>
-#include <boost/tuple/tuple_comparison.hpp>
 
 #include "Misc.h"
 #include "Index.h"
 #include "IndexClassification.h"
 #include "Lattice.h"
 
-namespace Pomerol { 
+namespace Pomerol {
 
 class Operator;
 
@@ -45,9 +45,9 @@ class Operator :
     boost::multipliable2<Operator, MelemType
     > > > > > >
 {
-    
+
 public:
-    
+
     Operator(){};
     Operator(Operator const& in):monomials(in.monomials){};
     //Operator(Operator &&);
@@ -59,35 +59,35 @@ public:
     Operator& operator=(Operator && o) noexcept
         { std::swap(monomials,o.monomials); return *this; }
 #endif
-*/       
+*/
     // Type of a fundamental operator
     enum op_type  {creation, annihilation };
-    static const int create_annihilate = 0;  // to use boost::get<create_annihilate>(...)
-    
+    static const int create_annihilate = 0;  // to use std::get<create_annihilate>(...)
+
     // A composite index labels one fundamental operator. It is LessThanComparable.
-    typedef boost::tuple<op_type, ParticleIndex> composite_index_t;
-    
+    typedef std::tuple<op_type, ParticleIndex> composite_index_t;
+
     friend std::ostream& operator<<(std::ostream &os, composite_index_t i)
     {
-        if(boost::get<create_annihilate>(i) == creation) os << "^+";
+        if(std::get<create_annihilate>(i) == creation) os << "^+";
         os << "(";
-        os << boost::get<1>(i);
+        os << std::get<1>(i);
         os << ")";
         return os;
     }
-    
+
     // Monomial: an ordered set of creation/annihilation operators
     // NB: std::vector supports lexicographical less-than comparison using std::lexicographical_compare
     typedef std::vector<composite_index_t> monomial_t;
-    
+
     friend std::ostream& operator<<(std::ostream &os, monomial_t const& m)
     {
-        BOOST_FOREACH(const composite_index_t & c, m){ 
+        BOOST_FOREACH(const composite_index_t & c, m){
             os << "C" << c;
         }
         return os;
     }
-    
+
     friend
     bool operator<(monomial_t const& m1, monomial_t const& m2)
     {
@@ -105,7 +105,7 @@ public:
     {
         if(op.monomials.size() != 0){
             bool print_plus = false;
-            BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials){ 
+            BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials){
                 os << (print_plus ? " + " : "" ) << m.second;
                 if(m.first.size()) os << "*";
                 os << m.first;
@@ -115,72 +115,72 @@ public:
             os << "0";
         return os;
     }
-    
+
     // Iterators (only const!)
     typedef monomials_map_t::const_iterator const_iterator;
     const_iterator begin() const { return monomials.begin(); }
     const_iterator end() const { return monomials.end(); }
     //const_iterator cbegin() const { return monomials.cbegin(); }
     //const_iterator cend() const { return monomials.cend(); }
-    
+
     // Algebraic operations involving MelemType constants
     Operator operator-() const
     {
         Operator tmp(*this);
-        BOOST_FOREACH( monomials_map_t::value_type& m, tmp.monomials) { 
+        BOOST_FOREACH( monomials_map_t::value_type& m, tmp.monomials) {
             m.second = -m.second; };
         return tmp;
     }
-    
+
     Operator& operator+=(const MelemType alpha)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        boost::tie(it,is_new_monomial) = monomials.insert(std::make_pair(monomial_t(0),alpha));
+        std::tie(it,is_new_monomial) = monomials.insert(std::make_pair(monomial_t(0),alpha));
         if(!is_new_monomial){
             it->second += alpha;
             erase_zero_monomial(monomials,it);
         }
         return *this;
     }
-    
+
     Operator& operator-=(const MelemType alpha)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        boost::tie(it,is_new_monomial) = monomials.insert(std::make_pair(monomial_t(0),-alpha));
+        std::tie(it,is_new_monomial) = monomials.insert(std::make_pair(monomial_t(0),-alpha));
         if(!is_new_monomial){
             it->second -= alpha;
             erase_zero_monomial(monomials,it);
         }
         return *this;
     }
-    
+
     friend
     Operator operator-(const MelemType alpha, Operator const& op)
     {
         return -op + alpha;
     }
-    
+
     Operator& operator*= (const MelemType alpha)
     {
         if(std::abs(alpha) < 100*std::numeric_limits<RealType>::epsilon()){
-            monomials.clear(); 
+            monomials.clear();
         } else {
-            BOOST_FOREACH(monomials_map_t::value_type& m, monomials) { 
+            BOOST_FOREACH(monomials_map_t::value_type& m, monomials) {
                 m.second *= alpha;
             };
         }
         return *this;
     }
-    
+
     // Algebraic operations
     Operator& operator+=(Operator const& op)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) { 
-            boost::tie(it,is_new_monomial) = monomials.insert(m);
+        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) {
+            std::tie(it,is_new_monomial) = monomials.insert(m);
             if(!is_new_monomial){
                 it->second += m.second;
                 erase_zero_monomial(monomials,it);
@@ -188,13 +188,13 @@ public:
         }
         return *this;
     }
-    
+
     Operator& operator-=(Operator const& op)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) { 
-            boost::tie(it,is_new_monomial) = monomials.insert(std::make_pair(m.first,-m.second));
+        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) {
+            std::tie(it,is_new_monomial) = monomials.insert(std::make_pair(m.first,-m.second));
             if(!is_new_monomial){
                 it->second -= m.second;
                 erase_zero_monomial(monomials,it);
@@ -202,21 +202,21 @@ public:
         }
         return *this;
     }
-    
+
     Operator& operator*=(Operator const& op)
     {
         monomials_map_t tmp_map; // product will be stored here
-        BOOST_FOREACH(const monomials_map_t::value_type& m, monomials)  
-            BOOST_FOREACH(const monomials_map_t::value_type& op_m, op.monomials) { 
+        BOOST_FOREACH(const monomials_map_t::value_type& m, monomials)
+            BOOST_FOREACH(const monomials_map_t::value_type& op_m, op.monomials) {
                 // prepare an unnormalized product
                 monomial_t product_m;
                 product_m.reserve(m.first.size() + op_m.first.size());
                 std::copy(m.first.begin(), m.first.end(), std::back_inserter(product_m));
                 std::copy(op_m.first.begin(), op_m.first.end(), std::back_inserter(product_m));
-                
+
                 normalize_and_insert(product_m, m.second*op_m.second, tmp_map);
             }
-            
+
         std::swap(monomials, tmp_map);
         return *this;
     }
@@ -225,11 +225,11 @@ public:
 
       /** Returns a matrix element of the operator.
      * \param[in] bra A state to the left of the operator.
-     * \param[in] ket A state to the right of the operator.     
+     * \param[in] ket A state to the right of the operator.
      * \param[out] Resulting matrix element.
      */
     virtual MelemType getMatrixElement(const FockState &bra, const FockState &ket) const;
-    
+
     /** Returns the matrix element of an operator between two states represented by a linear combination of FockState's. */
     virtual MelemType getMatrixElement( const VectorType & bra, const VectorType &ket, const std::vector<FockState> &states) const;
 
@@ -237,22 +237,22 @@ public:
      * \param[in] ket A state to act on.
      * \param[out] A map of states and corresponding matrix elements, which are the result of an action.
      */
-    static boost::tuple<FockState,MelemType> actRight(const monomial_t &in, const FockState &ket);
+    static std::tuple<FockState,MelemType> actRight(const monomial_t &in, const FockState &ket);
     virtual std::map<FockState, MelemType> actRight(const FockState &ket) const;
 
     /** Returns an operator that is a commutator of the current operator and another one
      * \param[in] rhs An operator to calculate a commutator with.
-     * \param[out] Resulting operator. 
+     * \param[out] Resulting operator.
      */
     Operator getCommutator(const Operator &rhs) const;
-    
+
     /** Returns an operator that is an anticommutator of the current operator and another one
      * \param[in] rhs An operator to calculate an anticommutator with.
-     * \param[out] Resulting operator. 
+     * \param[out] Resulting operator.
      */
     Operator getAntiCommutator(const Operator &rhs) const;
 
-    /** Checks if current operator commutes with a given one. 
+    /** Checks if current operator commutes with a given one.
      * \param[in] rhs An operator to calculate a commutator with.
     */
     bool commutes(const Operator &rhs) const;
@@ -260,8 +260,8 @@ public:
 
     friend
     bool operator==(const Operator &lhs, const Operator &rhs);
- 
-      
+
+
     // Free factory functions
     friend Operator Pomerol::OperatorPresets::c(ParticleIndex);
     friend Operator Pomerol::OperatorPresets::c_dag(ParticleIndex);
@@ -269,10 +269,10 @@ public:
     friend Operator Pomerol::OperatorPresets::n_offdiag(ParticleIndex, ParticleIndex);
 
 protected:
-    
+
     // Use a template parameter instead of std::complex<double>
     monomials_map_t monomials;
-    
+
     // Normalize a monomial and insert into a map
     static void normalize_and_insert(monomial_t & m, MelemType coeff, monomials_map_t & target)
     {
@@ -292,14 +292,14 @@ protected:
                         // Are we swapping C and C^+ with the same indices?
                         // A bit ugly ...
                         composite_index_t cur_index_flipped_type(cur_index);
-                        boost::get<create_annihilate>(cur_index_flipped_type) =
-                            op_type(!bool(boost::get<create_annihilate>(cur_index_flipped_type)));
+                        std::get<create_annihilate>(cur_index_flipped_type) =
+                            op_type(!bool(std::get<create_annihilate>(cur_index_flipped_type)));
                         if(prev_index == cur_index_flipped_type){
                             monomial_t new_m;
                             new_m.reserve(m.size() - 2);
                             std::copy(m.begin(), m.begin() + n-1, std::back_inserter(new_m));
                             std::copy(m.begin() + n+1, m.end(), std::back_inserter(new_m));
-                            
+
                             normalize_and_insert(new_m, coeff, target);
                         }
                         coeff = -coeff;
@@ -309,17 +309,17 @@ protected:
                 }
             } while(is_swapped);
         }
-        
+
         // Insert the result
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        boost::tie(it,is_new_monomial) = target.insert(std::make_pair(m, coeff));
+        std::tie(it,is_new_monomial) = target.insert(std::make_pair(m, coeff));
         if(!is_new_monomial){
             it->second += coeff;
             erase_zero_monomial(target,it);
         }
     }
-    
+
     // Erase a monomial with a close-to-zero coefficient.
     static void erase_zero_monomial(monomials_map_t & m,
                                     monomials_map_t::iterator & it)
@@ -341,21 +341,21 @@ protected:
 namespace OperatorPresets {
 inline Operator c(ParticleIndex index) {
     typedef Operator c_t;
-    
+
     c_t tmp;
-    c_t::monomial_t m; m.push_back(boost::make_tuple(c_t::annihilation, index));
+    c_t::monomial_t m; m.push_back(std::make_tuple(c_t::annihilation, index));
     tmp.monomials.insert(std::make_pair(m,1.0));
     return tmp;
 }
 
 inline Operator c_dag(ParticleIndex index) {
     typedef Operator c_dag_t;
-    
+
     c_dag_t tmp;
     c_dag_t::monomial_t m;
-    m.push_back(boost::make_tuple(c_dag_t::creation, index));
+    m.push_back(std::make_tuple(c_dag_t::creation, index));
     tmp.monomials.insert(std::make_pair(m,1.0));
-    return tmp;    
+    return tmp;
 }
 
 inline Operator n(ParticleIndex index) {
@@ -363,8 +363,8 @@ inline Operator n(ParticleIndex index) {
 
     n_t tmp;
     n_t::monomial_t m;
-    m.push_back(boost::make_tuple(n_t::creation, index));
-    m.push_back(boost::make_tuple(n_t::annihilation, index));
+    m.push_back(std::make_tuple(n_t::creation, index));
+    m.push_back(std::make_tuple(n_t::annihilation, index));
     tmp.monomials.insert(std::make_pair(m,1.0));
 
     return tmp;
@@ -375,8 +375,8 @@ inline Operator n_offdiag(ParticleIndex index1, ParticleIndex index2) {
 
     n_t tmp;
     n_t::monomial_t m;
-    m.push_back(boost::make_tuple(n_t::creation, index1));
-    m.push_back(boost::make_tuple(n_t::annihilation, index2));
+    m.push_back(std::make_tuple(n_t::creation, index1));
+    m.push_back(std::make_tuple(n_t::annihilation, index2));
     tmp.monomials.insert(std::make_pair(m,1.0));
 
     return tmp;

--- a/include/pomerol/Operator.h
+++ b/include/pomerol/Operator.h
@@ -16,9 +16,7 @@
 #include <limits>
 #include <cmath>
 #include <iterator>
-#include <boost/foreach.hpp>
 #include <boost/operators.hpp>
-#include <boost/type_traits/has_less.hpp>
 
 #include "Misc.h"
 #include "Index.h"
@@ -82,9 +80,8 @@ public:
 
     friend std::ostream& operator<<(std::ostream &os, monomial_t const& m)
     {
-        BOOST_FOREACH(const composite_index_t & c, m){
+        for(auto const& c : m)
             os << "C" << c;
-        }
         return os;
     }
 
@@ -105,7 +102,7 @@ public:
     {
         if(op.monomials.size() != 0){
             bool print_plus = false;
-            BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials){
+            for(auto const& m : op.monomials) {
                 os << (print_plus ? " + " : "" ) << m.second;
                 if(m.first.size()) os << "*";
                 os << m.first;
@@ -127,8 +124,8 @@ public:
     Operator operator-() const
     {
         Operator tmp(*this);
-        BOOST_FOREACH( monomials_map_t::value_type& m, tmp.monomials) {
-            m.second = -m.second; };
+        for(auto & m : tmp.monomials)
+            m.second = -m.second;
         return tmp;
     }
 
@@ -167,9 +164,7 @@ public:
         if(std::abs(alpha) < 100*std::numeric_limits<RealType>::epsilon()){
             monomials.clear();
         } else {
-            BOOST_FOREACH(monomials_map_t::value_type& m, monomials) {
-                m.second *= alpha;
-            };
+            for(auto & m : monomials) m.second *= alpha;
         }
         return *this;
     }
@@ -179,7 +174,7 @@ public:
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) {
+        for(auto const& m : op.monomials) {
             std::tie(it,is_new_monomial) = monomials.insert(m);
             if(!is_new_monomial){
                 it->second += m.second;
@@ -193,7 +188,7 @@ public:
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
-        BOOST_FOREACH(const monomials_map_t::value_type& m, op.monomials) {
+        for(auto const& m : op.monomials) {
             std::tie(it,is_new_monomial) = monomials.insert(std::make_pair(m.first,-m.second));
             if(!is_new_monomial){
                 it->second -= m.second;
@@ -206,8 +201,8 @@ public:
     Operator& operator*=(Operator const& op)
     {
         monomials_map_t tmp_map; // product will be stored here
-        BOOST_FOREACH(const monomials_map_t::value_type& m, monomials)
-            BOOST_FOREACH(const monomials_map_t::value_type& op_m, op.monomials) {
+        for(auto const& m : monomials)
+            for(auto const& op_m : op.monomials) {
                 // prepare an unnormalized product
                 monomial_t product_m;
                 product_m.reserve(m.first.size() + op_m.first.size());

--- a/include/pomerol/Symmetrizer.h
+++ b/include/pomerol/Symmetrizer.h
@@ -12,8 +12,10 @@
 #include "IndexClassification.h"
 #include "IndexHamiltonian.h"
 #include "ComputableObject.h"
-#include <boost/functional/hash.hpp>
+
+#include <memory>
 #include <set>
+#include <boost/functional/hash.hpp>
 
 namespace Pomerol{
 
@@ -44,7 +46,7 @@ private:
     /** Total amount of symmetries found. */
     int NSymmetries;
     /** A vector of operators that commute with the Hamiltonian. */
-    std::vector<boost::shared_ptr<Operator> > Operations;
+    std::vector<std::shared_ptr<Operator> > Operations;
 
 
     /** This method finds all possible symmetry operations. */ /** lattice permutation operators, that commute with the hamiltonian. */
@@ -60,7 +62,7 @@ public:
 
     bool checkSymmetry(const Operator &in);
     /** Get a vector of operators that commute with the Hamiltonian. */
-    const std::vector<boost::shared_ptr<Operator> >& getOperations() const;
+    const std::vector<std::shared_ptr<Operator> >& getOperations() const;
     /** Get a sample QuantumNumbers. Their amount is set. */
     QuantumNumbers getQuantumNumbers() const;
 };

--- a/include/pomerol/TwoParticleGF.h
+++ b/include/pomerol/TwoParticleGF.h
@@ -8,6 +8,7 @@
 #define __INCLUDE_TWOPARTICLEGF_H
 
 #include <sstream>
+#include <tuple>
 #include <iomanip>
 
 #include"Misc.h"
@@ -114,7 +115,7 @@ public:
      */
     std::vector<ComplexType> compute(
         bool clear = false,
-        std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> >(),
+        std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<std::tuple<ComplexType, ComplexType, ComplexType> >(),
         const boost::mpi::communicator & comm = boost::mpi::communicator()
     );
 

--- a/include/pomerol/TwoParticleGFContainer.h
+++ b/include/pomerol/TwoParticleGFContainer.h
@@ -28,6 +28,7 @@
 #include"IndexContainer4.h"
 
 #include <memory>
+#include <tuple>
 
 namespace Pomerol{
 
@@ -50,18 +51,18 @@ public:
     void prepareAll(const std::set<IndexCombination4>& InitialIndices = std::set<IndexCombination4>());
     std::map<IndexCombination4,std::vector<ComplexType> > computeAll(
         bool clearTerms = false,
-        std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> >(),
+        std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<std::tuple<ComplexType, ComplexType, ComplexType> >(),
         const boost::mpi::communicator & comm = boost::mpi::communicator(),
         bool split = true
         );
     std::map<IndexCombination4,std::vector<ComplexType> > computeAll_nosplit(
         bool clearTerms,
-        std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> >(),
+        std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<std::tuple<ComplexType, ComplexType, ComplexType> >(),
         const boost::mpi::communicator & comm = boost::mpi::communicator()
         );
     std::map<IndexCombination4,std::vector<ComplexType> > computeAll_split(
         bool clearTerms,
-        std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> >(),
+        std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs  = std::vector<std::tuple<ComplexType, ComplexType, ComplexType> >(),
         const boost::mpi::communicator & comm = boost::mpi::communicator()
         );
 

--- a/include/pomerol/TwoParticleGFContainer.h
+++ b/include/pomerol/TwoParticleGFContainer.h
@@ -27,9 +27,11 @@
 #include"FieldOperatorContainer.h"
 #include"IndexContainer4.h"
 
+#include <memory>
+
 namespace Pomerol{
 
-typedef boost::shared_ptr<TwoParticleGF> GF2Pointer;
+typedef std::shared_ptr<TwoParticleGF> GF2Pointer;
 
 class TwoParticleGFContainer: public IndexContainer4<TwoParticleGF,TwoParticleGFContainer>, public Thermal
 {

--- a/prog/anderson.cpp
+++ b/prog/anderson.cpp
@@ -32,6 +32,7 @@
 #include <string>
 #include <iostream>
 #include <algorithm>
+#include <tuple>
 
 #include <pomerol.h>
 
@@ -120,7 +121,7 @@ int main(int argc, char* argv[])
 
     U = p["U"].as<double>();
     e0 = p["ed"].as<double>();
-    boost::tie(beta, calc_gf, calc_2pgf) = boost::make_tuple(
+    std::tie(beta, calc_gf, calc_2pgf) = std::make_tuple(
         p["beta"].as<double>(), p["calc_gf"].as<int>(), p["calc_2pgf"].as<int>());
     calc_gf = calc_gf || calc_2pgf;
 
@@ -228,9 +229,9 @@ int main(int argc, char* argv[])
 
     if (calc_gf) {
         int ntau; double eta, step, hbw;
-        boost::tie(ntau, eta, step, hbw) = boost::make_tuple(p["gf.ntau"].as<int>(), p["gf.eta"].as<double>(), p["gf.step"].as<double>(), p["gf.D"].as<double>());
+        std::tie(ntau, eta, step, hbw) = std::make_tuple(p["gf.ntau"].as<int>(), p["gf.eta"].as<double>(), p["gf.step"].as<double>(), p["gf.D"].as<double>());
         int wf_min, wf_max, wb_min, wb_max;
-        boost::tie(wf_min, wf_max, wb_min, wb_max) = boost::make_tuple(p["wf_min"].as<int>(), p["wf_max"].as<int>(), p["wb_min"].as<int>(), p["wb_max"].as<int>());
+        std::tie(wf_min, wf_max, wb_min, wb_max) = std::make_tuple(p["wf_min"].as<int>(), p["wf_max"].as<int>(), p["wb_min"].as<int>(), p["wb_max"].as<int>());
 
         mpi_cout << "1-particle Green's functions calc" << std::endl;
         std::set<ParticleIndex> f; // a set of indices to evaluate c and c^+
@@ -306,7 +307,7 @@ int main(int argc, char* argv[])
             G4.prepare();
             comm.barrier(); // MPI::BARRIER
 
-            std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
+            std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
             fmatsubara_grid fgrid(wf_min, wf_max, beta);
             bmatsubara_grid bgrid(wb_min, wb_max + 1, beta);
             freqs_2pgf.reserve(fgrid.size() * fgrid.size() * bgrid.size());

--- a/prog/anderson.cpp
+++ b/prog/anderson.cpp
@@ -25,7 +25,6 @@
 ** \author Andrey Antipov (Andrey.E.Antipov@gmail.com)
 */
 
-#include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
 #include <boost/mpi.hpp>
 
@@ -258,7 +257,7 @@ int main(int argc, char* argv[])
 
             mpi_cout << "Saving imfreq G" << ind2 << " on "<< 4*wf_max << " Matsubara freqs. " << std::endl;
             grid_object<std::complex<double>, fmatsubara_grid> gf_imfreq (fmatsubara_grid(wf_min, wf_max*4, beta));
-            std::string ind_str = boost::lexical_cast<std::string>(ind2.Index1)+ boost::lexical_cast<std::string>(ind2.Index2);
+            std::string ind_str = std::to_string(ind2.Index1)+ std::to_string(ind2.Index2);
             for (auto p : gf_imfreq.grid().points()) { gf_imfreq[p] = GF(p.value()); }
             gf_imfreq.savetxt("gw_imfreq_"+ ind_str +".dat");
 
@@ -285,10 +284,10 @@ int main(int argc, char* argv[])
             std::set<IndexCombination4> indices4;
             // 2PGF = <T c c c^+ c^+>
             indices4.insert(index_comb);
-            std::string ind_str = boost::lexical_cast<std::string>(index_comb.Index1)
-                                + boost::lexical_cast<std::string>(index_comb.Index2)
-                                + boost::lexical_cast<std::string>(index_comb.Index3)
-                                + boost::lexical_cast<std::string>(index_comb.Index4);
+            std::string ind_str = std::to_string(index_comb.Index1)
+                                + std::to_string(index_comb.Index2)
+                                + std::to_string(index_comb.Index3)
+                                + std::to_string(index_comb.Index4);
 
             AnnihilationOperator const& C1 = Operators.getAnnihilationOperator(index_comb.Index1);
             AnnihilationOperator const& C2 = Operators.getAnnihilationOperator(index_comb.Index2);
@@ -340,7 +339,7 @@ int main(int argc, char* argv[])
                             ++w_ind;
                             }
                         }
-                    std::string fv1_name = "chi"+ind_str+"_W"+boost::lexical_cast<std::string>(std::imag(W.value()))+".dat";
+                    std::string fv1_name = "chi"+ind_str+"_W"+std::to_string(std::imag(W.value()))+".dat";
                     full_vertex_1freq.savetxt(fv1_name);
                     }
                 }

--- a/prog/hubbard2d.cpp
+++ b/prog/hubbard2d.cpp
@@ -34,7 +34,6 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-#include <boost/local_function.hpp>
 
 #include <string>
 #include <iostream>
@@ -128,8 +127,7 @@ int main(int argc, char* argv[])
 
     /* Add sites */
     std::vector<std::string> names(L);
-    //auto SiteIndexF = [size_x](size_t x, size_t y){return y*size_x + x;};
-    int BOOST_LOCAL_FUNCTION (bind size_x, size_t x, size_t y){return y*size_x + x;} BOOST_LOCAL_FUNCTION_NAME(SiteIndexF)
+    auto SiteIndexF = [size_x](size_t x, size_t y) -> int { return y*size_x + x; };
     for (size_t y=0; y<size_y; y++)
         for (size_t x=0; x<size_x; x++)
         {

--- a/prog/hubbard2d.cpp
+++ b/prog/hubbard2d.cpp
@@ -41,7 +41,7 @@
 #include <algorithm>
 #include <tclap/CmdLine.h>
 
-#include<cstdlib>
+#include <cstdlib>
 #include <fstream>
 
 #include <pomerol.h>
@@ -111,11 +111,11 @@ int main(int argc, char* argv[])
         cmd.parse( argc, argv );
         U = U_arg.getValue();
         mu = (mu_arg.isSet()?mu_arg.getValue():U/2);
-        boost::tie(t, beta, calc_gf, calc_2pgf, reduce_tol, coeff_tol) = boost::make_tuple( t_arg.getValue(), beta_arg.getValue(),
+        std::tie(t, beta, calc_gf, calc_2pgf, reduce_tol, coeff_tol) = std::make_tuple( t_arg.getValue(), beta_arg.getValue(),
             gf_arg.getValue(), twopgf_arg.getValue(), reduce_tol_arg.getValue(), coeff_tol_arg.getValue());
-        boost::tie(size_x, size_y) = boost::make_tuple(x_arg.getValue(), y_arg.getValue());
-        boost::tie(wf_max, wb_max) = boost::make_tuple(wn_arg.getValue(), wb_arg.getValue());
-        boost::tie(eta, hbw, step) = boost::make_tuple(eta_arg.getValue(), (hbw_arg.isSet()?hbw_arg.getValue():2.*U), step_arg.getValue());
+        std::tie(size_x, size_y) = std::make_tuple(x_arg.getValue(), y_arg.getValue());
+        std::tie(wf_max, wb_max) = std::make_tuple(wn_arg.getValue(), wb_arg.getValue());
+        std::tie(eta, hbw, step) = std::make_tuple(eta_arg.getValue(), (hbw_arg.isSet()?hbw_arg.getValue():2.*U), step_arg.getValue());
         calc_gf = calc_gf || calc_2pgf;
         calc_gf = calc_gf || calc_2pgf;
         }

--- a/prog/hubbard2d_model.h
+++ b/prog/hubbard2d_model.h
@@ -27,7 +27,7 @@ public:
     _mu = p.count("mu") ? p["mu"].as<double>() :U()/2;
     _t = p["t"].as<double>();
     _tp = p["tp"].as<double>();
-    boost::tie(size_x, size_y) = boost::make_tuple(p["x"].as<int>(), p["y"].as<int>());
+    std::tie(size_x, size_y) = std::make_tuple(p["x"].as<int>(), p["y"].as<int>());
   }
 
   virtual std::pair<ParticleIndex, ParticleIndex> get_node(const IndexClassification &IndexInfo) {

--- a/prog/quantum_model.cpp
+++ b/prog/quantum_model.cpp
@@ -88,7 +88,7 @@ void quantum_model::compute() {
         // Save Matsubara GF from pi/beta to pi/beta*(4*wf_max + 1)
         std::cout << "Saving imfreq G" << ind2 << " on " << 4 * wf_max << " Matsubara freqs. " << std::endl;
         grid_object<std::complex<double>, fmatsubara_grid> gf_imfreq (fmatsubara_grid(wf_min, wf_max*4, beta, true));
-        std::string ind_str = boost::lexical_cast<std::string>(ind2.Index1)+ boost::lexical_cast<std::string>(ind2.Index2);
+        std::string ind_str = std::to_string(ind2.Index1)+ std::to_string(ind2.Index2);
         for (auto p : gf_imfreq.grid().points()) { gf_imfreq[p] = GF(p.value()); }
         gf_imfreq.savetxt("gw_imfreq_"+ ind_str +".dat");
 
@@ -115,10 +115,10 @@ void quantum_model::compute() {
       std::set<IndexCombination4> indices4;
       // 2PGF = <T c c c^+ c^+>
       indices4.insert(index_comb);
-      std::string ind_str = boost::lexical_cast< std::string>(index_comb.Index1)
-                            + boost::lexical_cast< std::string>(index_comb.Index2)
-                            + boost::lexical_cast< std::string>(index_comb.Index3)
-                            + boost::lexical_cast< std::string>(index_comb.Index4);
+      std::string ind_str = std::to_string(index_comb.Index1)
+                            + std::to_string(index_comb.Index2)
+                            + std::to_string(index_comb.Index3)
+                            + std::to_string(index_comb.Index4);
 
       AnnihilationOperator const& C1 = Operators.getAnnihilationOperator(index_comb.Index1);
       AnnihilationOperator const& C2 = Operators.getAnnihilationOperator(index_comb.Index2);
@@ -168,7 +168,7 @@ void quantum_model::compute() {
               ++w_ind;
             }
           }
-          std::string fv1_name = "chi"+ind_str+"_W"+boost::lexical_cast<std::string>(std::imag(W.value()))+".dat";
+          std::string fv1_name = "chi"+ind_str+"_W"+std::to_string(std::imag(W.value()))+".dat";
           full_vertex_1freq.savetxt(fv1_name);
         }
       }

--- a/prog/quantum_model.cpp
+++ b/prog/quantum_model.cpp
@@ -63,9 +63,9 @@ void quantum_model::compute() {
     std::set<IndexCombination2> indices2; // a set of pairs of indices to evaluate Green's function
 
     int ntau; double eta, step, hbw;
-    boost::tuples::tie(ntau, eta, step, hbw) = boost::tuples::make_tuple(p["gf.ntau"].as<int>(), p["gf.eta"].as<double>(), p["gf.step"].as<double>(), p["gf.D"].as<double>());
+    std::tie(ntau, eta, step, hbw) = std::make_tuple(p["gf.ntau"].as<int>(), p["gf.eta"].as<double>(), p["gf.step"].as<double>(), p["gf.D"].as<double>());
     int wf_min, wf_max, wb_min, wb_max;
-    boost::tuples::tie(wf_min, wf_max, wb_min, wb_max) = boost::tuples::make_tuple(p["wf_min"].as<int>(), p["wf_max"].as<int>(), p["wb_min"].as<int>(), p["wb_max"].as<int>());
+    std::tie(wf_min, wf_max, wb_min, wb_max) = std::make_tuple(p["wf_min"].as<int>(), p["wf_max"].as<int>(), p["wb_min"].as<int>(), p["wb_max"].as<int>());
 
     // Take only impurity spin up and spin down indices
     f.insert(u0);
@@ -136,7 +136,7 @@ void quantum_model::compute() {
 
       G4.prepare();
       comm.barrier(); // MPI::BARRIER
-      std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
+      std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
       fmatsubara_grid fgrid(wf_min, wf_max, beta, true);
       bmatsubara_grid bgrid(wb_min, wb_max, beta, true);
       freqs_2pgf.reserve(fgrid.size() * fgrid.size() * bgrid.size());
@@ -144,7 +144,7 @@ void quantum_model::compute() {
         for (auto w3 : fgrid.values()) {
           for (auto w2 : fgrid.values()) {
             ComplexType w1 = W+w3;
-            freqs_2pgf.push_back(boost::make_tuple(w1,w2,w3));
+            freqs_2pgf.push_back(std::make_tuple(w1,w2,w3));
           }
         }
       }
@@ -164,7 +164,7 @@ void quantum_model::compute() {
               std::complex<double> val = chi_freq_data[w_ind];
               full_vertex[W][w3.index()][w2.index()] = val;
               full_vertex_1freq[w3.index()][w2.index()] = val;
-              if (!is_float_equal(boost::get<0>(freqs_2pgf[w_ind]), W.value()+w3.value())) throw std::logic_error("2pgf freq mismatch");
+              if (!is_float_equal(std::get<0>(freqs_2pgf[w_ind]), W.value()+w3.value())) throw std::logic_error("2pgf freq mismatch");
               ++w_ind;
             }
           }

--- a/prog/quantum_model.h
+++ b/prog/quantum_model.h
@@ -14,8 +14,9 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
+#include <tuple>
 
-#include<cstdlib>
+#include <cstdlib>
 #include <fstream>
 
 #include <pomerol.h>
@@ -54,7 +55,7 @@ public:
   virtual void init_parameters() {
     _U = p["U"].as<double>();
     _e0 = p["ed"].as<double>();
-    boost::tie(beta, calc_gf, calc_2pgf) = boost::make_tuple(p["beta"].as<double>(), p["calc_gf"].as<int>(), p["calc_2pgf"].as<int>());
+    std::tie(beta, calc_gf, calc_2pgf) = std::make_tuple(p["beta"].as<double>(), p["calc_gf"].as<int>(), p["calc_2pgf"].as<int>());
     calc_gf = calc_gf || calc_2pgf;
     rank = comm.rank();
   }

--- a/prog/quantum_model.h
+++ b/prog/quantum_model.h
@@ -9,7 +9,6 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <iostream>
 #include <string>

--- a/src/pomerol/IndexClassification.cpp
+++ b/src/pomerol/IndexClassification.cpp
@@ -4,7 +4,7 @@
 namespace Pomerol{
 
 //
-//IndexClassification::IndexInfo 
+//IndexClassification::IndexInfo
 //
 
 IndexClassification::IndexInfo::IndexInfo( const std::string &SiteLabel, const unsigned short Orbital, const unsigned short Spin):
@@ -14,7 +14,7 @@ IndexClassification::IndexInfo::IndexInfo( const std::string &SiteLabel, const u
     SiteLabelHash = string_hash(SiteLabel);
 };
 
-bool IndexClassification::IndexInfo::operator<(const IndexClassification::IndexInfo& rhs) const 
+bool IndexClassification::IndexInfo::operator<(const IndexClassification::IndexInfo& rhs) const
 {
     if (SiteLabelHash != rhs.SiteLabelHash) return (SiteLabelHash < rhs.SiteLabelHash);
     if (Orbital != rhs.Orbital) return (Orbital < rhs.Orbital);
@@ -95,18 +95,10 @@ ParticleIndex IndexClassification::getIndex(const std::string &Site, const unsig
 
 ParticleIndex IndexClassification::getIndex(const IndexClassification::IndexInfo &in) const
 {
-    std::map<IndexInfo, ParticleIndex>::const_iterator it=InfoToIndices.find(in); 
+    std::map<IndexInfo, ParticleIndex>::const_iterator it=InfoToIndices.find(in);
     if (it!=InfoToIndices.end()) return (*it).second;
     else return IndexSize;
 }
-
-/*
-boost::tuple<std::string, unsigned short, unsigned short> IndexClassification::getInfo(ParticleIndex in) const 
-{
-    if (in >= IndexSize) throw (exWrongIndex());
-    IndexInfo *out = IndicesToInfo[in];
-    return boost::make_tuple(out->SiteLabel, out->Orbital, out->Spin);
-}*/
 
 IndexClassification::IndexInfo IndexClassification::getInfo(ParticleIndex in) const
 {

--- a/src/pomerol/Operator.cpp
+++ b/src/pomerol/Operator.cpp
@@ -1,10 +1,8 @@
 #include "pomerol/Operator.h"
 #include <algorithm>
 #include <iterator>
-#include <boost/tuple/tuple.hpp>
 //#include <boost/lambda/lambda.hpp>
 //#include <boost/lambda/bind.hpp>
-#include "boost/tuple/tuple_comparison.hpp"
 #include "boost/utility/swap.hpp"
 #include <boost/functional/hash.hpp>
 
@@ -33,9 +31,9 @@ Operator Operator::getAntiCommutator(const Operator &rhs) const
     return (*this)*rhs + rhs*(*this);
 }
 
-boost::tuple<FockState,MelemType> Operator::actRight(const monomial_t &in, const FockState &ket)
+std::tuple<FockState,MelemType> Operator::actRight(const monomial_t &in, const FockState &ket)
 {
-    if (in.size()==0) return boost::make_tuple(ket, MelemType(1));
+    if (in.size()==0) return std::make_tuple(ket, MelemType(1));
     //DEBUG(in << "|" << ket << ">");
     //ParticleIndex prev_pos_ = ket.size(); // Here we'll store the index of the last operator to speed up sign counting
     ParticleIndex prev_pos_ = 0;
@@ -46,9 +44,9 @@ boost::tuple<FockState,MelemType> Operator::actRight(const monomial_t &in, const
     for (int i=N-1; i>=0; i--) // Is the number of operator in OperatorSequence. Now we need to count them from back.
         {
             bool op; ParticleIndex ind;
-            boost::tie(op,ind)=in[i];
+            std::tie(op,ind)=in[i];
             //DEBUG(op << "_" << ind);
-            if ((op == creation && bra[ind]) || (op == annihilation && !bra[ind]) ) return boost::make_tuple(ERROR_FOCK_STATE, 0); // This is Pauli principle.
+            if ((op == creation && bra[ind]) || (op == annihilation && !bra[ind]) ) return std::make_tuple(ERROR_FOCK_STATE, 0); // This is Pauli principle.
             if (ind > prev_pos_)
                 for (ParticleIndex j=prev_pos_; j<ind; ++j) { if (bra[j]) sign*=-1; }
             else
@@ -57,7 +55,7 @@ boost::tuple<FockState,MelemType> Operator::actRight(const monomial_t &in, const
             //prev_pos_ = 0;
 
         }
-    return boost::make_tuple(bra, MelemType(sign));
+    return std::make_tuple(bra, MelemType(sign));
 }
 
 
@@ -71,7 +69,7 @@ std::map<FockState, MelemType> Operator::actRight(const FockState &ket) const
         {
             FockState bra;
             MelemType melem;
-            boost::tie(bra,melem) = actRight(it->first,ket);
+            std::tie(bra,melem) = actRight(it->first,ket);
             //if (std::abs(melem)>1e-8) DEBUG(bra << "|*" << melem);
             if (bra!=ERROR_FOCK_STATE && std::abs(melem)>std::numeric_limits<RealType>::epsilon())
                 result1[bra]+=melem*(it->second);

--- a/src/pomerol/Operator.cpp
+++ b/src/pomerol/Operator.cpp
@@ -1,10 +1,6 @@
 #include "pomerol/Operator.h"
 #include <algorithm>
 #include <iterator>
-//#include <boost/lambda/lambda.hpp>
-//#include <boost/lambda/bind.hpp>
-#include "boost/utility/swap.hpp"
-#include <boost/functional/hash.hpp>
 
 namespace Pomerol{
 

--- a/src/pomerol/StatesClassification.cpp
+++ b/src/pomerol/StatesClassification.cpp
@@ -1,5 +1,7 @@
 #include "pomerol/StatesClassification.h"
 
+#include <memory>
+
 namespace Pomerol{
 
 bool BlockNumber::operator<(const BlockNumber& rhs) const {return number<rhs.number;}
@@ -10,18 +12,18 @@ bool BlockNumber::operator==(const BlockNumber& rhs) const {return number==rhs.n
 //
 
 StatesClassification::StatesClassification(const IndexClassification& IndexInfo, const Symmetrizer &Symm):
-    ComputableObject(), 
+    ComputableObject(),
     IndexInfo(IndexInfo),
     Symm(Symm)
 {
 }
 
-void StatesClassification::compute()             
+void StatesClassification::compute()
 {
     if (Status>=Computed) return;
     IndexSize = IndexInfo.getIndexSize();
     StateSize = 1<<IndexSize;
-    std::vector<boost::shared_ptr<Operator> > sym_op = Symm.getOperations();
+    std::vector<std::shared_ptr<Operator> > sym_op = Symm.getOperations();
     int NOperations=sym_op.size();
     BlockNumber block_index=0;
     for (QuantumState FockStateIndex=0; FockStateIndex<StateSize; ++FockStateIndex) {
@@ -81,8 +83,8 @@ const InnerQuantumState StatesClassification::getInnerState(FockState state) con
     if ( state.to_ulong() > StateSize ) { throw (exWrongState()); return StateSize; };
     BlockNumber block = this->getBlockNumber(state);
     for (InnerQuantumState n=0; n<StatesContainer[block].size(); n++ )
-      {    
-          if ( StatesContainer[block][n]== state) { return n; } 
+      {
+          if ( StatesContainer[block][n]== state) { return n; }
       }
     throw (exWrongState());
     return StateSize;
@@ -118,9 +120,9 @@ const size_t StatesClassification::getBlockSize( BlockNumber in ) const
 }
 
 const FockState StatesClassification::getFockState( BlockNumber in, InnerQuantumState m) const
-{  
+{
     if ( Status < Computed ) { ERROR("StatesClassification is not computed yet."); throw (exStatusMismatch()); };
-    if (int(in) < StatesContainer.size()) 
+    if (int(in) < StatesContainer.size())
         if ( m < StatesContainer[in].size())
             return StatesContainer[in][m];
     ERROR("Couldn't find state numbered " << m << " in block " << in);
@@ -149,7 +151,7 @@ BlockNumber StatesClassification::NumberOfBlocks() const
     return StatesContainer.size();
 }
 
-Symmetrizer::QuantumNumbers StatesClassification::getQuantumNumbers(FockState in) const             
+Symmetrizer::QuantumNumbers StatesClassification::getQuantumNumbers(FockState in) const
 {
     return BlockToQuantum.find(getBlockNumber(in))->second;
 }

--- a/src/pomerol/Symmetrizer.cpp
+++ b/src/pomerol/Symmetrizer.cpp
@@ -1,6 +1,7 @@
 #include "pomerol/Symmetrizer.h"
 #include "pomerol/OperatorPresets.h"
 
+
 namespace Pomerol {
 
 //
@@ -154,14 +155,14 @@ const DynamicIndexCombination& Symmetrizer::generateTrivialCombination(ParticleI
     return trivial;
 }
 
-const std::vector<boost::shared_ptr<Operator> >& Symmetrizer::getOperations() const
+const std::vector<std::shared_ptr<Operator> >& Symmetrizer::getOperations() const
 {
     return Operations;
 }
 
 bool Symmetrizer::checkSymmetry(const Operator &in)
 {
-    boost::shared_ptr<Operator> OP1 ( new Operator(in));
+    std::shared_ptr<Operator> OP1 ( new Operator(in));
     // Check that OP1 is an integrals of motion
     if (!Storage.commutes(*OP1)) return false;
 

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -4,6 +4,8 @@
 
 #include "mpi_dispatcher/mpi_skel.hpp"
 
+#include <tuple>
+
 namespace Pomerol{
 
 TwoParticleGF::TwoParticleGF(const StatesClassification& S, const Hamiltonian& H,
@@ -119,7 +121,7 @@ bool TwoParticleGF::isVanishing(void) const
 
 
 // An mpi adapter to 1) compute 2pgf terms; 2) convert them to a Matsubara Container; 3) purge terms
-typedef boost::tuple<ComplexType, ComplexType, ComplexType> freq_tuple;
+typedef std::tuple<ComplexType, ComplexType, ComplexType> freq_tuple;
 typedef std::vector<freq_tuple> freq_vec_t;
 struct ComputeAndClearWrap
 {
@@ -131,7 +133,7 @@ struct ComputeAndClearWrap
             #pragma omp parallel for
             #endif
             for (int w = 0; w < wsize; ++w) {
-                (*data_)[w] += (*p)(boost::get<0>((*freqs_)[w]), boost::get<1>((*freqs_)[w]), boost::get<2>((*freqs_)[w]));
+                (*data_)[w] += (*p)(std::get<0>((*freqs_)[w]), std::get<1>((*freqs_)[w]), std::get<2>((*freqs_)[w]));
                 }
             #ifdef POMEROL_USE_OPENMP
             #pragma omp barrier
@@ -150,7 +152,7 @@ protected:
     bool fill_;
 };
 
-std::vector<ComplexType> TwoParticleGF::compute(bool clear, std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
+std::vector<ComplexType> TwoParticleGF::compute(bool clear, std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
 {
     std::vector<ComplexType> m_data;
     if (Status < Prepared) throw (exStatusMismatch());

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -46,7 +46,7 @@ void TwoParticleGFContainer::prepareAll(const std::set<IndexCombination4>& Initi
        };
 }
 
-std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll(bool clearTerms, std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm, bool split)
+std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll(bool clearTerms, std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm, bool split)
 {
     if (split)
         return computeAll_split(clearTerms, freqs, comm);
@@ -54,7 +54,7 @@ std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::co
         return computeAll_nosplit(clearTerms, freqs, comm);
 }
 
-std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll_nosplit(bool clearTerms, std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
+std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll_nosplit(bool clearTerms, std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
 {
     std::map<IndexCombination4,std::vector<ComplexType> > out;
     for(std::map<IndexCombination4,ElementWithPermFreq<TwoParticleGF> >::iterator iter = ElementsMap.begin();
@@ -65,7 +65,7 @@ std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::co
     return out;
 }
 
-std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll_split(bool clearTerms, std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
+std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::computeAll_split(bool clearTerms, std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > const& freqs, const boost::mpi::communicator & comm)
 {
     std::map<IndexCombination4,std::vector<ComplexType> > out;
     std::map<IndexCombination4,std::vector<ComplexType> > storage;

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -97,7 +97,7 @@ std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::co
 
     boost::mpi::communicator comm_split = comm.split(proc_colors[comm.rank()]);
 
-    for(std::map<IndexCombination4, boost::shared_ptr<TwoParticleGF> >::iterator iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {
+    for(std::map<IndexCombination4, std::shared_ptr<TwoParticleGF> >::iterator iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {
         bool calc = (elem_colors[comp] == proc_colors[comm.rank()]);
         if (calc) {
             INFO("C" << elem_colors[comp] << "p" << comm.rank() << ": computing 2PGF for " << iter->first);
@@ -108,7 +108,7 @@ std::map<IndexCombination4,std::vector<ComplexType> > TwoParticleGFContainer::co
     // distribute data
     if (!comm.rank()) INFO_NONEWLINE("Distributing 2PGF container...");
     comp = 0;
-    for(std::map<IndexCombination4, boost::shared_ptr<TwoParticleGF> >::iterator iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {
+    for(std::map<IndexCombination4, std::shared_ptr<TwoParticleGF> >::iterator iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {
         int sender = color_roots[elem_colors[comp]];
         TwoParticleGF& chi = *((iter)->second);
         for (size_t p = 0; p<chi.parts.size(); p++) {

--- a/test/AndersonTest02.cpp
+++ b/test/AndersonTest02.cpp
@@ -11,10 +11,11 @@
 
 
 #include <string>
+#include <tuple>
 #include <iostream>
 #include <algorithm>
 
-#include<cstdlib>
+#include <cstdlib>
 #include <fstream>
 
 #include <pomerol.h>
@@ -149,7 +150,7 @@ int main(int argc, char* argv[])
             Chi4.MultiTermCoefficientTolerance = 1e-6;
             Chi4.prepareAll(indices4);
             comm.barrier();
-            std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > freqs;
+            std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > freqs;
             Chi4.computeAll(false, freqs, comm, true);
 
 

--- a/test/AndersonTest03.cpp
+++ b/test/AndersonTest03.cpp
@@ -13,8 +13,9 @@
 #include <string>
 #include <iostream>
 #include <algorithm>
+#include <tuple>
 
-#include<cstdlib>
+#include <cstdlib>
 #include <fstream>
 
 #include <pomerol.h>
@@ -162,14 +163,14 @@ int main(int argc, char* argv[])
             chi_uuuu_vals[7] = -5.370700986029e-03;
             chi_uuuu_vals[8] = -5.126175681822e-03;
             chi_uuuu_vals[9] = -4.732777836189e-03;
-            std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > freqs(chi_uuuu_vals.size());
+            std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > freqs(chi_uuuu_vals.size());
 
             ComplexType Omega = I*2.*M_PI/beta;
             ComplexType omega = I*M_PI/beta;
 
             for (int w = 0; w < chi_uuuu_vals.size(); ++w) {
                 ComplexType w_p = I*(2.*w+1.)*M_PI/beta;
-                freqs[w] = boost::make_tuple(omega+Omega, w_p, omega);
+                freqs[w] = std::make_tuple(omega+Omega, w_p, omega);
                 }
 
             std::map<IndexCombination4, std::vector<ComplexType> > data_freqs = Chi4.computeAll(true, freqs, comm, true);
@@ -182,10 +183,10 @@ int main(int argc, char* argv[])
 
             for (size_t w = 0; w < chi_uuuu_vals.size(); w++) {
 
-                std::cout << "(" << imag(boost::get<0>(freqs[w])) << "," << imag(boost::get<1>(freqs[w])) << "," << imag(boost::get<2>(freqs[w])) << "): " << std::flush;
+                std::cout << "(" << imag(std::get<0>(freqs[w])) << "," << imag(std::get<1>(freqs[w])) << "," << imag(std::get<2>(freqs[w])) << "): " << std::flush;
                 ComplexType chi_uuuu_val = chi_uuuu_out[w];
                 // this now won't work - all terms are cleared
-                //ComplexType chi_uuuu_val = chi_uuuu(boost::get<0>(freqs[w]), boost::get<1>(freqs[w]), boost::get<2>(freqs[w]));
+                //ComplexType chi_uuuu_val = chi_uuuu(std::get<0>(freqs[w]), std::get<1>(freqs[w]), std::get<2>(freqs[w]));
                 bool success = is_equal(chi_uuuu_val, chi_uuuu_vals[w], 1e-6);
                 std::cout << "uuuu: " << chi_uuuu_val << " == (exact_uuuu) " << chi_uuuu_vals[w] << " == " << std::boolalpha << success << std::endl;
                 if (!success) return EXIT_FAILURE;

--- a/test/CCdagOperatorTest.cpp
+++ b/test/CCdagOperatorTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -29,7 +29,6 @@
 #include "IndexClassification.h"
 #include "Operator.h"
 #include "OperatorPresets.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 
@@ -42,7 +41,7 @@ int main(int argc, char* argv[])
     L.addSite(new Lattice::Site("A",1,2));
     L.addSite(new Lattice::Site("B",1,2));
     L.addSite(new Lattice::Site("C",1,2));
-    
+
 
     IndexClassification Indices(L.getSiteMap());
     Indices.prepare();
@@ -56,16 +55,16 @@ int main(int argc, char* argv[])
     std::map<FockState, MelemType> map1=Cdag_op.actRight(ket);
     for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second; 
-        INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value ); 
+        MelemType Value= it1->second;
+        INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value );
         ket2=bra;
         }
 
     map1=O->actRight(ket);
     for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second; 
-        INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value ); 
+        MelemType Value= it1->second;
+        INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value );
         ket2=bra;
         }
 
@@ -74,8 +73,8 @@ int main(int argc, char* argv[])
     map1=C_op.actRight(ket);
     for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second; 
-        INFO("<" << bra << "| c_1 |" << ket << "> = " << Value ); 
+        MelemType Value= it1->second;
+        INFO("<" << bra << "| c_1 |" << ket << "> = " << Value );
         }
 
     return EXIT_SUCCESS;

--- a/test/HamiltonianPartTest01.cpp
+++ b/test/HamiltonianPartTest01.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -35,7 +35,6 @@
 #include "Symmetrizer.h"
 #include "StatesClassification.h"
 #include "HamiltonianPart.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 
@@ -44,7 +43,7 @@ int main(int argc, char* argv[])
     boost::mpi::environment env(argc,argv);
     boost::mpi::communicator world;
 
-    
+
 
     Lattice L;
     L.addSite(new Lattice::Site("A",1,2));

--- a/test/HamiltonianTest.cpp
+++ b/test/HamiltonianTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -36,7 +36,6 @@
 #include "StatesClassification.h"
 #include "HamiltonianPart.h"
 #include "Hamiltonian.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 
@@ -45,7 +44,7 @@ int main(int argc, char* argv[])
     boost::mpi::environment env(argc,argv);
     boost::mpi::communicator world;
 
-    
+
 
     Lattice L;
     L.addSite(new Lattice::Site("A",1,2));
@@ -71,7 +70,7 @@ int main(int argc, char* argv[])
     H.getPart(BlockNumber(4)).print_to_screen();
     H.compute(world);
     H.getPart(BlockNumber(4)).print_to_screen();
-    RealType E = -2.8860009; 
+    RealType E = -2.8860009;
     RealType E_calc = H.getGroundEnergy();
     INFO("Lowest energy level is " << E_calc);
     if (std::abs(E-E_calc) > 1e-7) return EXIT_FAILURE;

--- a/test/IndexPermutationTest.cpp
+++ b/test/IndexPermutationTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -29,7 +29,6 @@
 #include "IndexClassification.h"
 #include "IndexHamiltonian.h"
 #include "Symmetrizer.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 

--- a/test/NOperatorTest.cpp
+++ b/test/NOperatorTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -29,7 +29,6 @@
 #include "IndexClassification.h"
 #include "Operator.h"
 #include "OperatorPresets.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 
@@ -42,7 +41,7 @@ int main(int argc, char* argv[])
     L.addSite(new Lattice::Site("A",1,2));
     L.addSite(new Lattice::Site("B",1,2));
     L.addSite(new Lattice::Site("C",1,2));
-    
+
 
     IndexClassification Indices(L.getSiteMap());
     Indices.prepare();
@@ -57,8 +56,8 @@ int main(int argc, char* argv[])
     std::map<FockState, MelemType> map1=NN->actRight(ket);
     for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second; 
-        INFO("<" << bra << "| N |" << ket << "> = " << Value ); 
+        MelemType Value= it1->second;
+        INFO("<" << bra << "| N |" << ket << "> = " << Value );
         }
     if ( map1.size()!=1 && N.getMatrixElement(ket,ket)!=MelemType(2)) return EXIT_FAILURE;
     ket = FockState(IndexSize, 7);

--- a/test/OperatorTest.cpp
+++ b/test/OperatorTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -37,8 +37,8 @@ using namespace Pomerol::OperatorPresets;
 int main(int argc, char* argv[])
 {
   /* Test of Operator::Term*/
-  
-  Operator IT1 = Cdag(0)*C(0)*Cdag(1)*C(1); 
+
+  Operator IT1 = Cdag(0)*C(0)*Cdag(1)*C(1);
   INFO("Created Operator " << IT1);
 
    FockState a1(4);
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
    MelemType result;
    std::map<FockState, MelemType> out;
 
-   Operator IT2 = Cdag(1); 
+   Operator IT2 = Cdag(1);
    out=IT2.actRight(a1);
    res_state = out.begin()->first;
    result = out.begin()->second;
@@ -79,49 +79,49 @@ int main(int argc, char* argv[])
    Operator IT5 = Cdag(0)*C(1);
 
    Operator IT6 = - C(1)*Cdag(0);
-   Operator IT7 = C(1)*Cdag(0); 
-   
+   Operator IT7 = C(1)*Cdag(0);
+
    INFO("( " << IT5 << "==" << IT6 <<" ) = " << (IT5 == IT6));
    if (!(IT5 == IT6)) return EXIT_FAILURE;
    INFO("( " << IT5 << "==" << IT7 <<" ) = " << (IT5 == IT7));
    if ((IT5 == IT7)) return EXIT_FAILURE;
-   
+
    Operator IT7_2 = Cdag(2)*C(2);
    INFO(IT4 << " commutes with " << IT7_2 << " = " << IT4.commutes(IT7_2));
 
-   Operator IT101 = Cdag(1)*C(1); //((boost::make_tuple(1.0, ops)));
+   Operator IT101 = Cdag(1)*C(1); //((std::make_tuple(1.0, ops)));
 
-   Operator IT102 = Cdag(2)*C(2)*Cdag(0)*C(0); //((boost::make_tuple(1.0, ops)));
+   Operator IT102 = Cdag(2)*C(2)*Cdag(0)*C(0); //((std::make_tuple(1.0, ops)));
    if (!(IT102.commutes(IT101))) return EXIT_FAILURE;
 
-   Operator IT8 = Cdag(0)*C(1)*Cdag(2)*C(3); 
+   Operator IT8 = Cdag(0)*C(1)*Cdag(2)*C(3);
 
-   Operator IT9 = - Cdag(0) * C(1) * C(3) * Cdag(2); // (boost::make_tuple(-1.0, ops));
+   Operator IT9 = - Cdag(0) * C(1) * C(3) * Cdag(2); // (std::make_tuple(-1.0, ops));
    INFO("( " << IT8 << "==" << IT9 <<" ) = " << (IT8 == IT9));
    if (!(IT8==IT9)) return EXIT_FAILURE;
-   //ops[0]=boost::make_tuple(1,0);
-   //ops[1]=boost::make_tuple(0,1);
-   //ops[2]=boost::make_tuple(0,2);
-   //ops[3]=boost::make_tuple(1,2);
+   //ops[0]=std::make_tuple(1,0);
+   //ops[1]=std::make_tuple(0,1);
+   //ops[2]=std::make_tuple(0,2);
+   //ops[3]=std::make_tuple(1,2);
    Operator IT10 = Cdag(0)*C(1)*C(2)*Cdag(2);
 
    Operator IT11 = -C(1)*Cdag(0)*C(2)*Cdag(2);
    INFO("( " << IT10 << "==" << IT11 <<" ) = " << (IT10 == IT11));
    if (!(IT10==IT11)) return EXIT_FAILURE;
-   
+
    INFO(IT10 << " commutes with " << IT11 << " = " << IT10.commutes(IT11));
 
    // test reduce
    Operator IT12Base = Cdag(1)*C(1)*C(0)*Cdag(0);
-   Operator IT12 = 13*IT12Base; //(boost::make_tuple(13.0, ops));
-   Operator IT12_2 = -5 * IT12Base; // (boost::make_tuple(-5.0, ops));
-   Operator IT12_3 = -8*IT12Base; //(boost::make_tuple(-8.0, ops));
+   Operator IT12 = 13*IT12Base; //(std::make_tuple(13.0, ops));
+   Operator IT12_2 = -5 * IT12Base; // (std::make_tuple(-5.0, ops));
+   Operator IT12_3 = -8*IT12Base; //(std::make_tuple(-8.0, ops));
 
    Operator ITsum;
    ITsum=IT12;
    ITsum+=IT12_2;
    ITsum+=IT12_3;
-   
+
    INFO(IT12 << "+" << IT12_2 << "+" << IT12_3 << "=" << ITsum);
    if (!ITsum.isEmpty()) return EXIT_FAILURE;
 

--- a/test/SzOperatorTest.cpp
+++ b/test/SzOperatorTest.cpp
@@ -1,6 +1,6 @@
 //
-// This file is a part of pomerol - a scientific ED code for obtaining 
-// properties of a Hubbard model on a finite-size lattice 
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
 //
 // Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
 // Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
@@ -29,7 +29,6 @@
 #include "IndexClassification.h"
 #include "Operator.h"
 #include "OperatorPresets.h"
-#include <boost/shared_ptr.hpp>
 
 using namespace Pomerol;
 
@@ -57,8 +56,8 @@ int main(int argc, char* argv[])
     std::map<FockState, MelemType> map1=Sz.actRight(ket);
     for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second; 
-        INFO("<" << bra << "| Sz |" << ket << "> = " << Value ); 
+        MelemType Value= it1->second;
+        INFO("<" << bra << "| Sz |" << ket << "> = " << Value );
         }
     if ( map1.size()!=1 && std::abs(Sz.getMatrixElement(ket,ket)+1.0)>std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
     ket = FockState(IndexSize, 7);
@@ -70,7 +69,7 @@ int main(int argc, char* argv[])
     ket = FockState(IndexSize, 10);
     INFO ( "<" << ket << "| Sz |" << ket << "> = " << Sz.getMatrixElement(ket));
     if ( std::abs(Sz.getMatrixElement(ket) - 0.0) >std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
-    
+
     INFO(Sz.commutes(Sz));
     if (!(Sz.commutes(Sz))) return EXIT_FAILURE;
 

--- a/tutorial/example2site.cpp
+++ b/tutorial/example2site.cpp
@@ -28,6 +28,10 @@
  * pomerol library.
  */
 
+#include <iostream>
+#include <string>
+#include <tuple>
+
 // Include the pomerol library
 #include <pomerol.h>
 
@@ -268,7 +272,7 @@ int main(int argc, char* argv[])
     Chi.MultiTermCoefficientTolerance = 1e-6;
 
     Chi.prepare();
-    std::vector<boost::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
+    std::vector<std::tuple<ComplexType, ComplexType, ComplexType> > freqs_2pgf;
     Chi.compute(false, freqs_2pgf, world);
 
     if (world.rank()==0) {


### PR DESCRIPTION
This PR removes Boost smart pointers, tuples and other smaller bits of Boost and replaces them with C++11 counterparts.
More intrusive Boost libs will be removed in later PRs.