### PR TITLE
Allow bosonic operators in Hamiltonians

### DIFF
--- a/V2.0-ROADMAP.md
+++ b/V2.0-ROADMAP.md
@@ -21,7 +21,7 @@ Here is a list of questions to be answered and tasks to be completed before the
 
 - [x] Remove the `ENABLE_SAVE_PLAINTEXT` macro.
 
-- [ ] Decide whether we want to allow non-fermionic degrees of freedom
+- [x] Decide whether we want to allow non-fermionic degrees of freedom
       in Hamiltonians.
 
 - [x] Decide whether we want to stick with include guards or to switch to

--- a/include/pomerol/IndexClassification.hpp
+++ b/include/pomerol/IndexClassification.hpp
@@ -41,9 +41,12 @@ public:
      */
     template<typename ScalarType>
     IndexClassification(Operators::expression<ScalarType, IndexTypes...> const& H) {
+        // Collect indices of fermionic operators in the Hamiltonian
         for(auto const& mon : H) {
-            for(auto const& g : mon.monomial)
-                InfoToIndices.emplace(g.indices(), 0);
+            for(auto const& g : mon.monomial) {
+                if(libcommute::is_fermion(g))
+                    InfoToIndices.emplace(g.indices(), 0);
+            }
         }
         UpdateMaps();
     }

--- a/include/pomerol/LatticePresets.hpp
+++ b/include/pomerol/LatticePresets.hpp
@@ -10,10 +10,17 @@
 #include "Misc.hpp"
 #include "Operators.hpp"
 
+#include <ostream>
+
 namespace Pomerol {
 
 /** This is a set of presets of different Terms, most commonly used while writing a Hamiltonian. */
 namespace LatticePresets {
+
+    /** Possible spin projections are \b down and \b up */
+    enum spin : unsigned short {down, up};
+
+    std::ostream & operator<<(std::ostream & os, spin s);
 
     using RealExpr = Operators::expression<RealType, std::string, unsigned short, spin>;
     using ComplexExpr = Operators::expression<ComplexType, std::string, unsigned short, spin>;

--- a/include/pomerol/LatticePresets.hpp
+++ b/include/pomerol/LatticePresets.hpp
@@ -18,7 +18,7 @@ namespace Pomerol {
 namespace LatticePresets {
 
     /** Possible spin projections are \b down and \b up */
-    enum spin : unsigned short {down, up};
+    enum spin : short {undef = -1, down = 0, up = 1};
 
     std::ostream & operator<<(std::ostream & os, spin s);
 
@@ -163,6 +163,31 @@ namespace LatticePresets {
      */
     RealExpr SS(const std::string& Label1, const std::string& Label2, RealType ExchJ, unsigned short NOrbitals = 1);
     ComplexExpr SS(const std::string& Label1, const std::string& Label2, ComplexType ExchJ, unsigned short NOrbitals = 1);
+
+    //
+    // Bosons
+    //
+
+    /** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital.
+     * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
+     * \param[in] Value \f$\varepsilon\f$ - the energy level.
+     * \param[in] orbital \f$\alpha\f$ - affected orbital of the site.
+     * \param[in] spin \f$\sigma\f$ - affected spin component.
+     */
+    RealExpr BosonLevel(const std::string& Label, RealType Value, unsigned short ExtraIndex);
+    ComplexExpr BosonLevel(const std::string& Label, ComplexType Value, unsigned short ExtraIndex);
+
+    /**
+     * TODO: Bose-Hubbard interaction term
+     */
+    RealExpr BosonInteraction(const std::string& Label, RealType Value, unsigned short ExtraIndex);
+    ComplexExpr BosonInteraction(const std::string& Label, ComplexType Value, unsigned short ExtraIndex);
+
+    /**
+     * TODO: Holstein coupling
+     */
+    RealExpr HolsteinInteraction(const std::string& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex);
+    ComplexExpr HolsteinInteraction(const std::string& Label, ComplexType Value, unsigned short Orbital, unsigned short BosonExtraIndex);
 
 } // namespace Pomerol::LatticePresets
 } // namespace Pomerol

--- a/include/pomerol/Misc.hpp
+++ b/include/pomerol/Misc.hpp
@@ -83,11 +83,6 @@ using ColMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::ColMaj
 template<bool Complex>
 using RowMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::RowMajor>;
 
-/** Possible spin projections are \b down and \b up */
-enum spin : unsigned short {down, up};
-
-std::ostream & operator<<(std::ostream & os, spin s);
-
 /** A short name for imaginary unit. */
 static const ComplexType I = ComplexType(0.0,1.0);    // 'static' to prevent linking problems
 

--- a/include/pomerol/Misc.hpp
+++ b/include/pomerol/Misc.hpp
@@ -61,10 +61,10 @@ template<bool Complex>
 using MelemType = typename std::conditional<Complex, ComplexType, RealType>::type;
 
 template<typename ScalarType>
-using LOperatorType = libcommute::loperator<ScalarType, libcommute::fermion>;
+using LOperatorType = libcommute::loperator<ScalarType, libcommute::fermion, libcommute::boson>;
 
 template<bool Complex>
-using LOperatorTypeRC = libcommute::loperator<MelemType<Complex>, libcommute::fermion>;
+using LOperatorTypeRC = libcommute::loperator<MelemType<Complex>, libcommute::fermion, libcommute::boson>;
 
 template<bool Complex>
 using MatrixType = Eigen::Matrix<MelemType<Complex>, Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor>;

--- a/include/pomerol/Operators.hpp
+++ b/include/pomerol/Operators.hpp
@@ -25,6 +25,8 @@ using libcommute::hc;
 using libcommute::static_indices::c;
 using libcommute::static_indices::c_dag;
 using libcommute::static_indices::n;
+using libcommute::static_indices::a;
+using libcommute::static_indices::a_dag;
 
 namespace Detail {
 
@@ -67,21 +69,30 @@ make_index_sequence<std::tuple_size<typename std::decay<T>::type>::value>
 make_seq() { return {}; }
 
 template<size_t N, typename T>
-using element_t = typename std::tuple_element<N, typename std::decay<T>::type>::type;
+using element_t =
+typename std::tuple_element<N, typename std::decay<T>::type>::type;
 
 template<typename F, typename ArgsT, size_t... Is>
 auto apply_impl(F && f, ArgsT && args, index_sequence<Is...>) ->
-    decltype(f(static_cast<element_t<Is, ArgsT>>(std::get<Is>(std::forward<ArgsT>(args)))...)) {
-    return f(static_cast<element_t<Is, ArgsT>>(std::get<Is>(std::forward<ArgsT>(args)))...);
+    decltype(f(static_cast<element_t<Is, ArgsT>>(
+        std::get<Is>(std::forward<ArgsT>(args))
+    )...)) {
+    return f(static_cast<element_t<Is, ArgsT>>(
+        std::get<Is>(std::forward<ArgsT>(args))
+    )...);
 }
 
 template<typename F, typename ArgsT>
 auto apply(F && f, ArgsT && args) ->
-    decltype(apply_impl(std::forward<F>(f), std::forward<ArgsT>(args), make_seq<ArgsT>())) {
-    return apply_impl(std::forward<F>(f), std::forward<ArgsT>(args), make_seq<ArgsT>());
+    decltype(apply_impl(std::forward<F>(f),
+                        std::forward<ArgsT>(args),
+                        make_seq<ArgsT>())) {
+    return apply_impl(std::forward<F>(f),
+                      std::forward<ArgsT>(args),
+                      make_seq<ArgsT>());
 }
 
-} // namespace Pomerol::Operators::detail
+} // namespace Pomerol::Operators::Detail
 
 //
 // Operator presets

--- a/prog/anderson_model.hpp
+++ b/prog/anderson_model.hpp
@@ -44,8 +44,8 @@ public:
 
   virtual std::pair<ParticleIndex, ParticleIndex>
   get_node(const IndexInfoType & IndexInfo) override {
-    ParticleIndex d0 = IndexInfo.getIndex("A",0,down);
-    ParticleIndex u0 = IndexInfo.getIndex("A",0,up);
+    ParticleIndex d0 = IndexInfo.getIndex("A",0,LatticePresets::down);
+    ParticleIndex u0 = IndexInfo.getIndex("A",0,LatticePresets::up);
     return std::make_pair(d0, u0);
   }
 

--- a/prog/hubbard2d_model.hpp
+++ b/prog/hubbard2d_model.hpp
@@ -41,8 +41,8 @@ public:
 
   virtual std::pair<ParticleIndex, ParticleIndex>
   get_node(const IndexInfoType &IndexInfo) override {
-    ParticleIndex d0 = IndexInfo.getIndex("S0",0,down);
-    ParticleIndex u0 = IndexInfo.getIndex("S0",0,up);
+    ParticleIndex d0 = IndexInfo.getIndex("S0",0,LatticePresets::down);
+    ParticleIndex u0 = IndexInfo.getIndex("S0",0,LatticePresets::up);
     return std::make_pair(d0, u0);
   };
 
@@ -100,7 +100,7 @@ public:
                                std::set<ParticleIndex>& f,
                                const IndexInfoType &IndexInfo) override {
     for (size_t x=0; x<size_x; x++) {
-      ParticleIndex ind = IndexInfo.getIndex(names[SiteIndexF(x,0)],0,down);
+      ParticleIndex ind = IndexInfo.getIndex(names[SiteIndexF(x,0)],0,LatticePresets::down);
       f.insert(ind);
       indices2.insert(IndexCombination2(d0,ind));
     }

--- a/prog/quantum_model.hpp
+++ b/prog/quantum_model.hpp
@@ -42,9 +42,11 @@ class quantum_model {
 
 public:
 
-  using IndexInfoType = Pomerol::IndexClassification<std::string,
-                                                     unsigned short,
-                                                     Pomerol::spin>;
+  using IndexInfoType = Pomerol::IndexClassification<
+      std::string,
+      unsigned short,
+      Pomerol::LatticePresets::spin
+  >;
 
   quantum_model(int argc, char* argv[], const std::string &prog_desc);
   ~quantum_model();

--- a/src/pomerol/LatticePresets.cpp
+++ b/src/pomerol/LatticePresets.cpp
@@ -8,11 +8,17 @@ namespace LatticePresets {
 using Operators::c_dag;
 using Operators::c;
 using Operators::n;
+using Operators::a_dag;
+using Operators::a;
 
 // spin
 std::ostream & operator<<(std::ostream & os, spin s)
 {
-    return os << (s == up ? "up" : "dn");
+    switch(s) {
+      case undef: return os;
+      case up: return os << "up";
+      case down: return os << "dn";
+    }
 }
 
 //
@@ -325,6 +331,40 @@ ComplexExpr SS(const std::string& Label1, const std::string& Label2, ComplexType
         LatticePresets::SminusSplus(Label1, Label2, ExchJ / 2., Orbital);
     }
     return res;
+}
+
+RealExpr BosonLevel(const std::string& Label, RealType Value, unsigned short ExtraIndex)
+{
+    return Value * a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
+}
+
+ComplexExpr BosonLevel(const std::string& Label, ComplexType Value, unsigned short ExtraIndex)
+{
+    return Value * a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
+}
+
+RealExpr BosonInteraction(const std::string& Label, RealType Value, unsigned short ExtraIndex)
+{
+    auto nb = a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
+    return 0.5 * Value * nb * (nb - 1.0);
+}
+
+ComplexExpr BosonInteraction(const std::string& Label, ComplexType Value, unsigned short ExtraIndex)
+{
+    auto nb = a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
+    return 0.5 * Value * nb * (nb - 1.0);
+}
+
+RealExpr HolsteinInteraction(const std::string& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex)
+{
+    auto N = n(Label, Orbital, up) + n(Label, Orbital, down);
+    return Value * N * (a_dag(Label, BosonExtraIndex, undef) + a(Label, BosonExtraIndex, undef));
+}
+
+ComplexExpr HolsteinInteraction(const std::string& Label, ComplexType Value, unsigned short Orbital, unsigned short BosonExtraIndex)
+{
+    auto N = n(Label, Orbital, up) + n(Label, Orbital, down);
+    return Value * N * (a_dag(Label, BosonExtraIndex, undef) + a(Label, BosonExtraIndex, undef));
 }
 
 } // namespace Pomerol::LatticePresets

--- a/src/pomerol/LatticePresets.cpp
+++ b/src/pomerol/LatticePresets.cpp
@@ -9,6 +9,12 @@ using Operators::c_dag;
 using Operators::c;
 using Operators::n;
 
+// spin
+std::ostream & operator<<(std::ostream & os, spin s)
+{
+    return os << (s == up ? "up" : "dn");
+}
+
 //
 // 2-index presets
 //
@@ -251,8 +257,8 @@ RealExpr Magnetization(const std::string& Label, RealType Magnetization, unsigne
 {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
-        res += LatticePresets::Level(Label, Magnetization, Orbital, Pomerol::up);
-        res += LatticePresets::Level(Label, -Magnetization, Orbital, Pomerol::down);
+        res += LatticePresets::Level(Label, Magnetization, Orbital, up);
+        res += LatticePresets::Level(Label, -Magnetization, Orbital, down);
     }
     return res;
 }
@@ -261,8 +267,8 @@ ComplexExpr Magnetization(const std::string& Label, ComplexType Magnetization, u
 {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
-        res += LatticePresets::Level(Label, Magnetization, Orbital, Pomerol::up);
-        res += LatticePresets::Level(Label, -Magnetization, Orbital, Pomerol::down);
+        res += LatticePresets::Level(Label, Magnetization, Orbital, up);
+        res += LatticePresets::Level(Label, -Magnetization, Orbital, down);
     }
     return res;
 }

--- a/src/pomerol/Misc.cpp
+++ b/src/pomerol/Misc.cpp
@@ -2,15 +2,6 @@
 
 namespace Pomerol {
 
-//////////
-// spin //
-//////////
-std::ostream & operator<<(std::ostream & os, spin s)
-{
-    return os << (s == up ? "up" : "dn");
-}
-
-
 //////////////////
 // Permutation3 //
 //////////////////

--- a/test/AndersonComplexTest.cpp
+++ b/test/AndersonComplexTest.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 using namespace Pomerol;
+using LatticePresets::spin;
 
 // Parameters
 double mu = 1.2;
@@ -38,6 +39,9 @@ struct GF_ref {
 
     ComplexType operator()(spin s1, spin s2, int n) const {
         ComplexType iw = ComplexType(0,M_PI*(2*n+1)/beta);
+
+        using LatticePresets::up;
+        using LatticePresets::down;
 
         ComplexType res = 0;
         if(s1 == up && s2 == up) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(catch2 PRIVATE ${MPI_CXX_INCLUDE_PATH})
 # Pomerol tests
 set(tests
     HamiltonianTest
+    HamiltonianBosonsTest
     GF1siteTest
     GF2siteTest
     GF4siteTest

--- a/test/HamiltonianBosonsTest.cpp
+++ b/test/HamiltonianBosonsTest.cpp
@@ -108,7 +108,8 @@ TEST_CASE("Hamiltonian of an isolated Hubbard-Holstein atom",
 
     SECTION("bits_per_boson_map") {
         std::map<decltype(HExpr)::index_types, unsigned int> bits_per_boson_map;
-        bits_per_boson_map[{"A", 0, undef}] = bits_per_boson;
+        auto boson_indices = decltype(HExpr)::index_types("A", 0, undef);
+        bits_per_boson_map[boson_indices] = bits_per_boson;
         auto HS = MakeHilbertSpace(IndexInfo, HExpr, bits_per_boson_map);
         HS.compute();
         StatesClassification S;

--- a/test/HamiltonianBosonsTest.cpp
+++ b/test/HamiltonianBosonsTest.cpp
@@ -1,0 +1,130 @@
+//
+// This file is a part of pomerol - a scientific ED code for obtaining
+// properties of a Hubbard model on a finite-size lattice
+//
+// Copyright (C) 2010-2012 Andrey Antipov <antipov@ct-qmc.org>
+// Copyright (C) 2010-2012 Igor Krivenko <igor@shg.ru>
+//
+// pomerol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// pomerol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with pomerol.  If not, see <http://www.gnu.org/licenses/>.
+
+/** \file tests/green.cpp
+** \brief Test of a Green's function calculation (1 s-orbital).
+**
+** \author Igor Krivenko (igor@shg.ru)
+*/
+
+#include <pomerol/Misc.hpp>
+#include <pomerol/Operators.hpp>
+#include <pomerol/LatticePresets.hpp>
+#include <pomerol/IndexClassification.hpp>
+#include <pomerol/HilbertSpace.hpp>
+#include <pomerol/StatesClassification.hpp>
+#include <pomerol/Hamiltonian.hpp>
+#include <pomerol/DensityMatrix.hpp>
+#include <pomerol/FieldOperatorContainer.hpp>
+#include <pomerol/GreensFunction.hpp>
+#include <pomerol/GFContainer.hpp>
+
+#include "catch2/catch-pomerol.hpp"
+
+#include <algorithm>
+#include <map>
+#include <vector>
+
+using namespace Pomerol;
+
+TEST_CASE("Hamiltonian of an isolated Hubbard-Holstein atom",
+          "[HubbardHolstein]") {
+    using namespace LatticePresets;
+    using namespace Operators;
+
+    RealType U = 1.0;
+    RealType mu = 0.4;
+    RealType Omega = 4.0;
+    RealType lambda = 1.5;
+    unsigned int bits_per_boson = 6;
+    unsigned int n_ev_to_check = 64;
+
+    //
+    // Reference eigenvalues
+    //
+    // NB.: These are exact eigenvalues of the full infinitely-dimensional
+    // problem. As we truncate the bosonic Hilbert space, energies of the highly
+    // excited states will deviate from the exact values. That's why we check
+    // only the lowest n_ev_to_check eigenvalues.
+    //
+
+    // Renormalized chemical potential and Coulomb interaction
+    RealType mu_r = mu + lambda * lambda / Omega;
+    RealType U_r = U - 2 * lambda * lambda / Omega;
+
+    std::vector<double> ev_ref;
+    for(int nb = 0; nb < (1 << bits_per_boson); ++nb) {
+        ev_ref.push_back(Omega * nb);
+        ev_ref.push_back(-mu_r + Omega * nb);
+        ev_ref.push_back(-mu_r + Omega * nb);
+        ev_ref.push_back(-2 * mu_r + U_r + Omega * nb);
+    }
+    std::sort(ev_ref.begin(), ev_ref.end());
+
+    auto HExpr = CoulombS("A", U, -mu);
+    HExpr += BosonLevel("A", Omega, 0) +
+             HolsteinInteraction("A", lambda, 0, 0);
+    INFO("Hamiltonian\n" << HExpr);
+
+    auto IndexInfo = MakeIndexClassification(HExpr);
+    INFO("Indices\n" << IndexInfo);
+
+    SECTION("bits_per_boson") {
+        auto HS = MakeHilbertSpace(IndexInfo, HExpr, bits_per_boson);
+        HS.compute();
+        StatesClassification S;
+        S.compute(HS);
+
+        Hamiltonian H(S);
+        H.prepare(HExpr, HS, MPI_COMM_WORLD);
+        H.compute(MPI_COMM_WORLD);
+
+        // Sorted list of eigenvalues
+        auto ev = H.getEigenValues();
+        std::sort(ev.data(), ev.data() + ev.size());
+        INFO(ev);
+
+        REQUIRE(ev.size() == ev_ref.size());
+        for(int n = 0; n < n_ev_to_check; ++n)
+            REQUIRE_THAT(ev(n), IsCloseTo(ev_ref[n], 1e-10));
+    }
+
+    SECTION("bits_per_boson_map") {
+        std::map<decltype(HExpr)::index_types, unsigned int> bits_per_boson_map;
+        bits_per_boson_map[{"A", 0, undef}] = bits_per_boson;
+        auto HS = MakeHilbertSpace(IndexInfo, HExpr, bits_per_boson_map);
+        HS.compute();
+        StatesClassification S;
+        S.compute(HS);
+
+        Hamiltonian H(S);
+        H.prepare(HExpr, HS, MPI_COMM_WORLD);
+        H.compute(MPI_COMM_WORLD);
+
+        // Sorted list of eigenvalues
+        auto ev = H.getEigenValues();
+        std::sort(ev.data(), ev.data() + ev.size());
+        INFO(ev);
+
+        REQUIRE(ev.size() == ev_ref.size());
+        for(int n = 0; n < n_ev_to_check; ++n)
+            REQUIRE_THAT(ev(n), IsCloseTo(ev_ref[n], 1e-10));
+    }
+}


### PR DESCRIPTION
It has proven rather easy to add bosons as the heavy lifting is already done by libcommute.

* Definition of `LOperatorType` has been changed to enable action in truncated bosonic Hilbert spaces.
* `IndexClassification` does not store information about bosonic degrees of freedom.
* Constructor of `HilbertSpace` can now take and extra argument `unsigned int bits_per_boson = 1` (determines the truncated size of each bosonic elementary space) or `bits_per_boson_map` (truncated sizes set for each bosonic degree of freedom independently).
* The `spin` enumeration has been moved to `LatticePresets` namespace. In pomerol 1.x we were using the `(atom label,orbital,spin)` triplets to label single particle states. libcommute has made it possible to define and use expressions made of operators labeled by any number of indices with arbitrary types. Therefore, the specialized type for the spin indices makes sense only in the narrower context of lattice presets.
* New lattice presets `BosonLevel`, `BosonInteraction` and `HolsteinInteraction`.
* New element of the `spin` enumeration, `undef = -1`. This spin is meant to be carried by the bosonic degrees of freedom in expressions returned by the new lattice preset functions. Feels a bit ugly but is necessary since all operators (both fermions and bosons) met in the same expression have to carry indices of matching types.
* A unit test has been added.