### PR TITLE
Always assume complex matrix elements (resolve #38)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,6 @@ fix_rpath()
 set_linking_type()
 compiler_quirks()
 
-#Use complex Matrix elements
-option(POMEROL_COMPLEX_MATRIX_ELEMENTS "Use complex matrix elements" OFF)
-if (POMEROL_COMPLEX_MATRIX_ELEMENTS)
-    message(STATUS "Using complex matrix elements")
-else (POMEROL_COMPLEX_MATRIX_ELEMENTS)
-    message(STATUS "Using real matrix elements")
-endif (POMEROL_COMPLEX_MATRIX_ELEMENTS)
-
 # Enable/Disable and find OpenMP
 option(POMEROL_USE_OPENMP "Use OpenMP" TRUE)
 if (POMEROL_USE_OPENMP)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
       * boost::program_options is then required.
       * Some of the binaries depend on the [gftools](https://github.com/aeantipov/gftools) library, which will be automatically downloaded in case it cannot
         be found by CMake (use `-Dgftools_DIR` to specify its installation path). gftools supports direct hdf5-saving through [ALPSCore](http://alpscore.org).
-    * add `-DPOMEROL_COMPLEX_MATRIX_ELEMENTS=ON` for allowing complex matrix elements in the Hamiltonian. Default = OFF.
     * add `-DPOMEROL_USE_OPENMP=ON` to enable OpenMP optimization for two-particle GF calculation. Default = ON.
     * add `-DPOMEROL_BUILD_STATIC=ON` to compile static instead of shared libraries.
   - ` make`

--- a/include/mpi_dispatcher/misc.hpp
+++ b/include/mpi_dispatcher/misc.hpp
@@ -8,12 +8,6 @@
 
 #include "../pomerol/Misc.h"
 
-#ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
-#define MPI_MELEM_DATATYPE MPI_CXX_DOUBLE_COMPLEX
-#else
-#define MPI_MELEM_DATATYPE MPI_DOUBLE
-#endif
-
 namespace pMPI {
 
 // Size of communicator 'Comm'

--- a/include/pomerol/HamiltonianPart.h
+++ b/include/pomerol/HamiltonianPart.h
@@ -61,9 +61,9 @@ public:
     InnerQuantumState getSize(void) const;
 
     /** Get the matrix element of the HamiltonianPart by the number of states inside the part. */ 
-    MelemType getMatrixElement(InnerQuantumState m, InnerQuantumState n) const; //return H(m,n)
+    ComplexType getMatrixElement(InnerQuantumState m, InnerQuantumState n) const; //return H(m,n)
     /** Get the matrix element of the Hamiltonian within two given FockStates. */
-    MelemType getMatrixElement(FockState m, FockState n) const; //return H(m,n)
+    ComplexType getMatrixElement(FockState m, FockState n) const; //return H(m,n)
 
     /** Get the eigenvalue of the H matrix.
      * \param[in] Number of eigenvalue. */

--- a/include/pomerol/Lattice.h
+++ b/include/pomerol/Lattice.h
@@ -118,14 +118,14 @@ public:
     /** An array of orbitals on the sites, which are connected by this Lattice::Term. */
     std::vector<unsigned short> Orbitals;
     /** The matrix element of the Lattice::Term. */
-    MelemType Value;
+    ComplexType Value;
     /** This returns the order of Term. Also the inheritance from TermPointer is provided by this method. */
     unsigned int getOrder() const;
     /** Constructor */
     Term(unsigned int N);
 
     /** Full constructor */
-    Term(unsigned int N, bool OperatorSequence[ ], MelemType Value, std::string SiteLabels[ ], unsigned short Orbitals[ ], unsigned short Spins[ ]);
+    Term(unsigned int N, bool OperatorSequence[ ], ComplexType Value, std::string SiteLabels[ ], unsigned short Orbitals[ ], unsigned short Spins[ ]);
 
     /** Copy-constuctor
      * \param[in] in A Lattice::Term to copy.

--- a/include/pomerol/LatticePresets.h
+++ b/include/pomerol/LatticePresets.h
@@ -30,10 +30,10 @@ public:
      * \param[in] orbital \f$\alpha'\f$ - orbital of site \f$j\f$, which is connected by this term.
      * \param[in] spin \f$\sigma\f$ - spins of sites, which are connected by this term.
      */
-    static Term* Hopping     ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 , unsigned short spin2);
+    static Term* Hopping     ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 , unsigned short spin2);
 
     /** A shortcut to hopping Lattice::Term \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma}, j \neq i \f$ */
-    static Term* Hopping     ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital, unsigned short spin);
+    static Term* Hopping     ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital, unsigned short spin);
 
     /** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital. 
      * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
@@ -41,7 +41,7 @@ public:
      * \param[in] orbital \f$\alpha\f$ - affected orbital of the site.
      * \param[in] spin \f$\sigma\f$ - affected spin component.
      */
-    static Term* Level       ( const std::string& Label, MelemType Value, unsigned short orbital, unsigned short spin);
+    static Term* Level       ( const std::string& Label, ComplexType Value, unsigned short orbital, unsigned short spin);
 
     /** Generates a local density-density 4-point term \f$ U n_{i\alpha\sigma}n_{j\alpha'\sigma'} \f$.
      * \param[in] Label1 \f$i\f$ - site affected by this Lattice::Term.
@@ -52,14 +52,14 @@ public:
      * \param[in] spin1 \f$\sigma\f$ - the spin component affected by the first density operator.
      * \param[in] spin2 \f$\sigma'\f$ - the spin component affected by the second density operator.
      */
-    static Term* NupNdown    ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2);
+    static Term* NupNdown    ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2);
 
     /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{j\alpha'\downarrow'} \f$ term for \f$i=j\f$. */
-    static Term* NupNdown    ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2);
+    static Term* NupNdown    ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2);
     /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha'\downarrow'} \f$ term for spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
-    static Term* NupNdown    ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2);
+    static Term* NupNdown    ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2);
     /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha\downarrow'} \f$ term for the same orbital \f$m=m'\f$ and default parameters spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
-    static Term* NupNdown    ( const std::string& Label, MelemType Value, unsigned short orbital, unsigned short spin1 = up, unsigned short spin2 = down);
+    static Term* NupNdown    ( const std::string& Label, ComplexType Value, unsigned short orbital, unsigned short spin1 = up, unsigned short spin2 = down);
 
 
     /** Generates a spinflip \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
@@ -70,7 +70,7 @@ public:
      * \param[in] spin1 \f$\sigma\f$ - first affected spin component. By default set to \f$\uparrow\f$.
      * \param[in] spin2 \f$\sigma'\f$ - second affected spin component. By default set to \f$\downarrow\f$.
      */
-    static Term* Spinflip ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 = up, unsigned short spin2 = down);
+    static Term* Spinflip ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 = up, unsigned short spin2 = down);
 
 
     /** Generates a pair-hopping \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha\sigma'}c_{i\alpha'\sigma}c_{i\alpha'\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
@@ -81,11 +81,11 @@ public:
      * \param[in] spin1 \f$\sigma\f$ - first affected spin component. By default set to \f$\uparrow\f$.
      * \param[in] spin2 \f$\sigma'\f$ - second affected spin component. By default set to \f$\downarrow\f$.
      */
-    static Term* PairHopping (const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 = up, unsigned short spin2 = down);
+    static Term* PairHopping (const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1 = up, unsigned short spin2 = down);
 
 
-    static Term* SplusSminus ( const std::string& label1, const std::string& label2, MelemType Value, unsigned short orbital); 
-    static Term* SminusSplus ( const std::string& label1, const std::string& label2, MelemType Value, unsigned short orbital);
+    static Term* SplusSminus ( const std::string& label1, const std::string& label2, ComplexType Value, unsigned short orbital); 
+    static Term* SminusSplus ( const std::string& label1, const std::string& label2, ComplexType Value, unsigned short orbital);
 
     /** Exception: wrong indices. */
     class exWrongIndices : public std::exception { 
@@ -104,7 +104,7 @@ public:
      * \param[in] U \f$U\f$ - value of the onsite Coulomb interaction.
      * \param[in] Level \f$\varepsilon\f$ - the local energy level on the site.
      */
-    static void addCoulombS(Lattice *L, const std::string& label, MelemType U, MelemType Level);
+    static void addCoulombS(Lattice *L, const std::string& label, ComplexType U, ComplexType Level);
 
     /** Adds an interaction with the hamiltonian \f[ U \sum_{\alpha, \sigma > \sigma'} n_{i\alpha\sigma}n_{i\alpha\sigma'} + U' \sum_{\alpha\neq\alpha',\sigma > \sigma'} n_{i\alpha\sigma} n_{i\alpha'\sigma'} + \frac{U'-J}{2} \sum_{\alpha\neq\alpha',\sigma} n_{i\alpha\sigma} n_{i\alpha'\sigma} - J \sum_{\alpha\neq\alpha',\sigma > \sigma'} (c^\dagger_{i\alpha \sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'} + c^\dagger_{i\alpha'\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha\sigma}c_{i\alpha\sigma'}) to the specified site. \f] 
      * \param[in] L A pointer to the Lattice to add the site.
@@ -114,23 +114,23 @@ public:
      * \param[in] J \f$J\f$ - Kanamori J, value of the Hund's coupling.
      * \param[in] Level \f$\varepsilon\f$ - the local energy level on the site.
      */
-    static void addCoulombP(Lattice *L, const std::string& label, MelemType U, MelemType U_p, MelemType J, MelemType Level);
+    static void addCoulombP(Lattice *L, const std::string& label, ComplexType U, ComplexType U_p, ComplexType J, ComplexType Level);
     /** A shortcut to Lattice::Presets::addPSite with \f$U'=U-2J\f$, i.e. U_p = U - 2.0* J */
-    static void addCoulombP(Lattice *L, const std::string& label, MelemType U, MelemType J, MelemType Level);
+    static void addCoulombP(Lattice *L, const std::string& label, ComplexType U, ComplexType J, ComplexType Level);
 
     /** Adds a magnetic \f$ \sum\limits_\alpha mH \frac{1}{2} (n_{i\alpha\uparrow} - n_{i\alpha\downarrow}) \f$ splitting to a given site. Valid only for 2 spins.
      * \param[in] L A pointer to the Lattice to add the terms. 
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] Magnetization \f$mH\f$ - magnetization to add.
      */
-    static void addMagnetization( Lattice *L, const std::string& label, MelemType Magnetization);
+    static void addMagnetization( Lattice *L, const std::string& label, ComplexType Magnetization);
 
     /** Adds a level \f$ \sum\limits_{\alpha, \sigma} \varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$.
      * \param[in] L A pointer to the Lattice to add the terms.
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] Level \f$\varepsilon\f$ - energy level to add.
      */
-    static void addLevel ( Lattice *L, const std::string& label, MelemType Level);
+    static void addLevel ( Lattice *L, const std::string& label, ComplexType Level);
 
     /** Adds a SzSz \f[ \sum\limits_{\alpha} J \frac{1}{2}(n_{i\alpha\uparrow} - n_{i\alpha\downarrow})\frac{1}{2}(n_{j\alpha\uparrow} - n_{j\alpha\downarrow}) \f]
      * interaction terms. Valid only for 2 spins 
@@ -141,7 +141,7 @@ public:
      * \param[in] Orbitals Total amount of orbitals on the site. By default equal to 1.
      * \param[in] Spins Total amount of spin components on the site. By default equal to 2. Works only for 2 spins.
      */
-    static void addSzSz ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType ExchJ);
+    static void addSzSz ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType ExchJ);
 
     /** Adds a spin-spin \f[ \sum\limits_{\alpha} J \hat S_{i\alpha} \hat S_{j\alpha} \f]
      * interaction terms. Valid only for 2 spins 
@@ -150,7 +150,7 @@ public:
      * \param[in] Label2 \f$j\f$ - label of the second connected site. Site can be choosen the same as the first site.
      * \param[in] ExchJ \f$J\f$ - magnetic exchange constant.
      */
-    static void addSS ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType ExchJ);
+    static void addSS ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType ExchJ);
 
     /** Adds a hopping \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha'\sigma'} \f$ term to the Lattice. This is a safe method : indices are checked to belong to the lattice.
      * \param[in] L A pointer to the Lattice to add the terms. 
@@ -162,13 +162,13 @@ public:
      * \param[in] Spin1 \f$\sigma\f$ - spin component of the first site
      * \param[in] Spin2 \f$\sigma\f$ - spin component of the second site
      */
-    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short spin1, unsigned short spin2 );
+    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short spin1, unsigned short spin2 );
     /** A shortcut to addHopping \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
-    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short spin );
+    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short spin );
     /** A shortcut to addHopping \f$ \sum_{\sigma} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
-    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2 );
+    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2 );
     /** A shortcut to addHopping \f$ \sum_{\sigma\alpha} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
-    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, MelemType t );
+    static void addHopping ( Lattice *L, const std::string &label1, const std::string& label2, ComplexType t );
 };
 
 }; // end of namespace Pomerol

--- a/include/pomerol/Misc.h
+++ b/include/pomerol/Misc.h
@@ -51,13 +51,6 @@ typedef double RealType;
 /** Complex type. */
 typedef std::complex<double> ComplexType;
 
-/** Matrix element type. */
-#ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
-typedef ComplexType MelemType;
-#else
-typedef RealType MelemType;
-#endif
-
 /** Index represents a combination of spin, orbital, and lattice indices **/
 typedef unsigned int ParticleIndex;
 
@@ -81,8 +74,7 @@ typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign
 /** Dense real matrix. */
 typedef Eigen::Matrix<RealType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor> RealMatrixType;
 typedef Eigen::Matrix<RealType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor> LowerTriangularRealMatrixType;
-/** Default Matrix Type comes from MelemType. */
-typedef Eigen::Matrix<MelemType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor> MatrixType;
+typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor> MatrixType;
 
 /** Dense complex vector. */
 typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,1,Eigen::AutoAlign> ComplexVectorType;
@@ -90,13 +82,12 @@ typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,1,Eigen::AutoAlign> ComplexVect
 typedef Eigen::Matrix<RealType,Eigen::Dynamic,1,Eigen::AutoAlign> RealVectorType;
 /** Dense vector of integers. */
 typedef Eigen::Matrix<int,Eigen::Dynamic,1,Eigen::AutoAlign> IntVectorType;
-/** Default vector type comes from MelemType. */
-typedef Eigen::Matrix<MelemType,Eigen::Dynamic,1,Eigen::AutoAlign> VectorType;
+typedef Eigen::Matrix<ComplexType,Eigen::Dynamic,1,Eigen::AutoAlign> VectorType;
 
 /** Sparse complex matrix */
-typedef Eigen::SparseMatrix<MelemType,Eigen::ColMajor> ColMajorMatrixType;
-typedef Eigen::SparseMatrix<MelemType,Eigen::RowMajor> RowMajorMatrixType;
-typedef Eigen::DynamicSparseMatrix<MelemType,Eigen::ColMajor> DynamicSparseMatrixType;
+typedef Eigen::SparseMatrix<ComplexType,Eigen::ColMajor> ColMajorMatrixType;
+typedef Eigen::SparseMatrix<ComplexType,Eigen::RowMajor> RowMajorMatrixType;
+typedef Eigen::DynamicSparseMatrix<ComplexType,Eigen::ColMajor> DynamicSparseMatrixType;
 //typedef Eigen::Triplet<RealType> RealTypeTriplet;
 //typedef Eigen::Triplet<ComplexType> ComplexTypeTriplet;
 

--- a/include/pomerol/Operator.h
+++ b/include/pomerol/Operator.h
@@ -38,9 +38,9 @@ class Operator :
     boost::addable<Operator,
     boost::subtractable<Operator,
     boost::multipliable<Operator,
-    boost::addable2<Operator, MelemType,
-    boost::subtractable2<Operator, MelemType,
-    boost::multipliable2<Operator, MelemType
+    boost::addable2<Operator, ComplexType,
+    boost::subtractable2<Operator, ComplexType,
+    boost::multipliable2<Operator, ComplexType
     > > > > > >
 {
 
@@ -96,7 +96,7 @@ public:
     bool operator==(monomial_t const& m1, monomial_t const& m2);
 
     // Map of all monomials with coefficients
-    typedef std::map<monomial_t,MelemType> monomials_map_t;
+    typedef std::map<monomial_t,ComplexType> monomials_map_t;
     // Print Operator itself
     friend std::ostream& operator<<(std::ostream& os, Operator const& op)
     {
@@ -120,7 +120,7 @@ public:
     //const_iterator cbegin() const { return monomials.cbegin(); }
     //const_iterator cend() const { return monomials.cend(); }
 
-    // Algebraic operations involving MelemType constants
+    // Algebraic operations involving ComplexType constants
     Operator operator-() const
     {
         Operator tmp(*this);
@@ -129,7 +129,7 @@ public:
         return tmp;
     }
 
-    Operator& operator+=(const MelemType alpha)
+    Operator& operator+=(const ComplexType alpha)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
@@ -141,7 +141,7 @@ public:
         return *this;
     }
 
-    Operator& operator-=(const MelemType alpha)
+    Operator& operator-=(const ComplexType alpha)
     {
         bool is_new_monomial;
         monomials_map_t::iterator it;
@@ -154,12 +154,12 @@ public:
     }
 
     friend
-    Operator operator-(const MelemType alpha, Operator const& op)
+    Operator operator-(const ComplexType alpha, Operator const& op)
     {
         return -op + alpha;
     }
 
-    Operator& operator*= (const MelemType alpha)
+    Operator& operator*= (const ComplexType alpha)
     {
         if(std::abs(alpha) < 100*std::numeric_limits<RealType>::epsilon()){
             monomials.clear();
@@ -223,17 +223,17 @@ public:
      * \param[in] ket A state to the right of the operator.
      * \param[out] Resulting matrix element.
      */
-    virtual MelemType getMatrixElement(const FockState &bra, const FockState &ket) const;
+    virtual ComplexType getMatrixElement(const FockState &bra, const FockState &ket) const;
 
     /** Returns the matrix element of an operator between two states represented by a linear combination of FockState's. */
-    virtual MelemType getMatrixElement( const VectorType & bra, const VectorType &ket, const std::vector<FockState> &states) const;
+    virtual ComplexType getMatrixElement( const VectorType & bra, const VectorType &ket, const std::vector<FockState> &states) const;
 
     /** Returns a result of acting of an operator on a state to the right of the operator.
      * \param[in] ket A state to act on.
      * \param[out] A map of states and corresponding matrix elements, which are the result of an action.
      */
-    static std::tuple<FockState,MelemType> actRight(const monomial_t &in, const FockState &ket);
-    virtual std::map<FockState, MelemType> actRight(const FockState &ket) const;
+    static std::tuple<FockState,ComplexType> actRight(const monomial_t &in, const FockState &ket);
+    virtual std::map<FockState, ComplexType> actRight(const FockState &ket) const;
 
     /** Returns an operator that is a commutator of the current operator and another one
      * \param[in] rhs An operator to calculate a commutator with.
@@ -269,7 +269,7 @@ protected:
     monomials_map_t monomials;
 
     // Normalize a monomial and insert into a map
-    static void normalize_and_insert(monomial_t & m, MelemType coeff, monomials_map_t & target)
+    static void normalize_and_insert(monomial_t & m, ComplexType coeff, monomials_map_t & target)
     {
         // The normalization is done by employing a simple bubble sort algorithms.
         // Apart from sorting elements this function keeps track of the sign and

--- a/include/pomerol/OperatorPresets.h
+++ b/include/pomerol/OperatorPresets.h
@@ -18,9 +18,9 @@ private:
     const ParticleIndex Nmodes;
 public:
     N(ParticleIndex Nmodes);
-    std::map <FockState,MelemType> actRight(const FockState &ket) const;
-    MelemType getMatrixElement(const FockState &bra, const FockState &ket) const;
-    MelemType getMatrixElement(const FockState &ket) const;
+    std::map <FockState,ComplexType> actRight(const FockState &ket) const;
+    ComplexType getMatrixElement(const FockState &bra, const FockState &ket) const;
+    ComplexType getMatrixElement(const FockState &ket) const;
 };
 
 class Sz : public Operator {
@@ -32,9 +32,9 @@ private:
 public:
     Sz(ParticleIndex Nmodes, const std::vector<ParticleIndex> & SpinUpIndices); 
     Sz(const std::vector<ParticleIndex> & SpinUpIndices, const std::vector<ParticleIndex> & SpinDownIndices);
-    std::map <FockState,MelemType> actRight(const FockState &ket) const;
-    MelemType getMatrixElement(const FockState &bra, const FockState &ket) const;
-    MelemType getMatrixElement(const FockState &ket) const;
+    std::map <FockState,ComplexType> actRight(const FockState &ket) const;
+    ComplexType getMatrixElement(const FockState &bra, const FockState &ket) const;
+    ComplexType getMatrixElement(const FockState &ket) const;
 };
 
  

--- a/include/pomerol/SusceptibilityPart.h
+++ b/include/pomerol/SusceptibilityPart.h
@@ -105,7 +105,7 @@ class SusceptibilityPart : public Thermal
     const RealType MatrixElementTolerance; // 1e-8;
 
     /** BOSON: The weight of zero-energy pole. **/
-    MelemType ZeroPoleWeight;
+    ComplexType ZeroPoleWeight;
 
 public:
 

--- a/include/pomerol/Symmetrizer.h
+++ b/include/pomerol/Symmetrizer.h
@@ -110,12 +110,12 @@ friend class Symmetrizer;
 private:
     /** Total number of quantum numbers. */
     int amount;
-    /** A vector of numbers. For now set as MelemType. */
-    std::vector<MelemType> numbers;
+    /** A vector of numbers. For now set as ComplexType. */
+    std::vector<ComplexType> numbers;
     /** Private constuctor - can be called only inside Symmetrizer. */
     QuantumNumbers(int amount);
     /** Hash generator. */
-    boost::hash<std::vector<MelemType> > numbers_hash_generator;
+    boost::hash<std::vector<ComplexType> > numbers_hash_generator;
     /** A hash of the quantum numbers - used for comparison. */
     std::size_t NumbersHash;
 public:
@@ -123,7 +123,7 @@ public:
      * \param[in] pos Position of QuantumNumber, e.g. the number of operation in Symmetrizer::Operations.
      * \param[in] val Value of QuantumNumber.
      */
-    bool set ( int pos, MelemType val );
+    bool set ( int pos, ComplexType val );
 
     /* Comparison operators. */
     bool operator< (const QuantumNumbers& rhs) const ;

--- a/include/pomerol/first_include.h.in
+++ b/include/pomerol/first_include.h.in
@@ -6,7 +6,4 @@
 // openmp
 #cmakedefine POMEROL_USE_OPENMP
 
-// complex matrix elements
-#cmakedefine POMEROL_COMPLEX_MATRIX_ELEMENTS
-
 #endif // endif __INCLUDE_FIRST_INCLUDE_H_a83f82k

--- a/src/pomerol/FieldOperator.cpp
+++ b/src/pomerol/FieldOperator.cpp
@@ -136,7 +136,7 @@ BlockNumber FieldOperator::getLeftIndex(BlockNumber RightIndex) const
 BlockNumber FieldOperator::mapsTo(BlockNumber RightIndex) const
 {
     bool found=false;
-    std::map<FockState, MelemType> result;
+    std::map<FockState, ComplexType> result;
     const std::vector<FockState> &states=S.getFockStates(RightIndex);
     for (std::vector<FockState>::const_iterator state_it=states.begin(); state_it!=states.end() && !found; state_it++) {
         result = O->actRight(*state_it);

--- a/src/pomerol/FieldOperatorPart.cpp
+++ b/src/pomerol/FieldOperatorPart.cpp
@@ -32,23 +32,15 @@ void FieldOperatorPart::compute()
     for (std::vector<FockState>::const_iterator CurrentState = fromStates.begin();
                                                 CurrentState < fromStates.end(); CurrentState++) {
 	    FockState K=*CurrentState;
-        std::map<FockState, MelemType> result1 = O->actRight(K);
+        std::map<FockState, ComplexType> result1 = O->actRight(K);
         if (result1.size()) {
             FockState L=result1.begin()->first;
-            #ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
             int sign = int(std::real(result1.begin()->second));
-            #else
-            int sign = result1.begin()->second;
-            #endif
 	        if ( L!=ERROR_FOCK_STATE && std::abs(sign)>std::numeric_limits<RealType>::epsilon() ) {
 		        InnerQuantumState l=S.getInnerState(L), k=S.getInnerState(K);
 
                 for (InnerQuantumState n=0; n<toStates.size(); n++) {
-#ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
                     LeftMat(n,k) = std::conj(HTo.getMatrixElement(l,n));
-#else
-                    LeftMat(n,k) = HTo.getMatrixElement(l,n);
-#endif
                 }
 
                 for (InnerQuantumState m=0; m<fromStates.size(); m++) {
@@ -68,9 +60,6 @@ void FieldOperatorPart::compute()
     elementsRowMajor = (LeftMat * RightMat).sparseView(MatrixElementTolerance);
 #endif
 
-    #ifndef POMEROL_COMPLEX_MATRIX_ELEMENTS
-    elementsRowMajor.prune(MatrixElementTolerance);
-    #endif
     elementsColMajor = elementsRowMajor;
     Status = Computed;
 }

--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -43,7 +43,7 @@ void Hamiltonian::prepare(const MPI_Comm& comm)
 
             MPI_Bcast(parts[p]->H.data(),
                       parts[p]->H.size(),
-                      MPI_MELEM_DATATYPE,
+                      MPI_CXX_DOUBLE_COMPLEX,
                       rank,
                       comm
                      );
@@ -52,7 +52,7 @@ void Hamiltonian::prepare(const MPI_Comm& comm)
             parts[p]->H.resize(mat_rows, mat_rows);
             MPI_Bcast(parts[p]->H.data(),
                       mat_rows * mat_rows,
-                      MPI_MELEM_DATATYPE,
+                      MPI_CXX_DOUBLE_COMPLEX,
                       job_map[p],
                       comm
                      );
@@ -85,7 +85,7 @@ void Hamiltonian::compute(const MPI_Comm& comm)
             }
             MPI_Bcast(parts[p]->H.data(),
                       parts[p]->H.size(),
-                      MPI_MELEM_DATATYPE,
+                      MPI_CXX_DOUBLE_COMPLEX,
                       rank,
                       comm
                     );
@@ -99,7 +99,7 @@ void Hamiltonian::compute(const MPI_Comm& comm)
             parts[p]->Eigenvalues.resize(parts[p]->H.rows());
             MPI_Bcast(parts[p]->H.data(),
                       parts[p]->H.size(),
-                      MPI_MELEM_DATATYPE,
+                      MPI_CXX_DOUBLE_COMPLEX,
                       job_map[p],
                       comm);
             MPI_Bcast(parts[p]->Eigenvalues.data(),

--- a/src/pomerol/HamiltonianPart.cpp
+++ b/src/pomerol/HamiltonianPart.cpp
@@ -26,15 +26,15 @@ void HamiltonianPart::prepare()
 
     H.resize(BlockSize,BlockSize);
     H.setZero();
-    std::map<FockState,MelemType>::const_iterator melem_it;
+    std::map<FockState,ComplexType>::const_iterator melem_it;
 
     for(InnerQuantumState right_st=0; right_st<BlockSize; right_st++)
     {
         FockState ket = S.getFockState(Block,right_st);
-        std::map<FockState,MelemType> mapStates = F.actRight(ket);
+        std::map<FockState,ComplexType> mapStates = F.actRight(ket);
         for (melem_it=mapStates.begin(); melem_it!=mapStates.end(); melem_it++) {
             FockState bra = melem_it -> first;
-            MelemType melem = melem_it -> second;
+            ComplexType melem = melem_it -> second;
             //DEBUG("<" << bra << "|" << melem << "|" << F << "|" << ket << ">");
             InnerQuantumState left_st = S.getInnerState(bra);
 //            if (left_st > right_st) { ERROR("!"); exit(1); };
@@ -52,16 +52,10 @@ void HamiltonianPart::compute()		//method of diagonalization classificated part 
 {
     if (Status >= Computed) return;
     if (H.rows() == 1) {
-        #ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
         assert (std::abs(H(0,0) - std::real(H(0,0))) < std::numeric_limits<RealType>::epsilon());
-        #endif
         Eigenvalues.resize(1);
-        #ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
-	    Eigenvalues << std::real(H(0,0));
-        #else
-	    Eigenvalues << H(0,0);
-        #endif
-	    H(0,0) = 1;
+        Eigenvalues << std::real(H(0,0));
+        H(0,0) = 1;
         }
     else {
 	    Eigen::SelfAdjointEigenSolver<MatrixType> Solver(H,Eigen::ComputeEigenvectors);
@@ -72,7 +66,7 @@ void HamiltonianPart::compute()		//method of diagonalization classificated part 
 }
 
 
-MelemType HamiltonianPart::getMatrixElement(InnerQuantumState m, InnerQuantumState n) const	//return  H(m,n)
+ComplexType HamiltonianPart::getMatrixElement(InnerQuantumState m, InnerQuantumState n) const	//return  H(m,n)
 {
     return H(m,n);
 }

--- a/src/pomerol/Lattice.cpp
+++ b/src/pomerol/Lattice.cpp
@@ -35,7 +35,7 @@ Lattice::Term::Term (unsigned int N):N(N)
 };
 
 
-Lattice::Term::Term(unsigned int N, bool * OperatorSequence_, MelemType Value_, std::string * SiteLabels_, unsigned short * Orbitals_, unsigned short *Spins_):
+Lattice::Term::Term(unsigned int N, bool * OperatorSequence_, ComplexType Value_, std::string * SiteLabels_, unsigned short * Orbitals_, unsigned short *Spins_):
 N(N)
 {
   OperatorSequence.assign( OperatorSequence_, OperatorSequence_+N );

--- a/src/pomerol/LatticePresets.cpp
+++ b/src/pomerol/LatticePresets.cpp
@@ -8,7 +8,7 @@ namespace Pomerol {
 
 // 2-index presets
 
-Lattice::Term* Lattice::Term::Presets::Hopping ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::Hopping ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
 {
     Lattice::Term *T = new Term(2);
     bool OperatorSequence[2] = { 1, 0 };
@@ -23,12 +23,12 @@ Lattice::Term* Lattice::Term::Presets::Hopping ( const std::string& Label1, cons
     return T;
 };
 
-Lattice::Term* Lattice::Term::Presets::Hopping ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital, unsigned short spin)
+Lattice::Term* Lattice::Term::Presets::Hopping ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital, unsigned short spin)
 {
     return Hopping(Label1, Label2, Value, orbital, orbital, spin, spin);
 }
 
-Lattice::Term* Lattice::Term::Presets::Level ( const std::string& Label, MelemType Value, unsigned short orbital, unsigned short spin)
+Lattice::Term* Lattice::Term::Presets::Level ( const std::string& Label, ComplexType Value, unsigned short orbital, unsigned short spin)
 {
     Lattice::Term *T = new Term(2);
     bool OperatorSequence[2] = { 1, 0 };
@@ -45,7 +45,7 @@ Lattice::Term* Lattice::Term::Presets::Level ( const std::string& Label, MelemTy
 
 // 4-index presets
 
-Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label1, const std::string& Label2,  MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label1, const std::string& Label2,  ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
 {
     if (Label1 == Label2 && spin1 == spin2 && orbital1 == orbital2) {
         ERROR("NupNdown terms should have different sites or spin or orbital components. Returning simple Level term.");
@@ -64,22 +64,22 @@ Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label1, con
     return T;
 }
 
-Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
 {
     return NupNdown(Label, Label, Value, orbital1, orbital2, spin1, spin2);
 }
 
-Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2 )
+Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2 )
 {
     return NupNdown(Label, Label, Value, orbital1, orbital2, up, down);
 };
 
-Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, MelemType Value, unsigned short Orbital, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::NupNdown ( const std::string& Label, ComplexType Value, unsigned short Orbital, unsigned short spin1, unsigned short spin2 )
 {
     return NupNdown(Label, Label, Value, Orbital, Orbital, spin1, spin2);
 };
 
-Lattice::Term* Lattice::Term::Presets::Spinflip ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::Spinflip ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
 {
     if (orbital1 == orbital2 || spin1 == spin2) { ERROR("Spinflips should have different spins and orbitals"); throw (exWrongIndices()); }
     Lattice::Term *T = new Term(4);
@@ -95,7 +95,7 @@ Lattice::Term* Lattice::Term::Presets::Spinflip ( const std::string& Label, Mele
     return T;
 }
 
-Lattice::Term* Lattice::Term::Presets::PairHopping ( const std::string& Label, MelemType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
+Lattice::Term* Lattice::Term::Presets::PairHopping ( const std::string& Label, ComplexType Value, unsigned short orbital1, unsigned short orbital2, unsigned short spin1, unsigned short spin2 )
 {
     if (orbital1 == orbital2 || spin1 == spin2) { ERROR("Pair hopping terms should have different spins and orbitals"); throw (exWrongIndices()); }
     Lattice::Term *T = new Term(4);
@@ -111,7 +111,7 @@ Lattice::Term* Lattice::Term::Presets::PairHopping ( const std::string& Label, M
     return T;
 }
 
-Lattice::Term* Lattice::Term::Presets::SplusSminus ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital)
+Lattice::Term* Lattice::Term::Presets::SplusSminus ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital)
 {
     Term *T = new Term(4);
     bool order[4]              =      { 1,     0,     1,     0 };
@@ -126,7 +126,7 @@ Lattice::Term* Lattice::Term::Presets::SplusSminus ( const std::string& Label1, 
     return T;
 }
 
-Lattice::Term* Lattice::Term::Presets::SminusSplus ( const std::string& Label1, const std::string& Label2, MelemType Value, unsigned short orbital)
+Lattice::Term* Lattice::Term::Presets::SminusSplus ( const std::string& Label1, const std::string& Label2, ComplexType Value, unsigned short orbital)
 {
     Term *T = SplusSminus(Label1, Label2, Value, orbital);
     unsigned short Spins[4]    =      { down, up, up, down  };
@@ -144,7 +144,7 @@ const char* Lattice::Term::Presets::exWrongIndices::what() const throw(){
 // LatticePresets
 //
 
-void LatticePresets::addCoulombS(Lattice *L, const std::string& Label, MelemType U, MelemType Level)
+void LatticePresets::addCoulombS(Lattice *L, const std::string& Label, ComplexType U, ComplexType Level)
 {
     if (L->Sites.find(Label)==L->Sites.end()) throw (Lattice::exWrongLabel());
     unsigned short Orbitals = L->Sites[Label]->OrbitalSize;
@@ -158,7 +158,7 @@ void LatticePresets::addCoulombS(Lattice *L, const std::string& Label, MelemType
        };
 };
 
-void LatticePresets::addCoulombP(Lattice *L, const std::string& Label, MelemType U, MelemType U_p, MelemType J, MelemType Level)
+void LatticePresets::addCoulombP(Lattice *L, const std::string& Label, ComplexType U, ComplexType U_p, ComplexType J, ComplexType Level)
 {
     if (L->Sites.find(Label)==L->Sites.end()) throw (Lattice::exWrongLabel());
     unsigned short Orbitals = L->Sites[Label]->OrbitalSize;
@@ -184,12 +184,12 @@ void LatticePresets::addCoulombP(Lattice *L, const std::string& Label, MelemType
         };
 };
 
-void LatticePresets::addCoulombP(Lattice *L, const std::string& Label, MelemType U, MelemType J, MelemType Level)
+void LatticePresets::addCoulombP(Lattice *L, const std::string& Label, ComplexType U, ComplexType J, ComplexType Level)
 {
     addCoulombP(L, Label, U, U-2.0*J, J, Level);
 }
 
-void LatticePresets::addLevel(Lattice *L, const std::string& Label, MelemType Level)
+void LatticePresets::addLevel(Lattice *L, const std::string& Label, ComplexType Level)
 {
     if (L->Sites.find(Label)==L->Sites.end()) throw (Lattice::exWrongLabel());
     unsigned short Orbitals = L->Sites[Label]->OrbitalSize;
@@ -200,7 +200,7 @@ void LatticePresets::addLevel(Lattice *L, const std::string& Label, MelemType Le
             };
 }
 
-void LatticePresets::addMagnetization(Lattice *L, const std::string& Label, MelemType Magnetization)
+void LatticePresets::addMagnetization(Lattice *L, const std::string& Label, ComplexType Magnetization)
 {
     if (L->Sites.find(Label)==L->Sites.end()) { ERROR("No site" << Label << "found."); throw (Lattice::exWrongLabel()); };
     unsigned short Orbitals = L->Sites[Label]->OrbitalSize;
@@ -212,7 +212,7 @@ void LatticePresets::addMagnetization(Lattice *L, const std::string& Label, Mele
         };
 }
 
-void LatticePresets::addSzSz ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType ExchJ)
+void LatticePresets::addSzSz ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType ExchJ)
 {
 
     if (L->Sites.find(Label1)==L->Sites.end()) { ERROR("No site" << Label1 << "found."); throw (Lattice::exWrongLabel()); };
@@ -235,7 +235,7 @@ void LatticePresets::addSzSz ( Lattice *L, const std::string& Label1, const std:
         };
 }
 
-void LatticePresets::addSS ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType ExchJ)
+void LatticePresets::addSS ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType ExchJ)
 {
     if (L->Sites.find(Label1)==L->Sites.end()) { ERROR("No site" << Label1 << "found."); throw (Lattice::exWrongLabel()); };
     if (L->Sites.find(Label2)==L->Sites.end()) { ERROR("No site" << Label2 << "found."); throw (Lattice::exWrongLabel()); };
@@ -251,7 +251,7 @@ void LatticePresets::addSS ( Lattice *L, const std::string& Label1, const std::s
         };
 }
 
-void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short Spin1, unsigned short Spin2)
+void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short Spin1, unsigned short Spin2)
 {
     if (L->Sites.find(Label1)==L->Sites.end()) { ERROR("No site" << Label1 << "found."); throw (Lattice::exWrongLabel()); };
     if (L->Sites.find(Label2)==L->Sites.end()) { ERROR("No site" << Label2 << "found."); throw (Lattice::exWrongLabel()); };
@@ -259,19 +259,15 @@ void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const s
         ERROR("Orbital or Spin index mismatch"); throw ( Lattice::Term::Presets::exWrongIndices() );
         };
     L->addTerm(Lattice::Term::Presets::Hopping(Label1, Label2, t, Orbital1, Orbital2, Spin1, Spin2));
-    #ifdef POMEROL_COMPLEX_MATRIX_ELEMENTS
     L->addTerm(Lattice::Term::Presets::Hopping(Label2, Label1, conj(t), Orbital2, Orbital1, Spin2, Spin1)); // Hermite conjugate
-    #else
-    L->addTerm(Lattice::Term::Presets::Hopping(Label2, Label1, t, Orbital2, Orbital1, Spin2, Spin1));
-    #endif
 }
 
-void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short Spin)
+void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, unsigned short Spin)
 {
     addHopping(L,Label1, Label2, t, Orbital1, Orbital2, Spin, Spin);
 }
 
-void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType t, unsigned short Orbital1, unsigned short Orbital2)
+void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2)
 {
     if (L->Sites.find(Label1)==L->Sites.end()) { ERROR("No site " << Label1 << " found."); throw (Lattice::exWrongLabel()); };
     if (L->Sites.find(Label2)==L->Sites.end()) { ERROR("No site " << Label2 << " found."); throw (Lattice::exWrongLabel()); };
@@ -283,7 +279,7 @@ void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const s
     for (int z=0; z<Spins; ++z) addHopping(L, Label1, Label2, t, Orbital1, Orbital2, z, z);
 }
 
-void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, MelemType t)
+void LatticePresets::addHopping ( Lattice *L, const std::string& Label1, const std::string& Label2, ComplexType t)
 {
     if (L->Sites.find(Label1)==L->Sites.end()) { ERROR("No site" << Label1 << "found."); throw (Lattice::exWrongLabel()); };
     if (L->Sites.find(Label2)==L->Sites.end()) { ERROR("No site" << Label2 << "found."); throw (Lattice::exWrongLabel()); };

--- a/src/pomerol/OperatorPresets.cpp
+++ b/src/pomerol/OperatorPresets.cpp
@@ -14,19 +14,19 @@ N::N(ParticleIndex Nmodes):Operator(),Nmodes(Nmodes)
     };
 };
     
-std::map<FockState,MelemType> N::actRight(const FockState &ket) const
+std::map<FockState,ComplexType> N::actRight(const FockState &ket) const
 {
-    std::map<FockState,MelemType> output;
+    std::map<FockState,ComplexType> output;
     output[ket]=this->getMatrixElement(ket);
     return output;
 }
 
-MelemType N::getMatrixElement(const FockState &bra, const FockState &ket) const
+ComplexType N::getMatrixElement(const FockState &bra, const FockState &ket) const
 {
     return (bra!=ket)?0:getMatrixElement(ket);
 }
 
-MelemType N::getMatrixElement(const FockState &ket) const
+ComplexType N::getMatrixElement(const FockState &ket) const
 {
     return ket.count();
 }
@@ -62,7 +62,7 @@ void Sz::generateTerms()
     }
 }
 
-MelemType Sz::getMatrixElement(const FockState &ket) const
+ComplexType Sz::getMatrixElement(const FockState &ket) const
 {
     int up_value=0, down_value=0;
     std::vector<ParticleIndex>::const_iterator it_up=SpinUpIndices.begin(), it_down=SpinDownIndices.begin();
@@ -71,14 +71,14 @@ MelemType Sz::getMatrixElement(const FockState &ket) const
     return 0.5*(up_value-down_value);
 }
 
-MelemType Sz::getMatrixElement(const FockState &bra, const FockState &ket) const
+ComplexType Sz::getMatrixElement(const FockState &bra, const FockState &ket) const
 {
     return (bra!=ket)?0:getMatrixElement(ket);
 }
 
-std::map<FockState,MelemType> Sz::actRight(const FockState &ket) const
+std::map<FockState,ComplexType> Sz::actRight(const FockState &ket) const
 {
-    std::map<FockState,MelemType> output;
+    std::map<FockState,ComplexType> output;
     output[ket]=this->getMatrixElement(ket);
     return output;
 }

--- a/src/pomerol/StatesClassification.cpp
+++ b/src/pomerol/StatesClassification.cpp
@@ -30,7 +30,7 @@ void StatesClassification::compute()
         FockState current_state(IndexSize,FockStateIndex);
         QuantumNumbers QNumbers(Symm.getQuantumNumbers());
         for (int n=0; n<NOperations; ++n) {
-            MelemType Value=sym_op[n]->getMatrixElement(current_state, current_state);
+            ComplexType Value=sym_op[n]->getMatrixElement(current_state, current_state);
             QNumbers.set(n,Value);
         }
         std::map<QuantumNumbers, BlockNumber>::iterator map_pos=QuantumToBlock.find(QNumbers);

--- a/src/pomerol/Symmetrizer.cpp
+++ b/src/pomerol/Symmetrizer.cpp
@@ -104,11 +104,11 @@ const char* Symmetrizer::IndexPermutation::exEqualIndices::what() const throw(){
 // Symmetrizer::QuantumNumbers
 //
 
-Symmetrizer::QuantumNumbers::QuantumNumbers(int amount):amount(amount),numbers( std::vector<MelemType>(amount) ),NumbersHash(numbers_hash_generator(numbers))
+Symmetrizer::QuantumNumbers::QuantumNumbers(int amount):amount(amount),numbers( std::vector<ComplexType>(amount) ),NumbersHash(numbers_hash_generator(numbers))
 {
 };
 
-bool Symmetrizer::QuantumNumbers::set ( int pos, MelemType val )
+bool Symmetrizer::QuantumNumbers::set ( int pos, ComplexType val )
 {
     if (pos<amount) {
         numbers[pos] = val;

--- a/test/AndersonComplexTest.cpp
+++ b/test/AndersonComplexTest.cpp
@@ -102,8 +102,8 @@ bool run_test(ComplexType J /* spin-flip amplitude */) {
     // Reference
     GF_ref ref(J);
 
-    BOOST_FOREACH(spin s1, all_spins){
-    BOOST_FOREACH(spin s2, all_spins){
+    for(spin s1 : all_spins){
+    for(spin s2 : all_spins){
         INFO("s1 = " << s1 << " s2 = " << s2);
         ParticleIndex index1 = IndexInfo.getIndex("C",0,s1);
         ParticleIndex index2 = IndexInfo.getIndex("C",0,s2);
@@ -124,7 +124,7 @@ int main(int argc, char* argv[]) {
 
     MPI_Init(&argc, &argv);
 
-    return (
+    bool result =
      run_test(ComplexType( 0.1,0)) &&
      run_test(ComplexType(-0.1,0)) &&
      run_test(ComplexType(0, 0.1)) &&
@@ -132,6 +132,9 @@ int main(int argc, char* argv[]) {
      run_test(ComplexType(0.1, 0.1)) &&
      run_test(ComplexType(0.1,-0.1)) &&
      run_test(ComplexType(-0.1,0.1)) &&
-     run_test(ComplexType(-0.1,-0.1))
-     ) ? EXIT_SUCCESS : EXIT_FAILURE;
+     run_test(ComplexType(-0.1,-0.1));
+
+     MPI_Finalize();
+
+     return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/CCdagOperatorTest.cpp
+++ b/test/CCdagOperatorTest.cpp
@@ -49,18 +49,18 @@ int main(int argc, char* argv[])
 
     FockState ket(IndexSize,2);
     FockState ket2(IndexSize,2);
-    std::map<FockState, MelemType> map1=Cdag_op.actRight(ket);
-    for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
+    std::map<FockState, ComplexType> map1=Cdag_op.actRight(ket);
+    for ( std::map<FockState, ComplexType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second;
+        ComplexType Value= it1->second;
         INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value );
         ket2=bra;
         }
 
     map1=O->actRight(ket);
-    for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
+    for ( std::map<FockState, ComplexType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second;
+        ComplexType Value= it1->second;
         INFO("<" << bra << "| c^+_3 |" << ket << "> = " << Value );
         ket2=bra;
         }
@@ -68,9 +68,9 @@ int main(int argc, char* argv[])
     ket=ket2;
     OperatorPresets::C C_op(1);
     map1=C_op.actRight(ket);
-    for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
+    for ( std::map<FockState, ComplexType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second;
+        ComplexType Value= it1->second;
         INFO("<" << bra << "| c_1 |" << ket << "> = " << Value );
         }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ FieldOperatorTest
 GF1siteTest
 GF2siteTest
 AndersonTest
+AndersonComplexTest
 GF4siteTest
 GFContainerTest
 TwoParticleGFContainerTest
@@ -25,9 +26,6 @@ AndersonTest03
 EnsembleAverage1siteTest
 Susceptibility1siteTest
 )
-if(POMEROL_COMPLEX_MATRIX_ELEMENTS)
- list(APPEND tests AndersonComplexTest)
-endif(POMEROL_COMPLEX_MATRIX_ELEMENTS)
 
 foreach (test ${tests})
     set(test_src ${test}.cpp)

--- a/test/NOperatorTest.cpp
+++ b/test/NOperatorTest.cpp
@@ -50,19 +50,19 @@ int main(int argc, char* argv[])
     DEBUG(N.commutes(N));
 
     FockState ket(IndexSize,3);
-    std::map<FockState, MelemType> map1=NN->actRight(ket);
-    for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
+    std::map<FockState, ComplexType> map1=NN->actRight(ket);
+    for ( std::map<FockState, ComplexType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second;
+        ComplexType Value= it1->second;
         INFO("<" << bra << "| N |" << ket << "> = " << Value );
         }
-    if ( map1.size()!=1 && N.getMatrixElement(ket,ket)!=MelemType(2)) return EXIT_FAILURE;
+    if ( map1.size()!=1 && N.getMatrixElement(ket,ket)!=ComplexType(2)) return EXIT_FAILURE;
     ket = FockState(IndexSize, 7);
     INFO ( "<" << ket << "| N |" << ket << "> = " << N.getMatrixElement(ket));
-    if ( std::abs(N.getMatrixElement(ket) - MelemType(3)) >std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
+    if ( std::abs(N.getMatrixElement(ket) - ComplexType(3)) >std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
     ket = FockState(IndexSize, 8);
     INFO ( "<" << ket << "| N |" << ket << "> = " << N.getMatrixElement(ket));
-    if ( std::abs(N.getMatrixElement(ket) - MelemType(1)) >std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
+    if ( std::abs(N.getMatrixElement(ket) - ComplexType(1)) >std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;
     ket = FockState(IndexSize, 10);
     INFO ( "<" << ket << "| N |" << ket << "> = " << N.getMatrixElement(ket));
     INFO ( "<" << ket << "| N |" << ket << "> = " << NN->getMatrixElement(ket,ket));

--- a/test/OperatorTest.cpp
+++ b/test/OperatorTest.cpp
@@ -45,22 +45,22 @@ int main(int argc, char* argv[])
    a1[0]=1;
    a1[1]=0;
    FockState res_state;
-   MelemType result;
-   std::map<FockState, MelemType> out;
+   ComplexType result;
+   std::map<FockState, ComplexType> out;
 
    Operator IT2 = Cdag(1);
    out=IT2.actRight(a1);
    res_state = out.begin()->first;
    result = out.begin()->second;
    INFO ( IT2 << "|" << a1 << "> =" << result << "|" << res_state << ">");
-   if (result != MelemType(-1)) return EXIT_FAILURE;
+   if (result != ComplexType(-1)) return EXIT_FAILURE;
 
    Operator IT3 = C(0);
    out=IT3.actRight(a1);
    res_state = out.begin()->first;
    result = out.begin()->second;
    INFO ( IT3 << "|" << a1 << "> =" << result << "|" << res_state << ">");
-   if (result != MelemType(1)) return EXIT_FAILURE;
+   if (result != ComplexType(1)) return EXIT_FAILURE;
    if (res_state == ERROR_FOCK_STATE) DEBUG("Term vanishes");
 
    INFO(IT3 << "*" << IT2 << " = " << IT3*IT2);

--- a/test/SingletTest.cpp
+++ b/test/SingletTest.cpp
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
         for (size_t i=0; i<State.size(); ++i) { if (!is_equal(State(i),0.0,1e-3)) INFO_NONEWLINE(State(i) << "*|" << blockstates[i] << "> + "); }; INFO("");
         //RealType s2val = S2.getMatrixElement(State,State,blockstates);
         //RealType szszval = SzSz.getMatrixElement(State,State,blockstates);
-        MelemType splussminusval = SplusSminus.getMatrixElement(State,State,blockstates);
+        ComplexType splussminusval = SplusSminus.getMatrixElement(State,State,blockstates);
 
         //INFO("<S^2> = " << s2val);
         //INFO("<SzSz> = " << szszval);

--- a/test/SzOperatorTest.cpp
+++ b/test/SzOperatorTest.cpp
@@ -50,10 +50,10 @@ int main(int argc, char* argv[])
     OperatorPresets::Sz Sz(IndexSize,SpinUpIndices);
 
     FockState ket(IndexSize,3);
-    std::map<FockState, MelemType> map1=Sz.actRight(ket);
-    for ( std::map<FockState, MelemType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
+    std::map<FockState, ComplexType> map1=Sz.actRight(ket);
+    for ( std::map<FockState, ComplexType>::iterator it1=map1.begin(); it1!=map1.end(); it1++) {
         FockState bra = it1->first;
-        MelemType Value= it1->second;
+        ComplexType Value= it1->second;
         INFO("<" << bra << "| Sz |" << ket << "> = " << Value );
         }
     if ( map1.size()!=1 && std::abs(Sz.getMatrixElement(ket,ket)+1.0)>std::numeric_limits<double>::epsilon()) return EXIT_FAILURE;


### PR DESCRIPTION
The only classes benefitting from storing real matrices are `HamiltonianPart` and `FieldOperatorPart`. We should consider dynamical switching between the matrix storage type in these classes as part of porting to libcommute.