### PR TITLE
Reformat sources using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+BasedOnStyle: LLVM
+Language: Cpp
+Standard: Cpp11
+
+ColumnLimit: 120
+IndentWidth: 4
+AccessModifierOffset: -4
+PointerAlignment: Left
+SpaceBeforeParens: Never
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortCaseLabelsOnASingleLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowAllArgumentsOnNextLine: false
+BinPackParameters: false
+BinPackArguments: false
+SortUsingDeclarations: false
+BreakBeforeTernaryOperators: false
+
+# Stop clang-format from messing with Doxygen comments
+ReflowComments: false

--- a/V2.0-ROADMAP.md
+++ b/V2.0-ROADMAP.md
@@ -44,7 +44,7 @@ Here is a list of questions to be answered and tasks to be completed before the
     * Revise all exception types;
     * Fix other problems detected by `clang-tidy` and `cppcheck`.
 
-- [ ] Adopt `clang-format`, devise a configuration file for it and reformat
+- [x] Adopt `clang-format`, devise a configuration file for it and reformat
       sources.
 
 - [ ] Add MPL 2.0 headers to the source files.

--- a/include/mpi_dispatcher/mpi_dispatcher.hpp
+++ b/include/mpi_dispatcher/mpi_dispatcher.hpp
@@ -18,8 +18,7 @@ enum WorkerTag : int { Pending, Work, Finish }; // tags for MPI communication
 using JobId = int;
 using WorkerId = int;
 
-struct MPIWorker
-{
+struct MPIWorker {
     MPI_Comm Comm;
     WorkerId const id;
     WorkerId const boss;
@@ -38,8 +37,7 @@ protected:
     WorkerTag Status;
 };
 
-struct MPIMaster
-{
+struct MPIMaster {
     MPI_Comm Comm;
     int Ntasks, Nprocs;
 

--- a/include/pomerol/ComputableObject.hpp
+++ b/include/pomerol/ComputableObject.hpp
@@ -13,16 +13,18 @@ namespace Pomerol {
 
 struct ComputableObject {
     /** Computation statuses of the object. */
-    enum StatusEnum {Constructed, Prepared, Computed};
+    enum StatusEnum { Constructed, Prepared, Computed };
+
 protected:
     /** Current status of an object */
     StatusEnum Status = Constructed;
+
 public:
     ComputableObject() = default;
 
     /** Returns the current status of an object */
     StatusEnum getStatus() const { return Status; }
-    void setStatus(StatusEnum Status_in){
+    void setStatus(StatusEnum Status_in) {
         if(Status_in > Computed)
             throw StatusMismatch("Invalid computable object status");
         Status = Status_in;

--- a/include/pomerol/DensityMatrix.hpp
+++ b/include/pomerol/DensityMatrix.hpp
@@ -25,8 +25,7 @@ namespace Pomerol {
  * the Hamiltonian and the parts of the density matrix itself, since the density matrix
  * is a function of \f$ \hat H \f$.
  */
-class DensityMatrix : public Thermal, public ComputableObject
-{
+class DensityMatrix : public Thermal, public ComputableObject {
     /** A reference to a states classification object. */
     StatesClassification const& S;
     /** A reference to a Hamiltonian defining the grand canonical ensemble. */
@@ -67,7 +66,7 @@ public:
     RealType getAverageDoubleOccupancy(ParticleIndex i, ParticleIndex j) const;
 
     /** Truncate such blocks that do not include any states having larger weight than Tolerance. */
-    void truncateBlocks(RealType Tolerance, bool verbose=true);
+    void truncateBlocks(RealType Tolerance, bool verbose = true);
 
     /** Return true if the block has not been truncated. Always true if function truncateBlocks has not been called. */
     bool isRetained(BlockNumber in) const;

--- a/include/pomerol/DensityMatrixPart.hpp
+++ b/include/pomerol/DensityMatrixPart.hpp
@@ -20,8 +20,7 @@ namespace Pomerol {
  * block of the Hamiltonian.
  */
 
-class DensityMatrixPart : public Thermal
-{
+class DensityMatrixPart : public Thermal {
     /** A reference to a part of a Hamiltonian. */
     HamiltonianPart const& H;
 

--- a/include/pomerol/EnsembleAverage.hpp
+++ b/include/pomerol/EnsembleAverage.hpp
@@ -45,18 +45,19 @@ class EnsembleAverage : public Thermal, public ComputableObject {
     ComplexType Result = 0;
 
     /** Returns the contribution to the ensemble average from a part. Called in prepare() */
-    template<bool Complex>
-    ComplexType computeImpl(MonomialOperatorPart const& Apart, DensityMatrixPart const& DMpart);
+    template <bool Complex> ComplexType computeImpl(MonomialOperatorPart const& Apart, DensityMatrixPart const& DMpart);
 
 public:
-     /** Constructor.
+    /** Constructor.
      * \param[in] S A reference to a states classification object.
      * \param[in] H A reference to a Hamiltonian.
      * \param[in] A A reference to a quadratic operator.
      * \param[in] DM A reference to a density matrix.
      */
-     EnsembleAverage(StatesClassification const& S, Hamiltonian const& H,
-                     MonomialOperator const& A, DensityMatrix const& DM);
+    EnsembleAverage(StatesClassification const& S,
+                    Hamiltonian const& H,
+                    MonomialOperator const& A,
+                    DensityMatrix const& DM);
     /** Copy-constructor.
      * \param[in] EA EnsembleAverage object to be copied.
      */

--- a/include/pomerol/FieldOperatorContainer.hpp
+++ b/include/pomerol/FieldOperatorContainer.hpp
@@ -22,8 +22,7 @@ namespace Pomerol {
  * rotated to eigenvector basis of Hamiltonian H ) for a given Index.
  * If no field operator is yet initialized then calculation of the field operator is done.
  */
-class FieldOperatorContainer
-{
+class FieldOperatorContainer {
 
     /** A map which gives a link to the CreationOperator for a given index */
     std::unordered_map<ParticleIndex, CreationOperator> mapCreationOperators;
@@ -36,15 +35,14 @@ public:
      * \param[in] H A reference to a Hamiltonian.
      * \param[in] IndexInfo A reference to a IndexClassification
      */
-    template<typename... IndexTypes>
+    template <typename... IndexTypes>
     FieldOperatorContainer(IndexClassification<IndexTypes...> const& IndexInfo,
                            HilbertSpace<IndexTypes...> const& HS,
                            StatesClassification const& S,
                            Hamiltonian const& H,
-                           std::set<ParticleIndex> in = {})
-    {
+                           std::set<ParticleIndex> in = {}) {
         if(in.empty()) {
-            for (ParticleIndex p = 0; p < IndexInfo.getIndexSize(); ++p) {
+            for(ParticleIndex p = 0; p < IndexInfo.getIndexSize(); ++p) {
                 in.insert(p);
             }
         }
@@ -54,12 +52,10 @@ public:
         }
     }
 
-    template<typename... IndexTypes>
-    void prepareAll(HilbertSpace<IndexTypes...> const& HS)
-    {
-        for(auto & CX : mapCreationOperators)
+    template <typename... IndexTypes> void prepareAll(HilbertSpace<IndexTypes...> const& HS) {
+        for(auto& CX : mapCreationOperators)
             CX.second.prepare(HS);
-        for(auto & C : mapAnnihilationOperators)
+        for(auto& C : mapAnnihilationOperators)
             C.second.prepare(HS);
     }
     void computeAll();

--- a/include/pomerol/GFContainer.hpp
+++ b/include/pomerol/GFContainer.hpp
@@ -23,26 +23,27 @@
 
 namespace Pomerol {
 
-class GFContainer: public IndexContainer2<GreensFunction,GFContainer>, public Thermal
-{
+class GFContainer : public IndexContainer2<GreensFunction, GFContainer>, public Thermal {
 
 public:
-    template<typename... IndexTypes>
+    template <typename... IndexTypes>
     GFContainer(IndexClassification<IndexTypes...> const& IndexInfo,
                 StatesClassification const& S,
                 Hamiltonian const& H,
                 DensityMatrix const& DM,
-                FieldOperatorContainer const& Operators) :
-        IndexContainer2<GreensFunction, GFContainer>(*this, IndexInfo),
-        Thermal(DM), S(S), H(H), DM(DM), Operators(Operators)
-    {}
+                FieldOperatorContainer const& Operators)
+        : IndexContainer2<GreensFunction, GFContainer>(*this, IndexInfo),
+          Thermal(DM),
+          S(S),
+          H(H),
+          DM(DM),
+          Operators(Operators) {}
 
     void prepareAll(std::set<IndexCombination2> const& InitialIndices = {});
     void computeAll();
 
 protected:
-
-    friend class IndexContainer2<GreensFunction,GFContainer>;
+    friend class IndexContainer2<GreensFunction, GFContainer>;
     std::shared_ptr<GreensFunction> createElement(IndexCombination2 const& Indices) const;
 
     StatesClassification const& S;

--- a/include/pomerol/GreensFunction.hpp
+++ b/include/pomerol/GreensFunction.hpp
@@ -55,15 +55,18 @@ class GreensFunction : public Thermal, public ComputableObject {
     std::vector<GreensFunctionPart> parts;
 
 public:
-     /** Constructor.
+    /** Constructor.
      * \param[in] S A reference to a states classification object.
      * \param[in] H A reference to a Hamiltonian.
      * \param[in] C A reference to an annihilation operator.
      * \param[in] CX A reference to a creation operator.
      * \param[in] DM A reference to a density matrix.
      */
-    GreensFunction(StatesClassification const& S, Hamiltonian const& H,
-                   AnnihilationOperator const& C, CreationOperator const& CX, DensityMatrix const& DM);
+    GreensFunction(StatesClassification const& S,
+                   Hamiltonian const& H,
+                   AnnihilationOperator const& C,
+                   CreationOperator const& CX,
+                   DensityMatrix const& DM);
     /** Copy-constructor.
      * \param[in] GF GreensFunction object to be copied.
      */
@@ -81,17 +84,17 @@ public:
      */
     unsigned short getIndex(std::size_t Position) const;
 
-     /** Returns the value of the Green's function calculated at a given frequency.
+    /** Returns the value of the Green's function calculated at a given frequency.
      * \param[in] MatsubaraNum Number of the Matsubara frequency (\f$ \omega_n = \pi(2n+1)/\beta \f$).
      */
     ComplexType operator()(long MatsubaraNumber) const;
 
-     /** Returns the value of the Green's function calculated at a given frequency.
+    /** Returns the value of the Green's function calculated at a given frequency.
      * \param[in] z Input frequency
      */
     ComplexType operator()(ComplexType z) const;
 
-     /** Returns the value of the Green's function calculated at a given imaginary time point.
+    /** Returns the value of the Green's function calculated at a given imaginary time point.
      * \param[in] tau Imaginary time point.
      */
     ComplexType of_tau(RealType tau) const;
@@ -100,24 +103,28 @@ public:
 };
 
 inline ComplexType GreensFunction::operator()(long int MatsubaraNumber) const {
-    return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber+1));
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber + 1));
 }
 
 inline ComplexType GreensFunction::operator()(ComplexType z) const {
-    if(Vanishing) return 0;
+    if(Vanishing)
+        return 0;
     else {
-        return std::accumulate(parts.begin(), parts.end(), ComplexType(0),
-            [z](ComplexType s, GreensFunctionPart const& p) { return s + p(z); }
-        );
+        return std::accumulate(parts.begin(),
+                               parts.end(),
+                               ComplexType(0),
+                               [z](ComplexType s, GreensFunctionPart const& p) { return s + p(z); });
     }
 }
 
 inline ComplexType GreensFunction::of_tau(RealType tau) const {
-    if(Vanishing) return 0;
+    if(Vanishing)
+        return 0;
     else {
-        return std::accumulate(parts.begin(), parts.end(), ComplexType(0),
-            [tau](ComplexType s, GreensFunctionPart const& p) { return s + p.of_tau(tau); }
-        );
+        return std::accumulate(parts.begin(),
+                               parts.end(),
+                               ComplexType(0),
+                               [tau](ComplexType s, GreensFunctionPart const& p) { return s + p.of_tau(tau); });
     }
 }
 

--- a/include/pomerol/GreensFunctionPart.hpp
+++ b/include/pomerol/GreensFunctionPart.hpp
@@ -27,8 +27,7 @@ namespace Pomerol {
  * Every part describes all transitions allowed by selection rules
  * between a given pair of Hamiltonian blocks.
  */
-class GreensFunctionPart : public Thermal
-{
+class GreensFunctionPart : public Thermal {
     /** A reference to a part of a Hamiltonian (inner index iterates through it). */
     HamiltonianPart const& HpartInner;
     /** A reference to a part of a Hamiltonian (outer index iterates through it). */
@@ -54,9 +53,7 @@ class GreensFunctionPart : public Thermal
         struct Compare {
             double const Tolerance;
             Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
-            bool operator()(Term const& t1, Term const& t2) const {
-                return t2.Pole - t1.Pole >= Tolerance;
-            }
+            bool operator()(Term const& t1, Term const& t2) const { return t2.Pole - t1.Pole >= Tolerance; }
         };
 
         /** Does term have a negligible residue? */
@@ -66,9 +63,7 @@ class GreensFunctionPart : public Thermal
             bool operator()(Term const& t, std::size_t ToleranceDivisor) const {
                 return std::abs(t.Residue) < Tolerance / ToleranceDivisor;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         /** Constructor.
@@ -97,8 +92,7 @@ class GreensFunctionPart : public Thermal
      * \param[in] out An output stream to insert to.
      * \param[in] Term A term to be inserted.
      */
-    friend std::ostream& operator<<(std::ostream& os, Term const& T)
-    {
+    friend std::ostream& operator<<(std::ostream& os, Term const& T) {
         return os << T.Residue << "/(z - " << T.Pole << ")";
     }
 
@@ -109,7 +103,6 @@ class GreensFunctionPart : public Thermal
     RealType const MatrixElementTolerance = 1e-8;
 
 public:
-
     /** Constructor.
      * \param[in] C A reference to a part of an annihilation operator.
      * \param[in] CX A reference to a part of a creation operator.
@@ -118,9 +111,12 @@ public:
      * \param[in] DMpartInner A reference to a part of the density matrix (inner index).
      * \param[in] DMpartOuter A reference to a part of the density matrix (outer index).
      */
-    GreensFunctionPart(MonomialOperatorPart const& C, MonomialOperatorPart const& CX,
-                       HamiltonianPart const& HpartInner, HamiltonianPart const& HpartOuter,
-                       DensityMatrixPart const& DMpartInner, DensityMatrixPart const& DMpartOuter);
+    GreensFunctionPart(MonomialOperatorPart const& C,
+                       MonomialOperatorPart const& CX,
+                       HamiltonianPart const& HpartInner,
+                       HamiltonianPart const& HpartOuter,
+                       DensityMatrixPart const& DMpartInner,
+                       DensityMatrixPart const& DMpartOuter);
 
     /** Iterates over all matrix elements and fills the list of terms. */
     void compute();
@@ -145,13 +141,13 @@ public:
     RealType const ReduceTolerance = 1e-8;
 
 private:
-
-    template<bool Complex> void computeImpl();
+    template <bool Complex> void computeImpl();
 };
 
 // Inline call operators
 inline ComplexType GreensFunctionPart::operator()(long MatsubaraNumber) const {
-    return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber+1)); }
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber + 1));
+}
 
 inline ComplexType GreensFunctionPart::operator()(ComplexType z) const {
     return Terms(z);

--- a/include/pomerol/Hamiltonian.hpp
+++ b/include/pomerol/Hamiltonian.hpp
@@ -27,8 +27,7 @@ namespace Pomerol {
  * It provides eigenvalues and eigenfunctions of any of its parts once they are obtained within its parts.
  * The diagonalization and entering routines are done inside of HamiltonianPart instances.
  */
-class Hamiltonian : public ComputableObject
-{
+class Hamiltonian : public ComputableObject {
     bool Complex = {};
 
     /** Array of pointers to the Hamiltonian Parts */
@@ -39,11 +38,10 @@ class Hamiltonian : public ComputableObject
     RealType GroundEnergy = -HUGE_VAL;
 
 public:
-
     /** Constructor. */
     explicit Hamiltonian(StatesClassification const& S) : S(S) {}
 
-    template<typename ScalarType, typename... IndexTypes>
+    template <typename ScalarType, typename... IndexTypes>
     void prepare(Operators::expression<ScalarType, IndexTypes...> const& H,
                  HilbertSpace<IndexTypes...> const& HS,
                  MPI_Comm const& comm = MPI_COMM_WORLD);
@@ -64,16 +62,17 @@ public:
 private:
     void computeGroundEnergy();
 
-    template<bool C> void prepareImpl(LOperatorTypeRC<C> const& HOp, const MPI_Comm& comm);
-    template<bool C> void computeImpl(MPI_Comm const& comm);
+    template <bool C> void prepareImpl(LOperatorTypeRC<C> const& HOp, const MPI_Comm& comm);
+    template <bool C> void computeImpl(MPI_Comm const& comm);
 };
 
-template<typename ScalarType, typename... IndexTypes>
+template <typename ScalarType, typename... IndexTypes>
 void Hamiltonian::prepare(Operators::expression<ScalarType, IndexTypes...> const& H,
                           HilbertSpace<IndexTypes...> const& HS,
                           MPI_Comm const& comm) {
 
-    if(getStatus() >= Prepared) return;
+    if(getStatus() >= Prepared)
+        return;
 
     Complex = std::is_same<ScalarType, ComplexType>::value;
     LOperatorType<ScalarType> HOp(H, HS.getFullHilbertSpace());

--- a/include/pomerol/HamiltonianPart.hpp
+++ b/include/pomerol/HamiltonianPart.hpp
@@ -31,7 +31,7 @@ class HamiltonianPart : public ComputableObject {
 
     bool Complex;
 
-    void const * HOp;
+    void const* HOp;
 
     /** A matrix filled with matrix elements of HamiltonianPart in the space of FockState's.
      *  After diagonalization it stores the eigenfunctions of the problem in a rows of H. */
@@ -43,18 +43,14 @@ class HamiltonianPart : public ComputableObject {
     friend class Hamiltonian;
 
 public:
-
     /** Constructor.
      * \param[in] IndexInfo IndexClassification object. Provides information about the indices in the problem.
      * \param[in] F IndexHamiltonian object. Provides all Terms required to fill the Hamiltonian part.
      * \param[in] S StatesClassification object. Provides information about Fock States of the problem.
      * \param[in] Block The BlockNumber of current part. It is a genuine id of the part. */
-    template<typename ScalarType>
-    HamiltonianPart(LOperatorType<ScalarType> const& HOp,
-                    StatesClassification const& S,
-                    BlockNumber Block) :
-         S(S), Block(Block), Complex(std::is_same<ScalarType, ComplexType>::value), HOp(&HOp)
-    {}
+    template <typename ScalarType>
+    HamiltonianPart(LOperatorType<ScalarType> const& HOp, StatesClassification const& S, BlockNumber Block)
+        : S(S), Block(Block), Complex(std::is_same<ScalarType, ComplexType>::value), HOp(&HOp) {}
 
     /** Fill in the H matrix. */
     void prepare();
@@ -76,23 +72,21 @@ public:
     RealVectorType const& getEigenValues() const;
 
     /** Return the hamiltonian part matrix. */
-    template<bool Complex> MatrixType<Complex> const& getMatrix() const;
-    template<bool Complex> MatrixType<Complex>& getMatrix();
+    template <bool Complex> MatrixType<Complex> const& getMatrix() const;
+    template <bool Complex> MatrixType<Complex>& getMatrix();
 
     /** Return the lowest Eigenvalue of the current part. */
     RealType getMinimumEigenvalue() const;
 
     /** Return the eigenstate of the H matrix.
      * \param[in] Number of eigenvalue. */
-    template<bool Complex>
-    VectorType<Complex> getEigenState(InnerQuantumState state) const;
+    template <bool Complex> VectorType<Complex> getEigenState(InnerQuantumState state) const;
 
     /** Return the BlockNumber associated with the Hamiltonian part. */
     BlockNumber getBlockNumber() const { return Block; }
 
     /** Print the part of hamiltonian to screen. */
-    friend std::ostream & operator<<(std::ostream & os, HamiltonianPart const& part)
-    {
+    friend std::ostream& operator<<(std::ostream& os, HamiltonianPart const& part) {
         if(part.isComplex())
             os << part.getMatrix<true>() << std::endl;
         else
@@ -102,10 +96,9 @@ public:
     }
 
 private:
-
-    template<bool C> void initHMatrix();
-    template<bool C> void prepareImpl();
-    template<bool C> void computeImpl();
+    template <bool C> void initHMatrix();
+    template <bool C> void prepareImpl();
+    template <bool C> void computeImpl();
 
     void checkComputed() const;
 };

--- a/include/pomerol/HilbertSpace.hpp
+++ b/include/pomerol/HilbertSpace.hpp
@@ -25,16 +25,13 @@
 
 namespace Pomerol {
 
-template<typename... IndexTypes>
-class HilbertSpace : public ComputableObject {
+template <typename... IndexTypes> class HilbertSpace : public ComputableObject {
 
 public:
-
     using FullHilbertSpaceType = libcommute::hilbert_space<IndexTypes...>;
     using SpacePartitionType = libcommute::space_partition;
 
 private:
-
     IndexClassification<IndexTypes...> const& IndexInfo;
 
     FullHilbertSpaceType FullHilbertSpace;
@@ -48,9 +45,8 @@ private:
     struct boson_es_constructor_from_map {
         std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson;
 
-        explicit boson_es_constructor_from_map(
-            std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson
-        ) : bits_per_boson(bits_per_boson) {}
+        explicit boson_es_constructor_from_map(std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson)
+            : bits_per_boson(bits_per_boson) {}
 
         inline std::unique_ptr<libcommute::elementary_space<IndexTypes...>>
         operator()(libcommute::generator<IndexTypes...> const& g) const {
@@ -60,9 +56,7 @@ private:
             } else if(is_boson(g)) {
                 auto it = bits_per_boson.find(g.indices());
                 unsigned int bits = (it == bits_per_boson.end()) ? 1 : it->second;
-                return make_unique<elementary_space_boson<IndexTypes...>>(
-                    bits, g.indices()
-                );
+                return make_unique<elementary_space_boson<IndexTypes...>>(bits, g.indices());
             } else {
                 std::stringstream ss;
                 ss << "Unexpected algebra generator " << g;
@@ -72,29 +66,27 @@ private:
     };
 
 public:
-
-    template<typename ScalarType>
+    template <typename ScalarType>
     HilbertSpace(IndexClassification<IndexTypes...> const& IndexInfo,
                  Operators::expression<ScalarType, IndexTypes...> const& Hamiltonian,
-                 unsigned int bits_per_boson = 1) :
-      IndexInfo(IndexInfo),
-      FullHilbertSpace(Hamiltonian, libcommute::boson_es_constructor(bits_per_boson)),
-      HamiltonianComplex(std::is_same<ScalarType, ComplexType>::value),
-      HOp(std::make_shared<LOperatorType<ScalarType>>(Hamiltonian, FullHilbertSpace))
-    {}
+                 unsigned int bits_per_boson = 1)
+        : IndexInfo(IndexInfo),
+          FullHilbertSpace(Hamiltonian, libcommute::boson_es_constructor(bits_per_boson)),
+          HamiltonianComplex(std::is_same<ScalarType, ComplexType>::value),
+          HOp(std::make_shared<LOperatorType<ScalarType>>(Hamiltonian, FullHilbertSpace)) {}
 
-    template<typename ScalarType>
+    template <typename ScalarType>
     HilbertSpace(IndexClassification<IndexTypes...> const& IndexInfo,
                  Operators::expression<ScalarType, IndexTypes...> const& Hamiltonian,
-                 std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson_map) :
-      IndexInfo(IndexInfo),
-      FullHilbertSpace(Hamiltonian, boson_es_constructor_from_map(bits_per_boson_map)),
-      HamiltonianComplex(std::is_same<ScalarType, ComplexType>::value),
-      HOp(std::make_shared<LOperatorType<ScalarType>>(Hamiltonian, FullHilbertSpace))
-    {}
+                 std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson_map)
+        : IndexInfo(IndexInfo),
+          FullHilbertSpace(Hamiltonian, boson_es_constructor_from_map(bits_per_boson_map)),
+          HamiltonianComplex(std::is_same<ScalarType, ComplexType>::value),
+          HOp(std::make_shared<LOperatorType<ScalarType>>(Hamiltonian, FullHilbertSpace)) {}
 
     void compute() {
-        if(Status >= Computed) return;
+        if(Status >= Computed)
+            return;
 
         // Phase I of auto-partition algorithm
         if(HamiltonianComplex) {
@@ -110,14 +102,8 @@ public:
             using Operators::c_dag;
             using Operators::c;
             using Operators::Detail::apply;
-            auto Cd = LOperatorType<RealType>(
-                apply(c_dag<double, IndexTypes...>, info),
-                FullHilbertSpace
-            );
-            auto C = LOperatorType<RealType>(
-                apply(c<double, IndexTypes...>, info),
-                FullHilbertSpace
-            );
+            auto Cd = LOperatorType<RealType>(apply(c_dag<double, IndexTypes...>, info), FullHilbertSpace);
+            auto C = LOperatorType<RealType>(apply(c<double, IndexTypes...>, info), FullHilbertSpace);
             Partition->merge_subspaces(Cd, C, FullHilbertSpace, false);
         }
 
@@ -133,20 +119,19 @@ public:
     }
 };
 
-template<typename ScalarType, typename... IndexTypes>
-HilbertSpace<IndexTypes...>
-MakeHilbertSpace(IndexClassification<IndexTypes...> const& IndexInfo,
-                 Operators::expression<ScalarType, IndexTypes...> const& Hamiltonian,
-                 unsigned int bits_per_boson = 1) {
-  return HilbertSpace<IndexTypes...>(IndexInfo, Hamiltonian, bits_per_boson);
+template <typename ScalarType, typename... IndexTypes>
+HilbertSpace<IndexTypes...> MakeHilbertSpace(IndexClassification<IndexTypes...> const& IndexInfo,
+                                             Operators::expression<ScalarType, IndexTypes...> const& Hamiltonian,
+                                             unsigned int bits_per_boson = 1) {
+    return HilbertSpace<IndexTypes...>(IndexInfo, Hamiltonian, bits_per_boson);
 }
 
-template<typename ScalarType, typename... IndexTypes>
+template <typename ScalarType, typename... IndexTypes>
 HilbertSpace<IndexTypes...>
 MakeHilbertSpace(IndexClassification<IndexTypes...> const& IndexInfo,
                  Operators::expression<ScalarType, IndexTypes...> const& Hamiltonian,
                  std::map<std::tuple<IndexTypes...>, unsigned int> const& bits_per_boson_map) {
-  return HilbertSpace<IndexTypes...>(IndexInfo, Hamiltonian, bits_per_boson_map);
+    return HilbertSpace<IndexTypes...>(IndexInfo, Hamiltonian, bits_per_boson_map);
 }
 
 } // namespace Pomerol

--- a/include/pomerol/Index.hpp
+++ b/include/pomerol/Index.hpp
@@ -16,8 +16,7 @@
 namespace Pomerol {
 
 /** A structure to handle a combination of 2 Particle Indices. */
-struct IndexCombination2
-{
+struct IndexCombination2 {
     /** Actual indices */
     ParticleIndex Index1, Index2;
 
@@ -25,36 +24,25 @@ struct IndexCombination2
      * \param[in] Index1 - Index of a 1st operator (C)
      * \param[in] Index2 - Index of a 2nd operator (C^+)
     */
-    IndexCombination2(ParticleIndex Index1, ParticleIndex Index2) :
-        Index1(Index1), Index2(Index2) {}
+    IndexCombination2(ParticleIndex Index1, ParticleIndex Index2) : Index1(Index1), Index2(Index2) {}
 
     /** Operator < - comparison method for IndexCombination */
-    bool operator< (IndexCombination2 const& rhs) const
-    {
-        return std::make_tuple(Index1, Index2) <
-               std::make_tuple(rhs.Index1, rhs.Index2);
+    bool operator<(IndexCombination2 const& rhs) const {
+        return std::make_tuple(Index1, Index2) < std::make_tuple(rhs.Index1, rhs.Index2);
     }
     /** Operator == */
-    bool operator==(IndexCombination2 const& rhs) const
-    {
-        return Index1 == rhs.Index1 && Index2 == rhs.Index2;
-    }
+    bool operator==(IndexCombination2 const& rhs) const { return Index1 == rhs.Index1 && Index2 == rhs.Index2; }
     /** Operator != */
-    bool operator!=(IndexCombination2 const& rhs) const
-    {
-        return !operator==(rhs);
-    }
+    bool operator!=(IndexCombination2 const& rhs) const { return !operator==(rhs); }
 
     /** Output to external stream */
-    friend std::ostream& operator<<(std::ostream& os, IndexCombination2 const& ic)
-    {
+    friend std::ostream& operator<<(std::ostream& os, IndexCombination2 const& ic) {
         return os << "(" << ic.Index1 << ic.Index2 << ")";
     }
 };
 
 /** A structure to handle a combination of 4 Particle Indices. */
-struct IndexCombination4
-{
+struct IndexCombination4 {
     /** Actual indices */
     ParticleIndex Index1, Index2, Index3, Index4;
 
@@ -64,33 +52,23 @@ struct IndexCombination4
      * \param[in] Index3 - Index of a 3nd operator (C^+)
      * \param[in] Index4 - Index of a 4nd operator (C^+)
     */
-    IndexCombination4(ParticleIndex Index1, ParticleIndex Index2,
-                     ParticleIndex Index3, ParticleIndex Index4) :
-        Index1(Index1), Index2(Index2), Index3(Index3), Index4(Index4) {}
+    IndexCombination4(ParticleIndex Index1, ParticleIndex Index2, ParticleIndex Index3, ParticleIndex Index4)
+        : Index1(Index1), Index2(Index2), Index3(Index3), Index4(Index4) {}
 
     /** Operator < - comparison method for IndexCombination */
-    bool operator< (IndexCombination4 const& rhs) const
-    {
+    bool operator<(IndexCombination4 const& rhs) const {
         return std::make_tuple(Index1, Index2, Index3, Index4) <
                std::make_tuple(rhs.Index1, rhs.Index2, rhs.Index3, rhs.Index4);
     }
     /** Operator == */
-    bool operator==(IndexCombination4 const& rhs) const
-    {
-        return Index1 == rhs.Index1 &&
-               Index2 == rhs.Index2 &&
-               Index3 == rhs.Index3 &&
-               Index4 == rhs.Index4;
+    bool operator==(IndexCombination4 const& rhs) const {
+        return Index1 == rhs.Index1 && Index2 == rhs.Index2 && Index3 == rhs.Index3 && Index4 == rhs.Index4;
     }
     /** Operator != */
-    bool operator!=(IndexCombination4 const& rhs) const
-    {
-        return !operator==(rhs);
-    }
+    bool operator!=(IndexCombination4 const& rhs) const { return !operator==(rhs); }
 
     /** Output to external stream */
-    friend std::ostream& operator<<(std::ostream& os, IndexCombination4 const& ic)
-    {
+    friend std::ostream& operator<<(std::ostream& os, IndexCombination4 const& ic) {
         return os << "(" << ic.Index1 << ic.Index2 << ic.Index3 << ic.Index4 << ")";
     }
 };

--- a/include/pomerol/IndexClassification.hpp
+++ b/include/pomerol/IndexClassification.hpp
@@ -22,7 +22,7 @@ namespace Pomerol {
 
 /** This class handles all the indices classification, it allocates the indices to particular Site+Spin+Orbital configuration.
  *  It also returns the information about current ParticleIndex on request. */
-template<typename... IndexTypes> class IndexClassification {
+template <typename... IndexTypes> class IndexClassification {
 public:
     /** A structure, which holds the site label, orbital and spin of a ParticleIndex. */
     using IndexInfo = std::tuple<IndexTypes...>;
@@ -34,11 +34,10 @@ private:
     std::vector<IndexInfo> IndicesToInfo;
 
 public:
-
     /** Constructor
      * \param[in] L A pointer to a Lattice Object.
      */
-    template<typename ScalarType>
+    template <typename ScalarType>
     explicit IndexClassification(Operators::expression<ScalarType, IndexTypes...> const& H) {
         // Collect indices of fermionic operators in the Hamiltonian
         for(auto const& mon : H) {
@@ -77,9 +76,7 @@ public:
         }
     }
 
-    ParticleIndex getIndex(IndexTypes... info) const {
-        return getIndex(std::make_tuple(info...));
-    }
+    ParticleIndex getIndex(IndexTypes... info) const { return getIndex(std::make_tuple(info...)); }
 
     /** Return all information about the given index. */
     IndexInfo const& getInfo(ParticleIndex in) const {
@@ -92,8 +89,8 @@ public:
     ParticleIndex getIndexSize() const { return InfoToIndices.size(); }
 
     /** Print all Indices to the information stream */
-    friend std::ostream & operator<<(std::ostream & os, IndexClassification const& ic) {
-        for(ParticleIndex i=0; i<ic.InfoToIndices.size(); ++i) {
+    friend std::ostream& operator<<(std::ostream& os, IndexClassification const& ic) {
+        for(ParticleIndex i = 0; i < ic.InfoToIndices.size(); ++i) {
             os << "Index " << i << " = (";
             libcommute::print_tuple(os, ic.IndicesToInfo[i]);
             os << ")" << std::endl;
@@ -102,21 +99,19 @@ public:
     }
 
 private:
-
     void UpdateMaps() {
         IndicesToInfo.clear();
         IndicesToInfo.reserve(InfoToIndices.size());
-        for(auto & ii : InfoToIndices) {
+        for(auto& ii : InfoToIndices) {
             ii.second = IndicesToInfo.size();
             IndicesToInfo.emplace_back(ii.first);
         }
     }
 };
 
-template<typename ScalarType, typename... IndexTypes>
-IndexClassification<IndexTypes...>
-MakeIndexClassification(Operators::expression<ScalarType, IndexTypes...> const& H) {
-  return IndexClassification<IndexTypes...>(H);
+template <typename ScalarType, typename... IndexTypes>
+IndexClassification<IndexTypes...> MakeIndexClassification(Operators::expression<ScalarType, IndexTypes...> const& H) {
+    return IndexClassification<IndexTypes...>(H);
 }
 
 } // namespace Pomerol

--- a/include/pomerol/IndexContainer2.hpp
+++ b/include/pomerol/IndexContainer2.hpp
@@ -17,8 +17,7 @@
 namespace Pomerol {
 
 /** A container to store components of a function with 2 indices. */
-template<typename ElementType, typename SourceObject>
-class IndexContainer2 {
+template <typename ElementType, typename SourceObject> class IndexContainer2 {
 protected:
     ParticleIndex NumIndices;
     std::map<IndexCombination2, std::shared_ptr<ElementType>> ElementsMap;
@@ -28,11 +27,9 @@ protected:
     std::set<IndexCombination2> enumerateInitialIndices() const;
 
 public:
-
-    template<typename... IndexTypes>
-    IndexContainer2(SourceObject const& Source, IndexClassification<IndexTypes...> const& IndexInfo) :
-        NumIndices(IndexInfo.getIndexSize()), Source(Source)
-    {}
+    template <typename... IndexTypes>
+    IndexContainer2(SourceObject const& Source, IndexClassification<IndexTypes...> const& IndexInfo)
+        : NumIndices(IndexInfo.getIndexSize()), Source(Source) {}
 
     void fill(std::set<IndexCombination2> InitialIndices = std::set<IndexCombination2>());
     ElementType& set(IndexCombination2 const& Indices);
@@ -47,21 +44,18 @@ public:
 /////////////////////
 // IndexContainer2 //
 /////////////////////
-template<typename ElementType, typename SourceObject>
-bool IndexContainer2<ElementType,SourceObject>::isInContainer(IndexCombination2 const& Indices) const
-{
+template <typename ElementType, typename SourceObject>
+bool IndexContainer2<ElementType, SourceObject>::isInContainer(IndexCombination2 const& Indices) const {
     return ElementsMap.count(Indices) > 0;
 }
 
-template<typename ElementType, typename SourceObject>
-bool IndexContainer2<ElementType,SourceObject>::isInContainer(ParticleIndex Index1, ParticleIndex Index2) const
-{
+template <typename ElementType, typename SourceObject>
+bool IndexContainer2<ElementType, SourceObject>::isInContainer(ParticleIndex Index1, ParticleIndex Index2) const {
     return isInContainer(IndexCombination2(Index1, Index2));
 }
 
-template<typename ElementType, typename SourceObject>
-void IndexContainer2<ElementType,SourceObject>::fill(std::set<IndexCombination2> InitialIndices)
-{
+template <typename ElementType, typename SourceObject>
+void IndexContainer2<ElementType, SourceObject>::fill(std::set<IndexCombination2> InitialIndices) {
     // TODO: this method should use symmetry information
     // InitialIndices should be split into equivalence classes with
     // the equivalence relation provided by a symmetry analyzer
@@ -70,9 +64,7 @@ void IndexContainer2<ElementType,SourceObject>::fill(std::set<IndexCombination2>
     // remove existing elements
     ElementsMap.clear();
 
-    std::set<IndexCombination2> II = InitialIndices.empty() ?
-                                     enumerateInitialIndices() :
-                                     std::move(InitialIndices);
+    std::set<IndexCombination2> II = InitialIndices.empty() ? enumerateInitialIndices() : std::move(InitialIndices);
 
     for(auto const& ic : II) {
         if(!isInContainer(ic)) {
@@ -81,45 +73,39 @@ void IndexContainer2<ElementType,SourceObject>::fill(std::set<IndexCombination2>
     }
 }
 
-template<typename ElementType, typename SourceObject>
-ElementType& IndexContainer2<ElementType,SourceObject>::set(IndexCombination2 const& Indices)
-{
+template <typename ElementType, typename SourceObject>
+ElementType& IndexContainer2<ElementType, SourceObject>::set(IndexCombination2 const& Indices) {
     std::shared_ptr<ElementType> pElement(Source.createElement(Indices));
     ElementsMap[Indices] = pElement;
 
-    DEBUG("IndexContainer2::set() at " << this << ": "
-          "added an element with indices " << Indices << " (" << pElement << ").");
+    DEBUG("IndexContainer2::set() at " << this
+                                       << ": "
+                                          "added an element with indices "
+                                       << Indices << " (" << pElement << ").");
 
     return *pElement;
 }
 
-template<typename ElementType, typename SourceObject>
-ElementType& IndexContainer2<ElementType,SourceObject>::operator()(IndexCombination2 const& Indices)
-{
+template <typename ElementType, typename SourceObject>
+ElementType& IndexContainer2<ElementType, SourceObject>::operator()(IndexCombination2 const& Indices) {
     auto iter = ElementsMap.find(Indices);
 
     if(iter == ElementsMap.end()) {
-        DEBUG("IndexContainer2 at " << this << ": " <<
-              "cache miss for Index1=" << Indices.Index1 <<
-              ", Index2=" << Indices.Index2 <<
-              "; add a new element to the container using source " << &Source
-        );
+        DEBUG("IndexContainer2 at " << this << ": "
+                                    << "cache miss for Index1=" << Indices.Index1 << ", Index2=" << Indices.Index2
+                                    << "; add a new element to the container using source " << &Source);
         return set(Indices);
     }
     return *(iter->second);
 }
 
-template<typename ElementType, typename SourceObject>
-ElementType& IndexContainer2<ElementType, SourceObject>::operator()
-    (ParticleIndex Index1, ParticleIndex Index2)
-{
+template <typename ElementType, typename SourceObject>
+ElementType& IndexContainer2<ElementType, SourceObject>::operator()(ParticleIndex Index1, ParticleIndex Index2) {
     return operator()(IndexCombination2(Index1, Index2));
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-std::set<IndexCombination2> IndexContainer2<ElementType,SourceObject>::enumerateInitialIndices() const
-{
+template <typename ElementType, typename SourceObject>
+inline std::set<IndexCombination2> IndexContainer2<ElementType, SourceObject>::enumerateInitialIndices() const {
     std::set<IndexCombination2> AllIndices;
 
     for(ParticleIndex Index1 = 0; Index1 < NumIndices; ++Index1)

--- a/include/pomerol/IndexContainer4.hpp
+++ b/include/pomerol/IndexContainer4.hpp
@@ -1,4 +1,4 @@
- //
+//
 // This file is a part of pomerol - a scientific ED code for obtaining
 // properties of a Hubbard model on a finite-size lattice
 //
@@ -18,7 +18,6 @@
 // You should have received a copy of the GNU General Public License
 // along with pomerol.  If not, see <http://www.gnu.org/licenses/>.
 
-
 /** \file src/IndexContainer4.h
 **
 ** \author Igor Krivenko (Igor.S.Krivenko@gmail.com)
@@ -37,9 +36,7 @@
 namespace Pomerol {
 
 /** Decorator around an element to intercept operator(n1,n2,n3) calls nd permute Matsubara frequencies. */
-template<typename ElementType>
-struct ElementWithPermFreq
-{
+template <typename ElementType> struct ElementWithPermFreq {
     std::shared_ptr<ElementType> pElement;
     Permutation4 const FrequenciesPermutation;
 
@@ -50,8 +47,7 @@ struct ElementWithPermFreq
 };
 
 /** A container to store components of a function with 4 indices. */
-template<typename ElementType, typename SourceObject>
-class IndexContainer4 {
+template <typename ElementType, typename SourceObject> class IndexContainer4 {
 protected:
     ParticleIndex NumIndices;
 
@@ -60,75 +56,68 @@ protected:
     std::set<IndexCombination4> enumerateInitialIndices() const;
 
 public:
-    std::map<IndexCombination4,ElementWithPermFreq<ElementType>> ElementsMap;
+    std::map<IndexCombination4, ElementWithPermFreq<ElementType>> ElementsMap;
     std::map<IndexCombination4, std::shared_ptr<ElementType>> NonTrivialElements;
 
-    template<typename... IndexTypes>
-    IndexContainer4(SourceObject const& Source, IndexClassification<IndexTypes...> const& IndexInfo) :
-        NumIndices(IndexInfo.getIndexSize()), Source(Source)
-    {}
+    template <typename... IndexTypes>
+    IndexContainer4(SourceObject const& Source, IndexClassification<IndexTypes...> const& IndexInfo)
+        : NumIndices(IndexInfo.getIndexSize()), Source(Source) {}
 
     void fill(std::set<IndexCombination4> InitialIndices = std::set<IndexCombination4>());
     ElementWithPermFreq<ElementType>& set(IndexCombination4 const& Indices);
 
     bool isInContainer(IndexCombination4 const& Indices) const;
-    bool isInContainer( ParticleIndex Index1, ParticleIndex Index2,
-                        ParticleIndex Index3, ParticleIndex Index4) const;
+    bool isInContainer(ParticleIndex Index1, ParticleIndex Index2, ParticleIndex Index3, ParticleIndex Index4) const;
 
     ElementWithPermFreq<ElementType>& operator()(IndexCombination4 const& Indices);
-    ElementWithPermFreq<ElementType>& operator()(ParticleIndex Index1, ParticleIndex Index2,
-                                                 ParticleIndex Index3, ParticleIndex Index4);
+    ElementWithPermFreq<ElementType>&
+    operator()(ParticleIndex Index1, ParticleIndex Index2, ParticleIndex Index3, ParticleIndex Index4);
 };
 
 /////////////////////////
 // ElementWithPermFreq //
 /////////////////////////
-template<typename ElementType> inline
-ElementWithPermFreq<ElementType>::ElementWithPermFreq(
-    std::shared_ptr<ElementType> pElement, Permutation4 const& FrequenciesPermutation) :
-    pElement(pElement), FrequenciesPermutation(FrequenciesPermutation)
-{}
+template <typename ElementType>
+inline ElementWithPermFreq<ElementType>::ElementWithPermFreq(std::shared_ptr<ElementType> pElement,
+                                                             Permutation4 const& FrequenciesPermutation)
+    : pElement(pElement), FrequenciesPermutation(FrequenciesPermutation) {}
 
-template<typename ElementType> inline
-ComplexType ElementWithPermFreq<ElementType>::operator()(
-    long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const
-{
-    long MatsubaraNumbers[4] = {MatsubaraNumber1,MatsubaraNumber2,MatsubaraNumber3,
-                                MatsubaraNumber1+MatsubaraNumber2-MatsubaraNumber3};
+template <typename ElementType>
+inline ComplexType ElementWithPermFreq<ElementType>::operator()(long MatsubaraNumber1,
+                                                                long MatsubaraNumber2,
+                                                                long MatsubaraNumber3) const {
+    long MatsubaraNumbers[4] = {MatsubaraNumber1,
+                                MatsubaraNumber2,
+                                MatsubaraNumber3,
+                                MatsubaraNumber1 + MatsubaraNumber2 - MatsubaraNumber3};
     return (*pElement)(MatsubaraNumbers[FrequenciesPermutation.perm[0]],
                        MatsubaraNumbers[FrequenciesPermutation.perm[1]],
-                       MatsubaraNumbers[FrequenciesPermutation.perm[2]])
-                    *RealType(FrequenciesPermutation.sign);
+                       MatsubaraNumbers[FrequenciesPermutation.perm[2]]) *
+           RealType(FrequenciesPermutation.sign);
 }
 
-template<typename ElementType> inline
-ElementWithPermFreq<ElementType>::operator ElementType&()
-{
+template <typename ElementType> inline ElementWithPermFreq<ElementType>::operator ElementType&() {
     return *pElement;
 }
 
 /////////////////////
 // IndexContainer4 //
 /////////////////////
-template<typename ElementType, typename SourceObject>
-inline
-bool IndexContainer4<ElementType,SourceObject>::isInContainer(IndexCombination4 const& Indices) const
-{
+template <typename ElementType, typename SourceObject>
+inline bool IndexContainer4<ElementType, SourceObject>::isInContainer(IndexCombination4 const& Indices) const {
     return ElementsMap.count(Indices) > 0;
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-bool IndexContainer4<ElementType,SourceObject>::isInContainer(ParticleIndex Index1, ParticleIndex Index2,
-                                                              ParticleIndex Index3, ParticleIndex Index4) const
-{
-    return isInContainer(IndexCombination4(Index1,Index2,Index3,Index4));
+template <typename ElementType, typename SourceObject>
+inline bool IndexContainer4<ElementType, SourceObject>::isInContainer(ParticleIndex Index1,
+                                                                      ParticleIndex Index2,
+                                                                      ParticleIndex Index3,
+                                                                      ParticleIndex Index4) const {
+    return isInContainer(IndexCombination4(Index1, Index2, Index3, Index4));
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-void IndexContainer4<ElementType,SourceObject>::fill(std::set<IndexCombination4> InitialIndices)
-{
+template <typename ElementType, typename SourceObject>
+inline void IndexContainer4<ElementType, SourceObject>::fill(std::set<IndexCombination4> InitialIndices) {
     // TODO: this method should use symmetry information
     // InitialIndices should be split into equivalence classes with
     // the equivalence relation provided by a symmetry analyzer
@@ -137,9 +126,7 @@ void IndexContainer4<ElementType,SourceObject>::fill(std::set<IndexCombination4>
     // remove existing elements
     ElementsMap.clear();
 
-    std::set<IndexCombination4> II = InitialIndices.empty() ?
-                                     enumerateInitialIndices() :
-                                     std::move(InitialIndices);
+    std::set<IndexCombination4> II = InitialIndices.empty() ? enumerateInitialIndices() : std::move(InitialIndices);
 
     for(auto const& ic : II) {
         if(!isInContainer(ic)) {
@@ -148,95 +135,86 @@ void IndexContainer4<ElementType,SourceObject>::fill(std::set<IndexCombination4>
     }
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-ElementWithPermFreq<ElementType>& IndexContainer4<ElementType,SourceObject>::set(IndexCombination4 const& Indices)
-{
+template <typename ElementType, typename SourceObject>
+inline ElementWithPermFreq<ElementType>&
+IndexContainer4<ElementType, SourceObject>::set(IndexCombination4 const& Indices) {
     std::shared_ptr<ElementType> pElement(Source.createElement(Indices));
-    auto iter = ElementsMap.emplace(Indices, ElementWithPermFreq<ElementType>(pElement,permutations4[0])).first;
+    auto iter = ElementsMap.emplace(Indices, ElementWithPermFreq<ElementType>(pElement, permutations4[0])).first;
 
-    DEBUG("IndexContainer4::fill() at " << this << ": " <<
-        "added an element with indices " << Indices <<
-        " and frequency permutation " << permutations4[0] <<
-        " (" << pElement << ").");
+    DEBUG("IndexContainer4::fill() at " << this << ": "
+                                        << "added an element with indices " << Indices << " and frequency permutation "
+                                        << permutations4[0] << " (" << pElement << ").");
 
-    bool SameCIndices = (Indices.Index1==Indices.Index2);
-    bool SameCXIndices = (Indices.Index3==Indices.Index4);
+    bool SameCIndices = (Indices.Index1 == Indices.Index2);
+    bool SameCXIndices = (Indices.Index3 == Indices.Index4);
 
     NonTrivialElements.emplace(Indices, pElement);
 
-    if(!SameCIndices){
-        IndexCombination4 Indices2134(Indices.Index2,Indices.Index1,Indices.Index3,Indices.Index4);
-        if(!isInContainer(Indices2134)){
-            ElementsMap.emplace(Indices2134, ElementWithPermFreq<ElementType>(pElement,permutations4[6]));
-            DEBUG("IndexContainer4::fill() at " << this << ": " <<
-                "added an element with indices " << Indices <<
-                " and frequency permutation " << permutations4[6] <<
-                " (" << pElement << ").");
+    if(!SameCIndices) {
+        IndexCombination4 Indices2134(Indices.Index2, Indices.Index1, Indices.Index3, Indices.Index4);
+        if(!isInContainer(Indices2134)) {
+            ElementsMap.emplace(Indices2134, ElementWithPermFreq<ElementType>(pElement, permutations4[6]));
+            DEBUG("IndexContainer4::fill() at " << this << ": "
+                                                << "added an element with indices " << Indices
+                                                << " and frequency permutation " << permutations4[6] << " (" << pElement
+                                                << ").");
         }
     }
-    if(!SameCXIndices){
-        IndexCombination4 Indices1243(Indices.Index1,Indices.Index2,Indices.Index4,Indices.Index3);
-        if(!isInContainer(Indices1243)){
-            ElementsMap.emplace(Indices1243, ElementWithPermFreq<ElementType>(pElement,permutations4[1]));
-            DEBUG("IndexContainer4::fill() at " << this << ": " <<
-                "added an element with indices " << Indices <<
-                " and frequency permutation " << permutations4[1] <<
-                " (" << pElement << ").");
+    if(!SameCXIndices) {
+        IndexCombination4 Indices1243(Indices.Index1, Indices.Index2, Indices.Index4, Indices.Index3);
+        if(!isInContainer(Indices1243)) {
+            ElementsMap.emplace(Indices1243, ElementWithPermFreq<ElementType>(pElement, permutations4[1]));
+            DEBUG("IndexContainer4::fill() at " << this << ": "
+                                                << "added an element with indices " << Indices
+                                                << " and frequency permutation " << permutations4[1] << " (" << pElement
+                                                << ").");
         }
     }
-    if(!SameCIndices && !SameCXIndices){
-        IndexCombination4 Indices2143(Indices.Index2,Indices.Index1,Indices.Index4,Indices.Index3);
-        if(!isInContainer(Indices2143)){
-            ElementsMap.emplace(Indices2143, ElementWithPermFreq<ElementType>(pElement,permutations4[7]));
-            DEBUG("IndexContainer4::fill() at " << this << ": " <<
-                "added an element with indices " << Indices <<
-                " and frequency permutation " << permutations4[7] <<
-                " (" << pElement << ").");
+    if(!SameCIndices && !SameCXIndices) {
+        IndexCombination4 Indices2143(Indices.Index2, Indices.Index1, Indices.Index4, Indices.Index3);
+        if(!isInContainer(Indices2143)) {
+            ElementsMap.emplace(Indices2143, ElementWithPermFreq<ElementType>(pElement, permutations4[7]));
+            DEBUG("IndexContainer4::fill() at " << this << ": "
+                                                << "added an element with indices " << Indices
+                                                << " and frequency permutation " << permutations4[7] << " (" << pElement
+                                                << ").");
         }
     }
 
     return iter->second;
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-ElementWithPermFreq<ElementType>& IndexContainer4<ElementType,SourceObject>::operator()
-    (IndexCombination4 const& Indices)
-{
+template <typename ElementType, typename SourceObject>
+inline ElementWithPermFreq<ElementType>&
+IndexContainer4<ElementType, SourceObject>::operator()(IndexCombination4 const& Indices) {
     auto iter = ElementsMap.find(Indices);
 
-    if(iter == ElementsMap.end()){
-        DEBUG("IndexContainer4 at " << this << ": " <<
-              "cache miss for Index1=" << Indices.Index1 <<
-              ", Index2=" << Indices.Index2 <<
-              ", Index3=" << Indices.Index3 <<
-              ", Index4=" << Indices.Index4 <<
-              "; add a new element to the container using source " << &Source
-        );
+    if(iter == ElementsMap.end()) {
+        DEBUG("IndexContainer4 at " << this << ": "
+                                    << "cache miss for Index1=" << Indices.Index1 << ", Index2=" << Indices.Index2
+                                    << ", Index3=" << Indices.Index3 << ", Index4=" << Indices.Index4
+                                    << "; add a new element to the container using source " << &Source);
         return set(Indices);
-    }else
+    } else
         return iter->second;
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-ElementWithPermFreq<ElementType>& IndexContainer4<ElementType,SourceObject>::operator()
-    (ParticleIndex Index1, ParticleIndex Index2, ParticleIndex Index3, ParticleIndex Index4)
-{
-    return operator()(IndexCombination4(Index1,Index2,Index3,Index4));
+template <typename ElementType, typename SourceObject>
+inline ElementWithPermFreq<ElementType>& IndexContainer4<ElementType, SourceObject>::operator()(ParticleIndex Index1,
+                                                                                                ParticleIndex Index2,
+                                                                                                ParticleIndex Index3,
+                                                                                                ParticleIndex Index4) {
+    return operator()(IndexCombination4(Index1, Index2, Index3, Index4));
 }
 
-template<typename ElementType, typename SourceObject>
-inline
-std::set<IndexCombination4> IndexContainer4<ElementType,SourceObject>::enumerateInitialIndices() const
-{
+template <typename ElementType, typename SourceObject>
+inline std::set<IndexCombination4> IndexContainer4<ElementType, SourceObject>::enumerateInitialIndices() const {
     std::set<IndexCombination4> AllIndices;
 
-    for(ParticleIndex Index1=0; Index1<NumIndices; ++Index1)
-        for(ParticleIndex Index2=Index1; Index2<NumIndices; ++Index2)
-            for(ParticleIndex Index3=0; Index3<NumIndices; ++Index3)
-                for(ParticleIndex Index4=Index3; Index4<NumIndices; ++Index4)
+    for(ParticleIndex Index1 = 0; Index1 < NumIndices; ++Index1)
+        for(ParticleIndex Index2 = Index1; Index2 < NumIndices; ++Index2)
+            for(ParticleIndex Index3 = 0; Index3 < NumIndices; ++Index3)
+                for(ParticleIndex Index4 = Index3; Index4 < NumIndices; ++Index4)
                     AllIndices.emplace(Index1, Index2, Index3, Index4);
 
     return AllIndices;

--- a/include/pomerol/LatticePresets.hpp
+++ b/include/pomerol/LatticePresets.hpp
@@ -18,32 +18,32 @@ namespace Pomerol {
 /** This is a set of presets of different Terms, most commonly used while writing a Hamiltonian. */
 namespace LatticePresets {
 
-    /** Possible spin projections are \b down and \b up */
-    enum spin : short {undef = -1, down = 0, up = 1};
+/** Possible spin projections are \b down and \b up */
+enum spin : short { undef = -1, down = 0, up = 1 };
 
-    std::ostream & operator<<(std::ostream & os, spin s);
+std::ostream& operator<<(std::ostream& os, spin s);
 
-    using RealExpr = Operators::expression<RealType, std::string, unsigned short, spin>;
-    using ComplexExpr = Operators::expression<ComplexType, std::string, unsigned short, spin>;
+using RealExpr = Operators::expression<RealType, std::string, unsigned short, spin>;
+using ComplexExpr = Operators::expression<ComplexType, std::string, unsigned short, spin>;
 
-    /** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital.
+/** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital.
      * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
      * \param[in] Value \f$\varepsilon\f$ - the energy level.
      * \param[in] orbital \f$\alpha\f$ - affected orbital of the site.
      * \param[in] spin \f$\sigma\f$ - affected spin component.
      */
-    RealExpr Level(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin);
-    ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin);
+RealExpr Level(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin);
+ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin);
 
-    /** Adds a level \f$ \sum\limits_{\alpha, \sigma} \varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$.
+/** Adds a level \f$ \sum\limits_{\alpha, \sigma} \varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$.
      * \param[in] L A pointer to the Lattice to add the terms.
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] Level \f$\varepsilon\f$ - energy level to add.
      */
-    RealExpr Level(std::string const& Label, RealType Value, unsigned short NOrbitals = 1);
-    ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short NOrbitals = 1);
+RealExpr Level(std::string const& Label, RealType Value, unsigned short NOrbitals = 1);
+ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short NOrbitals = 1);
 
-    /** Generates a hopping term \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha'\sigma}, j \neq i \f$ between two sites.
+/** Generates a hopping term \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha'\sigma}, j \neq i \f$ between two sites.
      * \param[in] Label1 \f$i\f$ - the first site which is connected by this term.
      * \param[in] Label2 \f$j\f$ - the second site which is connected by this term.
      * \param[in] Value \f$t\f$ - matrix element of a term.
@@ -51,19 +51,40 @@ namespace LatticePresets {
      * \param[in] orbital \f$\alpha'\f$ - orbital of site \f$j\f$, which is connected by this term.
      * \param[in] spin \f$\sigma\f$ - spins of sites, which are connected by this term.
      */
-    RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    /** A shortcut to hopping Lattice::Term \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma}, j \neq i \f$ */
-    RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital, spin Spin);
-    ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital, spin Spin);
-    /** A shortcut to Hopping \f$ \sum_{\sigma} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
-    RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital1, unsigned short Orbital2);
-    ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2);
-    /** A shortcut to Hopping \f$ \sum_{\sigma\alpha} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
-    RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short NOrbitals = 1);
-    ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short NOrbitals = 1);
+RealExpr Hopping(std::string const& Label1,
+                 std::string const& Label2,
+                 RealType t,
+                 unsigned short Orbital1,
+                 unsigned short Orbital2,
+                 spin Spin1,
+                 spin Spin2);
+ComplexExpr Hopping(std::string const& Label1,
+                    std::string const& Label2,
+                    ComplexType t,
+                    unsigned short Orbital1,
+                    unsigned short Orbital2,
+                    spin Spin1,
+                    spin Spin2);
+/** A shortcut to hopping Lattice::Term \f$ t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma}, j \neq i \f$ */
+RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital, spin Spin);
+ComplexExpr
+Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital, spin Spin);
+/** A shortcut to Hopping \f$ \sum_{\sigma} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
+RealExpr Hopping(std::string const& Label1,
+                 std::string const& Label2,
+                 RealType t,
+                 unsigned short Orbital1,
+                 unsigned short Orbital2);
+ComplexExpr Hopping(std::string const& Label1,
+                    std::string const& Label2,
+                    ComplexType t,
+                    unsigned short Orbital1,
+                    unsigned short Orbital2);
+/** A shortcut to Hopping \f$ \sum_{\sigma\alpha} t c^{\dagger}_{i\alpha\sigma}c_{j\alpha\sigma} \f$ */
+RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short NOrbitals = 1);
+ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short NOrbitals = 1);
 
-    /** Generates a local density-density 4-point term \f$ U n_{i\alpha\sigma}n_{j\alpha'\sigma'} \f$.
+/** Generates a local density-density 4-point term \f$ U n_{i\alpha\sigma}n_{j\alpha'\sigma'} \f$.
      * \param[in] Label1 \f$i\f$ - site affected by this Lattice::Term.
      * \param[in] Label2 \f$j\f$ - site affected by this Lattice::Term.
      * \param[in] Value \f$U\f$ - matrix element of the term.
@@ -72,19 +93,42 @@ namespace LatticePresets {
      * \param[in] spin1 \f$\sigma\f$ - the spin component affected by the first density operator.
      * \param[in] spin2 \f$\sigma'\f$ - the spin component affected by the second density operator.
      */
-    RealExpr NupNdown(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    ComplexExpr NupNdown(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{j\alpha'\downarrow'} \f$ term for \f$i=j\f$. */
-    RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2);
-    /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha'\downarrow'} \f$ term for spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
-    RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2);
-    ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2);
-    /** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha\downarrow'} \f$ term for the same orbital \f$m=m'\f$ and default parameters spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
-    RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin1 = up, spin Spin2 = down);
-    ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin1 = up, spin Spin2 = down);
+RealExpr NupNdown(std::string const& Label1,
+                  std::string const& Label2,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1,
+                  spin Spin2);
+ComplexExpr NupNdown(std::string const& Label1,
+                     std::string const& Label2,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2);
+/** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{j\alpha'\downarrow'} \f$ term for \f$i=j\f$. */
+RealExpr NupNdown(std::string const& Label,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1,
+                  spin Spin2);
+ComplexExpr NupNdown(std::string const& Label,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2);
+/** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha'\downarrow'} \f$ term for spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
+RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2);
+ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2);
+/** A shortcut to Pomerol::Lattice::Term::Presets::NupNdown \f$ U n_{i\alpha\uparrow}n_{i\alpha\downarrow'} \f$ term for the same orbital \f$m=m'\f$ and default parameters spin1 = \f$\uparrow\f$, spin2 = \f$\downarrow\f$. */
+RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin1 = up, spin Spin2 = down);
+ComplexExpr
+NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin1 = up, spin Spin2 = down);
 
-    /** Generates a spinflip \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
+/** Generates a spinflip \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
      * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
      * \param[in] Value \f$J\f$ - matrix element of the term.
      * \param[in] orbital \f$\alpha\f$ - first orbital affected by this term.
@@ -92,10 +136,20 @@ namespace LatticePresets {
      * \param[in] spin1 \f$\sigma\f$ - first affected spin component. By default set to \f$\uparrow\f$.
      * \param[in] spin2 \f$\sigma'\f$ - second affected spin component. By default set to \f$\downarrow\f$.
      */
-    RealExpr Spinflip(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1 = up, spin Spin2 = down);
-    ComplexExpr Spinflip(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1 = up, spin Spin2 = down);
+RealExpr Spinflip(std::string const& Label,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1 = up,
+                  spin Spin2 = down);
+ComplexExpr Spinflip(std::string const& Label,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1 = up,
+                     spin Spin2 = down);
 
-    /** Generates a pair-hopping \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha\sigma'}c_{i\alpha'\sigma}c_{i\alpha'\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
+/** Generates a pair-hopping \f$ J c^\dagger_{i\alpha\sigma}c^\dagger_{i\alpha\sigma'}c_{i\alpha'\sigma}c_{i\alpha'\sigma'}, \alpha \neq \alpha', \sigma \neq \sigma' \f$ term.
      * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
      * \param[in] Value \f$J\f$ - matrix element of the term.
      * \param[in] orbital \f$\alpha\f$ - first orbital affected by this term.
@@ -103,25 +157,37 @@ namespace LatticePresets {
      * \param[in] spin1 \f$\sigma\f$ - first affected spin component. By default set to \f$\uparrow\f$.
      * \param[in] spin2 \f$\sigma'\f$ - second affected spin component. By default set to \f$\downarrow\f$.
      */
-    RealExpr PairHopping(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1 = up, spin Spin2 = down);
-    ComplexExpr PairHopping(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1 = up, spin Spin2 = down);
+RealExpr PairHopping(std::string const& Label,
+                     RealType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1 = up,
+                     spin Spin2 = down);
+ComplexExpr PairHopping(std::string const& Label,
+                        ComplexType Value,
+                        unsigned short Orbital1,
+                        unsigned short Orbital2,
+                        spin Spin1 = up,
+                        spin Spin2 = down);
 
-    RealExpr SplusSminus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital);
-    ComplexExpr SplusSminus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital);
+RealExpr SplusSminus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital);
+ComplexExpr
+SplusSminus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital);
 
-    RealExpr SminusSplus(std::string const& label1, std::string const& Label2, RealType Value, unsigned short Orbital);
-    ComplexExpr SminusSplus(std::string const& label1, std::string const& Label2, ComplexType Value, unsigned short Orbital);
+RealExpr SminusSplus(std::string const& label1, std::string const& Label2, RealType Value, unsigned short Orbital);
+ComplexExpr
+SminusSplus(std::string const& label1, std::string const& Label2, ComplexType Value, unsigned short Orbital);
 
-    /** Adds an interaction with the hamiltonian \f[ \sum\limits_{\alpha, \sigma > \sigma'} Un_{i\alpha\sigma}Un_{i\alpha\sigma'} + \sum\limits_{\alpha,\sigma} \varepsilon n_{i\alpha\sigma} to a specified site. \f]
+/** Adds an interaction with the hamiltonian \f[ \sum\limits_{\alpha, \sigma > \sigma'} Un_{i\alpha\sigma}Un_{i\alpha\sigma'} + \sum\limits_{\alpha,\sigma} \varepsilon n_{i\alpha\sigma} to a specified site. \f]
      * \param[in] L A pointer to the Lattice to add the site.
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] U \f$U\f$ - value of the onsite Coulomb interaction.
      * \param[in] Level \f$\varepsilon\f$ - the local energy level on the site.
      */
-    RealExpr CoulombS(std::string const& Label, RealType U, RealType Level, unsigned short NOrbitals = 1);
-    ComplexExpr CoulombS(std::string const& Label, ComplexType U, ComplexType Level, unsigned short NOrbitals = 1);
+RealExpr CoulombS(std::string const& Label, RealType U, RealType Level, unsigned short NOrbitals = 1);
+ComplexExpr CoulombS(std::string const& Label, ComplexType U, ComplexType Level, unsigned short NOrbitals = 1);
 
-    /** Adds an interaction with the hamiltonian \f[ U \sum_{\alpha, \sigma > \sigma'} n_{i\alpha\sigma}n_{i\alpha\sigma'} + U' \sum_{\alpha\neq\alpha',\sigma > \sigma'} n_{i\alpha\sigma} n_{i\alpha'\sigma'} + \frac{U'-J}{2} \sum_{\alpha\neq\alpha',\sigma} n_{i\alpha\sigma} n_{i\alpha'\sigma} - J \sum_{\alpha\neq\alpha',\sigma > \sigma'} (c^\dagger_{i\alpha \sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'} + c^\dagger_{i\alpha'\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha\sigma}c_{i\alpha\sigma'}) to the specified site. \f]
+/** Adds an interaction with the hamiltonian \f[ U \sum_{\alpha, \sigma > \sigma'} n_{i\alpha\sigma}n_{i\alpha\sigma'} + U' \sum_{\alpha\neq\alpha',\sigma > \sigma'} n_{i\alpha\sigma} n_{i\alpha'\sigma'} + \frac{U'-J}{2} \sum_{\alpha\neq\alpha',\sigma} n_{i\alpha\sigma} n_{i\alpha'\sigma} - J \sum_{\alpha\neq\alpha',\sigma > \sigma'} (c^\dagger_{i\alpha \sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha'\sigma}c_{i\alpha\sigma'} + c^\dagger_{i\alpha'\sigma}c^\dagger_{i\alpha'\sigma'}c_{i\alpha\sigma}c_{i\alpha\sigma'}) to the specified site. \f]
      * \param[in] L A pointer to the Lattice to add the site.
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] U \f$U\f$ - Kanamori \f$U\f$,  value of the onsite Coulomb interaction.
@@ -129,21 +195,28 @@ namespace LatticePresets {
      * \param[in] J \f$J\f$ - Kanamori J, value of the Hund's coupling.
      * \param[in] Level \f$\varepsilon\f$ - the local energy level on the site.
      */
-    RealExpr CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J, RealType Level, unsigned short NOrbitals = 3);
-    ComplexExpr CoulombP(std::string const& Label, ComplexType U, ComplexType U_p, ComplexType J, ComplexType Level, unsigned short NOrbitals = 3);
-    /** A shortcut to Lattice::Presets::addPSite with \f$U'=U-2J\f$, i.e. U_p = U - 2.0* J */
-    RealExpr CoulombP(std::string const& Label, RealType U, RealType J, RealType Level, unsigned short NOrbitals = 3);
-    ComplexExpr CoulombP(std::string const& Label, ComplexType U, ComplexType J, ComplexType Level, unsigned short NOrbitals = 3);
+RealExpr
+CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J, RealType Level, unsigned short NOrbitals = 3);
+ComplexExpr CoulombP(std::string const& Label,
+                     ComplexType U,
+                     ComplexType U_p,
+                     ComplexType J,
+                     ComplexType Level,
+                     unsigned short NOrbitals = 3);
+/** A shortcut to Lattice::Presets::addPSite with \f$U'=U-2J\f$, i.e. U_p = U - 2.0* J */
+RealExpr CoulombP(std::string const& Label, RealType U, RealType J, RealType Level, unsigned short NOrbitals = 3);
+ComplexExpr
+CoulombP(std::string const& Label, ComplexType U, ComplexType J, ComplexType Level, unsigned short NOrbitals = 3);
 
-    /** Adds a magnetic \f$ \sum\limits_\alpha mH \frac{1}{2} (n_{i\alpha\uparrow} - n_{i\alpha\downarrow}) \f$ splitting to a given site. Valid only for 2 spins.
+/** Adds a magnetic \f$ \sum\limits_\alpha mH \frac{1}{2} (n_{i\alpha\uparrow} - n_{i\alpha\downarrow}) \f$ splitting to a given site. Valid only for 2 spins.
      * \param[in] L A pointer to the Lattice to add the terms.
      * \param[in] label \f$i\f$ - label of the site.
      * \param[in] Magnetization \f$mH\f$ - magnetization to add.
      */
-    RealExpr Magnetization(std::string const& Label, RealType Magnetization, unsigned short NOrbitals = 1);
-    ComplexExpr Magnetization(std::string const& Label, ComplexType Magnetization, unsigned short NOrbitals = 1);
+RealExpr Magnetization(std::string const& Label, RealType Magnetization, unsigned short NOrbitals = 1);
+ComplexExpr Magnetization(std::string const& Label, ComplexType Magnetization, unsigned short NOrbitals = 1);
 
-    /** Adds a SzSz \f[ \sum\limits_{\alpha} J \frac{1}{2}(n_{i\alpha\uparrow} - n_{i\alpha\downarrow})\frac{1}{2}(n_{j\alpha\uparrow} - n_{j\alpha\downarrow}) \f]
+/** Adds a SzSz \f[ \sum\limits_{\alpha} J \frac{1}{2}(n_{i\alpha\uparrow} - n_{i\alpha\downarrow})\frac{1}{2}(n_{j\alpha\uparrow} - n_{j\alpha\downarrow}) \f]
      * interaction terms. Valid only for 2 spins
      * \param[in] L A pointer to the Lattice to add the terms.
      * \param[in] Label1 \f$i\f$ - label of the first connected site.
@@ -152,45 +225,49 @@ namespace LatticePresets {
      * \param[in] Orbitals Total amount of orbitals on the site. By default equal to 1.
      * \param[in] Spins Total amount of spin components on the site. By default equal to 2. Works only for 2 spins.
      */
-    RealExpr SzSz(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals = 1);
-    ComplexExpr SzSz(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals = 1);
+RealExpr SzSz(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals = 1);
+ComplexExpr SzSz(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals = 1);
 
-    /** Adds a spin-spin \f[ \sum\limits_{\alpha} J \hat S_{i\alpha} \hat S_{j\alpha} \f]
+/** Adds a spin-spin \f[ \sum\limits_{\alpha} J \hat S_{i\alpha} \hat S_{j\alpha} \f]
      * interaction terms. Valid only for 2 spins
      * \param[in] L A pointer to the Lattice to add the terms.
      * \param[in] Label1 \f$i\f$ - label of the first connected site.
      * \param[in] Label2 \f$j\f$ - label of the second connected site. Site can be choosen the same as the first site.
      * \param[in] ExchJ \f$J\f$ - magnetic exchange constant.
      */
-    RealExpr SS(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals = 1);
-    ComplexExpr SS(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals = 1);
+RealExpr SS(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals = 1);
+ComplexExpr SS(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals = 1);
 
-    //
-    // Bosons
-    //
+//
+// Bosons
+//
 
-    /** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital.
+/** Generates a single energy level term \f$\varepsilon c^{\dagger}_{i\alpha\sigma}c_{i\alpha\sigma} \f$ on a local site for a given spin and orbital.
      * \param[in] Label \f$i\f$ - site affected by this Lattice::Term.
      * \param[in] Value \f$\varepsilon\f$ - the energy level.
      * \param[in] orbital \f$\alpha\f$ - affected orbital of the site.
      * \param[in] spin \f$\sigma\f$ - affected spin component.
      */
-    RealExpr BosonLevel(std::string const& Label, RealType Value, unsigned short ExtraIndex);
-    ComplexExpr BosonLevel(std::string const& Label, ComplexType Value, unsigned short ExtraIndex);
+RealExpr BosonLevel(std::string const& Label, RealType Value, unsigned short ExtraIndex);
+ComplexExpr BosonLevel(std::string const& Label, ComplexType Value, unsigned short ExtraIndex);
 
-    /**
+/**
      * TODO: Bose-Hubbard interaction term
      */
-    RealExpr BosonInteraction(std::string const& Label, RealType Value, unsigned short ExtraIndex);
-    ComplexExpr BosonInteraction(std::string const& Label, ComplexType Value, unsigned short ExtraIndex);
+RealExpr BosonInteraction(std::string const& Label, RealType Value, unsigned short ExtraIndex);
+ComplexExpr BosonInteraction(std::string const& Label, ComplexType Value, unsigned short ExtraIndex);
 
-    /**
+/**
      * TODO: Holstein coupling
      */
-    RealExpr HolsteinInteraction(std::string const& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex);
-    ComplexExpr HolsteinInteraction(std::string const& Label, ComplexType Value, unsigned short Orbital, unsigned short BosonExtraIndex);
+RealExpr
+HolsteinInteraction(std::string const& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex);
+ComplexExpr HolsteinInteraction(std::string const& Label,
+                                ComplexType Value,
+                                unsigned short Orbital,
+                                unsigned short BosonExtraIndex);
 
-} // namespace Pomerol::LatticePresets
+} // namespace LatticePresets
 } // namespace Pomerol
 
 #endif // #ifndef POMEROL_INCLUDE_POMEROL_LATTICEPRESETS_H

--- a/include/pomerol/MatsubaraContainers.hpp
+++ b/include/pomerol/MatsubaraContainers.hpp
@@ -15,15 +15,13 @@
 namespace Pomerol {
 
 // class MatsubaraContainer4
-template<typename SourceObject>
-class MatsubaraContainer4 {
+template <typename SourceObject> class MatsubaraContainer4 {
     SourceObject const& Source;
     long NumberOfMatsubaras = 0;
     std::vector<ComplexMatrixType> Values;
     std::vector<long> FermionicIndexOffset;
 
 public:
-
     explicit MatsubaraContainer4(SourceObject const& Source) : Source(Source) {}
 
     ComplexType operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const;
@@ -34,60 +32,56 @@ public:
     long getNumberOfMatsubaras() const { return NumberOfMatsubaras; }
 };
 
-template<typename SourceObject> inline
-void MatsubaraContainer4<SourceObject>::fill(long NumberOfMatsubaras)
-{
+template <typename SourceObject> inline void MatsubaraContainer4<SourceObject>::fill(long NumberOfMatsubaras) {
     this->NumberOfMatsubaras = NumberOfMatsubaras;
 
-    if(NumberOfMatsubaras == 0){
+    if(NumberOfMatsubaras == 0) {
         Values.clear();
         FermionicIndexOffset.clear();
         return;
-    }else{
-        Values.resize(4*NumberOfMatsubaras-1);
-        FermionicIndexOffset.resize(4*NumberOfMatsubaras-1);
+    } else {
+        Values.resize(4 * NumberOfMatsubaras - 1);
+        FermionicIndexOffset.resize(4 * NumberOfMatsubaras - 1);
     }
 
     // \omega_1 = \nu, \omega_3 = \nu', \omega_1+\omega_2 = \Omega
-    for(long BosonicIndexV=0; BosonicIndexV<=4*NumberOfMatsubaras-2; ++BosonicIndexV){
-        long BosonicIndex = BosonicIndexV - 2*NumberOfMatsubaras;
-        long FermionicMatrixSize = 2*NumberOfMatsubaras - std::abs(BosonicIndex+1);
-        Values[BosonicIndexV].resize(FermionicMatrixSize,FermionicMatrixSize);
-        FermionicIndexOffset[BosonicIndexV] =
-            (BosonicIndex < 0 ? 0 : BosonicIndex+1) -NumberOfMatsubaras;
+    for(long BosonicIndexV = 0; BosonicIndexV <= 4 * NumberOfMatsubaras - 2; ++BosonicIndexV) {
+        long BosonicIndex = BosonicIndexV - 2 * NumberOfMatsubaras;
+        long FermionicMatrixSize = 2 * NumberOfMatsubaras - std::abs(BosonicIndex + 1);
+        Values[BosonicIndexV].resize(FermionicMatrixSize, FermionicMatrixSize);
+        FermionicIndexOffset[BosonicIndexV] = (BosonicIndex < 0 ? 0 : BosonicIndex + 1) - NumberOfMatsubaras;
 
-        for(long NuIndexM=0; NuIndexM<FermionicMatrixSize; ++NuIndexM)
-        for(long NupIndexM=0; NupIndexM<FermionicMatrixSize; ++NupIndexM) {
-            long MatsubaraNumber1 = NuIndexM+FermionicIndexOffset[BosonicIndexV];
-            long MatsubaraNumber2 = BosonicIndex - MatsubaraNumber1;
-            long MatsubaraNumber3 = NupIndexM+FermionicIndexOffset[BosonicIndexV];
-            Values[BosonicIndexV](NuIndexM,NupIndexM) =
-                Source.value(MatsubaraNumber1,MatsubaraNumber2,MatsubaraNumber3);
-        }
+        for(long NuIndexM = 0; NuIndexM < FermionicMatrixSize; ++NuIndexM)
+            for(long NupIndexM = 0; NupIndexM < FermionicMatrixSize; ++NupIndexM) {
+                long MatsubaraNumber1 = NuIndexM + FermionicIndexOffset[BosonicIndexV];
+                long MatsubaraNumber2 = BosonicIndex - MatsubaraNumber1;
+                long MatsubaraNumber3 = NupIndexM + FermionicIndexOffset[BosonicIndexV];
+                Values[BosonicIndexV](NuIndexM, NupIndexM) =
+                    Source.value(MatsubaraNumber1, MatsubaraNumber2, MatsubaraNumber3);
+            }
     }
 }
 
-template<typename SourceObject> inline
-ComplexType MatsubaraContainer4<SourceObject>::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const
-{
-    long BosonicIndexV = MatsubaraNumber2 + MatsubaraNumber1 + 2*NumberOfMatsubaras;
-    if(BosonicIndexV >=0 && BosonicIndexV <= 2*(2*NumberOfMatsubaras-1)){
-        long NuIndexM = MatsubaraNumber1-FermionicIndexOffset[BosonicIndexV];
-        long NupIndexM = MatsubaraNumber3-FermionicIndexOffset[BosonicIndexV];
-        if(NuIndexM >= 0 && NuIndexM < Values[BosonicIndexV].rows() &&
-           NupIndexM >= 0 && NupIndexM < Values[BosonicIndexV].cols())
-            return Values[BosonicIndexV](NuIndexM,NupIndexM);
+template <typename SourceObject>
+inline ComplexType MatsubaraContainer4<SourceObject>::operator()(long MatsubaraNumber1,
+                                                                 long MatsubaraNumber2,
+                                                                 long MatsubaraNumber3) const {
+    long BosonicIndexV = MatsubaraNumber2 + MatsubaraNumber1 + 2 * NumberOfMatsubaras;
+    if(BosonicIndexV >= 0 && BosonicIndexV <= 2 * (2 * NumberOfMatsubaras - 1)) {
+        long NuIndexM = MatsubaraNumber1 - FermionicIndexOffset[BosonicIndexV];
+        long NupIndexM = MatsubaraNumber3 - FermionicIndexOffset[BosonicIndexV];
+        if(NuIndexM >= 0 && NuIndexM < Values[BosonicIndexV].rows() && NupIndexM >= 0 &&
+           NupIndexM < Values[BosonicIndexV].cols())
+            return Values[BosonicIndexV](NuIndexM, NupIndexM);
     }
 
-    DEBUG("MatsubaraContainer4 at " << this << ": " <<
-          "cache miss for n1 = " << MatsubaraNumber1 << ", " <<
-          "n2 = " << MatsubaraNumber2 << ", " <<
-          "n3 = " << MatsubaraNumber3 <<
-          " (NumberOfMatsubaras = " << NumberOfMatsubaras <<
-          "), fetching a raw value from " << &Source
-    );
+    DEBUG("MatsubaraContainer4 at " << this << ": "
+                                    << "cache miss for n1 = " << MatsubaraNumber1 << ", "
+                                    << "n2 = " << MatsubaraNumber2 << ", "
+                                    << "n3 = " << MatsubaraNumber3 << " (NumberOfMatsubaras = " << NumberOfMatsubaras
+                                    << "), fetching a raw value from " << &Source);
 
-    return Source.value(MatsubaraNumber1,MatsubaraNumber2,MatsubaraNumber3);
+    return Source.value(MatsubaraNumber1, MatsubaraNumber2, MatsubaraNumber3);
 }
 
 } // namespace Pomerol

--- a/include/pomerol/Misc.hpp
+++ b/include/pomerol/Misc.hpp
@@ -29,15 +29,15 @@
 
 namespace Pomerol {
 
-#define MSG_PREFIX            __FILE__ << ":" << __LINE__ << ": "
+#define MSG_PREFIX __FILE__ << ":" << __LINE__ << ": "
 #ifndef NDEBUG
-#define DEBUG(MSG)            std::cout << MSG_PREFIX << MSG << std::endl
+#define DEBUG(MSG) std::cout << MSG_PREFIX << MSG << std::endl
 #else
-#define DEBUG(MSG)            NULL;
+#define DEBUG(MSG) NULL;
 #endif
-#define INFO(MSG)             std::cout << MSG << std::endl
-#define INFO_NONEWLINE(MSG)   std::cout << MSG << std::flush
-#define ERROR(MSG)            std::cerr << MSG_PREFIX << MSG << std::endl
+#define INFO(MSG) std::cout << MSG << std::endl
+#define INFO_NONEWLINE(MSG) std::cout << MSG << std::flush
+#define ERROR(MSG) std::cerr << MSG_PREFIX << MSG << std::endl
 
 /** Real floating point type. */
 using RealType = double;
@@ -57,36 +57,34 @@ using QuantumState = libcommute::sv_index_type;
 using ParticleIndex = unsigned int;
 
 /** Dense complex matrix. */
-using ComplexMatrixType = Eigen::Matrix<ComplexType,Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor>;
+using ComplexMatrixType =
+    Eigen::Matrix<ComplexType, Eigen::Dynamic, Eigen::Dynamic, Eigen::AutoAlign | Eigen::RowMajor>;
 
-template<bool Complex>
-using MelemType = typename std::conditional<Complex, ComplexType, RealType>::type;
+template <bool Complex> using MelemType = typename std::conditional<Complex, ComplexType, RealType>::type;
 
-template<typename ScalarType>
+template <typename ScalarType>
 using LOperatorType = libcommute::loperator<ScalarType, libcommute::fermion, libcommute::boson>;
 
-template<bool Complex>
+template <bool Complex>
 using LOperatorTypeRC = libcommute::loperator<MelemType<Complex>, libcommute::fermion, libcommute::boson>;
 
-template<bool Complex>
-using MatrixType = Eigen::Matrix<MelemType<Complex>, Eigen::Dynamic,Eigen::Dynamic,Eigen::AutoAlign|Eigen::RowMajor>;
+template <bool Complex>
+using MatrixType =
+    Eigen::Matrix<MelemType<Complex>, Eigen::Dynamic, Eigen::Dynamic, Eigen::AutoAlign | Eigen::RowMajor>;
 
 /** Dense complex vector. */
-using ComplexVectorType = Eigen::Matrix<ComplexType,Eigen::Dynamic,1,Eigen::AutoAlign>;
+using ComplexVectorType = Eigen::Matrix<ComplexType, Eigen::Dynamic, 1, Eigen::AutoAlign>;
 /** Dense real vector. */
-using RealVectorType = Eigen::Matrix<RealType,Eigen::Dynamic,1,Eigen::AutoAlign>;
+using RealVectorType = Eigen::Matrix<RealType, Eigen::Dynamic, 1, Eigen::AutoAlign>;
 
-template<bool Complex>
-using VectorType = Eigen::Matrix<MelemType<Complex>, Eigen::Dynamic,1,Eigen::AutoAlign>;
+template <bool Complex> using VectorType = Eigen::Matrix<MelemType<Complex>, Eigen::Dynamic, 1, Eigen::AutoAlign>;
 
 /** Sparse complex matrix */
-template<bool Complex>
-using ColMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::ColMajor>;
-template<bool Complex>
-using RowMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::RowMajor>;
+template <bool Complex> using ColMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::ColMajor>;
+template <bool Complex> using RowMajorMatrixType = Eigen::SparseMatrix<MelemType<Complex>, Eigen::RowMajor>;
 
 /** A short name for imaginary unit. */
-static ComplexType const I = ComplexType(0.0,1.0);    // 'static' to prevent linking problems
+static ComplexType const I = ComplexType(0.0, 1.0); // 'static' to prevent linking problems
 
 /** Permutation of 3 elements */
 struct Permutation3 {

--- a/include/pomerol/MonomialOperatorPart.hpp
+++ b/include/pomerol/MonomialOperatorPart.hpp
@@ -32,9 +32,8 @@ class MonomialOperatorPart : public ComputableObject {
     friend class FieldOperatorContainer;
 
 private:
-
     bool MOpComplex;
-    void const * MOp;
+    void const* MOp;
 
     bool Complex;
 
@@ -44,8 +43,8 @@ private:
     HamiltonianPart const& HFrom;
     /** A reference to the HamiltonianPart on the left hand side. */
     HamiltonianPart const& HTo;
-protected:
 
+protected:
     /** Storage of the matrix elements of the operator. Row ordered sparse matrix. */
     std::shared_ptr<void> elementsRowMajor;
     /** Copy of the Storage of the matrix elements of the operator. Column ordered sparse matrix. */
@@ -54,7 +53,6 @@ protected:
     RealType const MatrixElementTolerance = 1e-8;
 
 public:
-
     /** Constructor.
      * \param[in] IndexInfo A const reference to the IndexClassification object.
      * \param[in] S A const reference to the StateClassification object.
@@ -62,15 +60,17 @@ public:
      * \param[in] HTo A const reference to the HamiltonianPart on the left hand side.
      * \param[in] PIndex Index of the field operator.
      */
-    template<typename ScalarType>
+    template <typename ScalarType>
     MonomialOperatorPart(LOperatorType<ScalarType> const& MOp,
                          StatesClassification const& S,
                          HamiltonianPart const& HFrom,
-                         HamiltonianPart const& HTo) :
-      MOpComplex(std::is_same<ScalarType, ComplexType>::value), MOp(&MOp),
-      Complex(MOpComplex || HFrom.isComplex() || HTo.isComplex()),
-      S(S), HFrom(HFrom), HTo(HTo)
-    {}
+                         HamiltonianPart const& HTo)
+        : MOpComplex(std::is_same<ScalarType, ComplexType>::value),
+          MOp(&MOp),
+          Complex(MOpComplex || HFrom.isComplex() || HTo.isComplex()),
+          S(S),
+          HFrom(HFrom),
+          HTo(HTo) {}
 
     /** Compute all the matrix elements. Changes the Status of the object to Computed. */
     void compute();
@@ -80,18 +80,17 @@ public:
     bool isComplex() const { return Complex; }
 
     /** Returns the row ordered sparse matrix of matrix elements. */
-    template<bool C> RowMajorMatrixType<C>& getRowMajorValue();
-    template<bool C> RowMajorMatrixType<C> const& getRowMajorValue() const;
+    template <bool C> RowMajorMatrixType<C>& getRowMajorValue();
+    template <bool C> RowMajorMatrixType<C> const& getRowMajorValue() const;
     /** Returns the column ordered sparse matrix of matrix elements. */
-    template<bool C> ColMajorMatrixType<C>& getColMajorValue();
-    template<bool C> ColMajorMatrixType<C> const& getColMajorValue() const;
+    template <bool C> ColMajorMatrixType<C>& getColMajorValue();
+    template <bool C> ColMajorMatrixType<C> const& getColMajorValue() const;
     /** Returns the right hand side index. */
     BlockNumber getRightIndex() const { return HFrom.getBlockNumber(); }
     /** Returns the left hand side index. */
     BlockNumber getLeftIndex() const { return HTo.getBlockNumber(); }
 
-    friend std::ostream & operator<<(std::ostream & os, MonomialOperatorPart const& part)
-    {
+    friend std::ostream& operator<<(std::ostream& os, MonomialOperatorPart const& part) {
         if(part.isComplex())
             part.streamOutputImpl<true>(os);
         else
@@ -100,9 +99,8 @@ public:
     }
 
 private:
-
-    template<bool C, bool HC> void computeImpl();
-    template<bool C> void streamOutputImpl(std::ostream & os) const;
+    template <bool C, bool HC> void computeImpl();
+    template <bool C> void streamOutputImpl(std::ostream& os) const;
 };
 
 } // namespace Pomerol

--- a/include/pomerol/StatesClassification.hpp
+++ b/include/pomerol/StatesClassification.hpp
@@ -39,16 +39,16 @@ class StatesClassification : public ComputableObject {
     std::vector<BlockNumber> StateBlockIndex;
 
 public:
-
     StatesClassification() = default;
 
     /** Perform a classification of all FockStates */
     // TODO: Optionally accept a list of integrals of motion
     // (Operators::expression<ScalarType, IndexTypes...> objects) and fill lists
     // of quantum numbers.
-    template<typename ScalarType, typename... IndexTypes>
+    template <typename ScalarType, typename... IndexTypes>
     void compute(HilbertSpace<ScalarType, IndexTypes...> const& HS) {
-        if(Status == Computed) return;
+        if(Status == Computed)
+            return;
         auto const& FullHilbertSpace = HS.getFullHilbertSpace();
         auto Dim = FullHilbertSpace.dim();
         if(HS.getStatus() == Computed) { // Multiple blocks revealed by HS
@@ -92,7 +92,6 @@ public:
     InnerQuantumState getInnerState(QuantumState in) const;
 
 private:
-
     void initSingleBlock(unsigned long Dim);
     void initMultipleBlocks(libcommute::space_partition const& partition);
     void checkComputed() const;

--- a/include/pomerol/Susceptibility.hpp
+++ b/include/pomerol/Susceptibility.hpp
@@ -72,15 +72,18 @@ class Susceptibility : public Thermal, public ComputableObject {
     ComplexType ave_A = {}, ave_B = {};
 
 public:
-     /** Constructor.
+    /** Constructor.
      * \param[in] S A reference to a states classification object.
      * \param[in] H A reference to a Hamiltonian.
      * \param[in] A A reference to a quadratic operator.
      * \param[in] B A reference to a quadratic operator.
      * \param[in] DM A reference to a density matrix.
      */
-    Susceptibility(StatesClassification const& S, Hamiltonian const& H,
-                   MonomialOperator const& A, MonomialOperator const& B, DensityMatrix const& DM);
+    Susceptibility(StatesClassification const& S,
+                   Hamiltonian const& H,
+                   MonomialOperator const& A,
+                   MonomialOperator const& B,
+                   DensityMatrix const& DM);
     /** Copy-constructor.
      * \param[in] GF Susceptibility object to be copied.
      */
@@ -106,19 +109,19 @@ public:
      * \param[in] EA_A Predefined EnsembleAverage class for operator A.
      * \param[in] EA_B Predefined EnsembleAverage class for operator B.
      */
-    void subtractDisconnected(EnsembleAverage &EA_A, EnsembleAverage &EA_B);
+    void subtractDisconnected(EnsembleAverage& EA_A, EnsembleAverage& EA_B);
 
-     /** Returns the value of the Green's function calculated at a given frequency.
+    /** Returns the value of the Green's function calculated at a given frequency.
      * \param[in] MatsubaraNum Number of the Matsubara frequency (\f$ \omega_n = \pi(2n+1)/\beta \f$).
      */
     ComplexType operator()(long MatsubaraNumber) const;
 
-     /** Returns the value of the Green's function calculated at a given frequency.
+    /** Returns the value of the Green's function calculated at a given frequency.
      * \param[in] z Input frequency
      */
     ComplexType operator()(ComplexType z) const;
 
-     /** Returns the value of the Green's function calculated at a given imaginary time point.
+    /** Returns the value of the Green's function calculated at a given imaginary time point.
      * \param[in] tau Imaginary time point.
      */
     ComplexType of_tau(RealType tau) const;
@@ -128,26 +131,29 @@ public:
 
 // BOSON: bosononic Matsubara frequency
 inline ComplexType Susceptibility::operator()(long int MatsubaraNumber) const {
-    return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber)); }
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber));
+}
 
 inline ComplexType Susceptibility::operator()(ComplexType z) const {
     ComplexType Value = 0;
     if(!Vanishing) {
-        Value = std::accumulate(parts.begin(), parts.end(), ComplexType(0),
-            [z](ComplexType s, SusceptibilityPart const& p) { return s + p(z); }
-        );
+        Value = std::accumulate(parts.begin(),
+                                parts.end(),
+                                ComplexType(0),
+                                [z](ComplexType s, SusceptibilityPart const& p) { return s + p(z); });
     }
     if(SubtractDisconnected && std::abs(z) < 1e-15)
-            Value -= ave_A * ave_B * beta;  // only for n=0
+        Value -= ave_A * ave_B * beta; // only for n=0
     return Value;
 }
 
 inline ComplexType Susceptibility::of_tau(RealType tau) const {
     ComplexType Value = 0;
     if(!Vanishing) {
-        Value = std::accumulate(parts.begin(), parts.end(), ComplexType(0),
-            [tau](ComplexType s, SusceptibilityPart const& p) { return s + p.of_tau(tau); }
-        );
+        Value = std::accumulate(parts.begin(),
+                                parts.end(),
+                                ComplexType(0),
+                                [tau](ComplexType s, SusceptibilityPart const& p) { return s + p.of_tau(tau); });
     }
     if(SubtractDisconnected)
         Value -= ave_A * ave_B;

--- a/include/pomerol/SusceptibilityPart.hpp
+++ b/include/pomerol/SusceptibilityPart.hpp
@@ -27,8 +27,7 @@ namespace Pomerol {
  * Every part describes all transitions allowed by selection rules
  * between a given pair of Hamiltonian blocks.
  */
-class SusceptibilityPart : public Thermal
-{
+class SusceptibilityPart : public Thermal {
     /** A reference to a part of a Hamiltonian (inner index iterates through it). */
     HamiltonianPart const& HpartInner;
     /** A reference to a part of a Hamiltonian (outer index iterates through it). */
@@ -54,9 +53,7 @@ class SusceptibilityPart : public Thermal
         struct Compare {
             double const Tolerance;
             Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
-            bool operator()(Term const& t1, Term const& t2) const {
-                return t2.Pole - t1.Pole >= Tolerance;
-            }
+            bool operator()(Term const& t1, Term const& t2) const { return t2.Pole - t1.Pole >= Tolerance; }
         };
 
         /** Does term have a negligible residue? */
@@ -66,9 +63,7 @@ class SusceptibilityPart : public Thermal
             bool operator()(Term const& t, std::size_t ToleranceDivisor) const {
                 return std::abs(t.Residue) < Tolerance / ToleranceDivisor;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         /** Constructor.
@@ -97,8 +92,7 @@ class SusceptibilityPart : public Thermal
      * \param[in] out An output stream to insert to.
      * \param[in] Term A term to be inserted.
      */
-    friend std::ostream& operator<<(std::ostream& os, Term const& T)
-    {
+    friend std::ostream& operator<<(std::ostream& os, Term const& T) {
         return os << T.Residue << "/(z - " << T.Pole << ")";
     }
 
@@ -112,7 +106,6 @@ class SusceptibilityPart : public Thermal
     ComplexType ZeroPoleWeight = 0;
 
 public:
-
     /** Constructor.
      * \param[in] A A reference to a part of a quadratic operator.
      * \param[in] B A reference to a part of a quadratic operator.
@@ -121,9 +114,12 @@ public:
      * \param[in] DMpartInner A reference to a part of the density matrix (inner index).
      * \param[in] DMpartOuter A reference to a part of the density matrix (outer index).
      */
-    SusceptibilityPart(MonomialOperatorPart const& A, MonomialOperatorPart const& B,
-                       HamiltonianPart const& HpartInner, HamiltonianPart const& HpartOuter,
-                       DensityMatrixPart const& DMpartInner, DensityMatrixPart const& DMpartOuter);
+    SusceptibilityPart(MonomialOperatorPart const& A,
+                       MonomialOperatorPart const& B,
+                       HamiltonianPart const& HpartInner,
+                       HamiltonianPart const& HpartOuter,
+                       DensityMatrixPart const& DMpartInner,
+                       DensityMatrixPart const& DMpartOuter);
 
     /** Iterates over all matrix elements and fills the list of terms. */
     void compute();
@@ -148,18 +144,18 @@ public:
     RealType const ReduceTolerance = 1e-8;
 
 private:
-
-    template<bool AComplex, bool BComplex> void computeImpl();
+    template <bool AComplex, bool BComplex> void computeImpl();
 };
 
 // Inline call operators
 // BOSON: bosononic Matsubara frequency
 inline ComplexType SusceptibilityPart::operator()(long MatsubaraNumber) const {
-    return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber)); }
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber));
+}
 
 inline ComplexType SusceptibilityPart::operator()(ComplexType z) const {
     // BOSON: add contribution of zero-energy pole
-    ComplexType ZeroPole = std::abs(z) < 1e-15 ? ZeroPoleWeight*beta : 0;
+    ComplexType ZeroPole = std::abs(z) < 1e-15 ? ZeroPoleWeight * beta : 0;
     return Terms(z) + ZeroPole;
 }
 

--- a/include/pomerol/TermList.hpp
+++ b/include/pomerol/TermList.hpp
@@ -25,7 +25,7 @@ namespace Pomerol {
  * A term T is considered negligible and is automatically removed from the
  * container if TermType::IsNegligible(T, current_number_of_terms + 1) evaluates to true.
  */
-template<typename TermType> class TermList {
+template <typename TermType> class TermList {
     /** Comparison function */
     using Compare = typename TermType::Compare;
     /** Predicate for determining negligible terms */
@@ -35,13 +35,11 @@ template<typename TermType> class TermList {
     IsNegligible is_negligible;
 
 public:
-
     /** Constructor.
      * \param[in] compare Compare predicate for the underlying std::set object
      * \param[in] is_negligible Predicate that determines whether a term can be neglected
      */
-    TermList(Compare const& compare, IsNegligible const& is_negligible) :
-        data(compare), is_negligible(is_negligible) {}
+    TermList(Compare const& compare, IsNegligible const& is_negligible) : data(compare), is_negligible(is_negligible) {}
 
     /** Add a new term to the container
      * \param[in] term Term to be added
@@ -50,7 +48,7 @@ public:
         auto it = data.find(term);
         if(it == data.end()) { // new term
             data.emplace(term);
-        } else {               // similar term
+        } else { // similar term
             TermType sum = *it;
             sum += term;
             data.erase(*it);
@@ -74,8 +72,7 @@ public:
     /** Pass arguments to operator() of each term in the container
      *  and return a sum of their return values.
      */
-    template<typename... Args>
-    ComplexType operator()(Args&&... args) const {
+    template <typename... Args> ComplexType operator()(Args&&... args) const {
         ComplexType res = 0;
         for(auto const& t : data)
             res += t(std::forward<Args>(args)...);
@@ -104,10 +101,13 @@ public:
 
     /** Check that all terms in the container are properly ordered and are not negligible */
     bool check_terms() const {
-        if(size() == 0) return true;
+        if(size() == 0)
+            return true;
         auto prev_it = data.begin();
-        if(is_negligible(*prev_it, data.size() + 1)) return false;
-        if(size() == 1) return true;
+        if(is_negligible(*prev_it, data.size() + 1))
+            return false;
+        if(size() == 1)
+            return true;
 
         Compare const& compare = data.key_comp();
 

--- a/include/pomerol/TwoParticleGF.hpp
+++ b/include/pomerol/TwoParticleGF.hpp
@@ -45,7 +45,7 @@ using FreqVec = std::vector<FreqTuple>;
  */
 class TwoParticleGF : public Thermal, public ComputableObject {
 
-friend class TwoParticleGFContainer;
+    friend class TwoParticleGFContainer;
 
     /** A reference to a states classification object. */
     StatesClassification const& S;
@@ -66,7 +66,6 @@ friend class TwoParticleGFContainer;
     std::vector<TwoParticleGFPart> parts;
 
 protected:
-
     /** A flag to determine whether this GF is identical to zero */
     bool Vanishing = true;
 
@@ -75,7 +74,8 @@ protected:
      * \param[in] OperatorPosition The number of the position of the operator.
      * \param[in] LeftIndex A left block index referring to the part needed.
      */
-    MonomialOperatorPart const& OperatorPartAtPosition(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const;
+    MonomialOperatorPart const&
+    OperatorPartAtPosition(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const;
     /** Chooses an operator standing at a specified position in a given permutation and
      * returns a left block index corresponding to the right block index. May return INVALID_BLOCK_NUMBER if
      * the operator does not have such a (non-zero) block.
@@ -91,7 +91,8 @@ protected:
      * \param[in] OperatorPosition The number of the position of the operator.
      * \param[in] LeftIndex A left block index.
      */
-    BlockNumber getRightIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const; //!< return right index of an operator at current position for a current permutation
+    BlockNumber getRightIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex)
+        const; //!< return right index of an operator at current position for a current permutation
 
 public:
     /** A difference in energies with magnitude less than this value is treated as zero. default = 1e-8. */
@@ -110,10 +111,13 @@ public:
      * \param[in] CX4 A reference to the second creation operator.
      * \param[in] DM A reference to a density matrix.
      */
-    TwoParticleGF(StatesClassification const& S, Hamiltonian const& H,
-            AnnihilationOperator const& C1, AnnihilationOperator const& C2,
-            CreationOperator const& CX3, CreationOperator const& CX4,
-            DensityMatrix const& DM);
+    TwoParticleGF(StatesClassification const& S,
+                  Hamiltonian const& H,
+                  AnnihilationOperator const& C1,
+                  AnnihilationOperator const& C2,
+                  CreationOperator const& CX3,
+                  CreationOperator const& CX4,
+                  DensityMatrix const& DM);
 
     /** Chooses relevant parts of C1, C2, CX3 and CX4 and allocates resources for the parts. */
     void prepare();
@@ -121,11 +125,8 @@ public:
     /** Actually computes the parts and fill the internal cache of precomputed values.
      * \param[in] NumberOfMatsubaras Number of positive Matsubara frequencies.
      */
-    std::vector<ComplexType> compute(
-        bool clear = false,
-        FreqVec const& freqs = {},
-        MPI_Comm const& comm = MPI_COMM_WORLD
-    );
+    std::vector<ComplexType>
+    compute(bool clear = false, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
 
     /** Returns the 'bit' (index) of one of operators C1, C2, CX3 or CX4.
      * \param[in] Position Zero-based number of the operator to use.
@@ -153,18 +154,21 @@ public:
 };
 
 inline ComplexType TwoParticleGF::operator()(ComplexType z1, ComplexType z2, ComplexType z3) const {
-    if(Vanishing) return 0;
+    if(Vanishing)
+        return 0;
     else {
-        return std::accumulate(parts.begin(), parts.end(), ComplexType(0),
-            [z1,z2,z3](ComplexType s, TwoParticleGFPart const& p) { return s + p(z1,z2,z3); }
-        );
+        return std::accumulate(parts.begin(),
+                               parts.end(),
+                               ComplexType(0),
+                               [z1, z2, z3](ComplexType s, TwoParticleGFPart const& p) { return s + p(z1, z2, z3); });
     }
 }
 
-inline ComplexType TwoParticleGF::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const {
-    return (*this)(MatsubaraSpacing*RealType(2*MatsubaraNumber1+1),
-                   MatsubaraSpacing*RealType(2*MatsubaraNumber2+1),
-                   MatsubaraSpacing*RealType(2*MatsubaraNumber3+1));
+inline ComplexType
+TwoParticleGF::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const {
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber1 + 1),
+                   MatsubaraSpacing * RealType(2 * MatsubaraNumber2 + 1),
+                   MatsubaraSpacing * RealType(2 * MatsubaraNumber3 + 1));
 }
 
 } // namespace Pomerol

--- a/include/pomerol/TwoParticleGFContainer.hpp
+++ b/include/pomerol/TwoParticleGFContainer.hpp
@@ -40,8 +40,7 @@
 
 namespace Pomerol {
 
-class TwoParticleGFContainer: public IndexContainer4<TwoParticleGF,TwoParticleGFContainer>, public Thermal
-{
+class TwoParticleGFContainer : public IndexContainer4<TwoParticleGF, TwoParticleGFContainer>, public Thermal {
 public:
     /** A difference in energies with magnitude less than this value is treated as zero. default = 1e-8. */
     RealType ReduceResonanceTolerance = 1e-8;
@@ -50,37 +49,31 @@ public:
     /** Minimal magnitude of the coefficient of a term to take it into account with respect to amount of terms. default = 1e-5. */
     RealType MultiTermCoefficientTolerance = 1e-5;
 
-    template<typename... IndexTypes>
+    template <typename... IndexTypes>
     TwoParticleGFContainer(IndexClassification<IndexTypes...> const& IndexInfo,
                            StatesClassification const& S,
                            Hamiltonian const& H,
                            DensityMatrix const& DM,
-                           FieldOperatorContainer const& Operators) :
-        IndexContainer4<TwoParticleGF, TwoParticleGFContainer>(*this, IndexInfo), Thermal(DM),
-        S(S), H(H), DM(DM), Operators(Operators)
-    {}
+                           FieldOperatorContainer const& Operators)
+        : IndexContainer4<TwoParticleGF, TwoParticleGFContainer>(*this, IndexInfo),
+          Thermal(DM),
+          S(S),
+          H(H),
+          DM(DM),
+          Operators(Operators) {}
 
     void prepareAll(std::set<IndexCombination4> const& InitialIndices = {});
-    std::map<IndexCombination4,std::vector<ComplexType>> computeAll(
-        bool clearTerms = false,
-        FreqVec const& freqs = {},
-        MPI_Comm const& comm = MPI_COMM_WORLD,
-        bool split = true
-    );
-    std::map<IndexCombination4,std::vector<ComplexType>> computeAll_nosplit(
-        bool clearTerms,
-        FreqVec const& freqs = {},
-        MPI_Comm const& comm = MPI_COMM_WORLD
-    );
-    std::map<IndexCombination4,std::vector<ComplexType>> computeAll_split(
-        bool clearTerms,
-        FreqVec const& freqs = {},
-        MPI_Comm const& comm = MPI_COMM_WORLD
-    );
+    std::map<IndexCombination4, std::vector<ComplexType>> computeAll(bool clearTerms = false,
+                                                                     FreqVec const& freqs = {},
+                                                                     MPI_Comm const& comm = MPI_COMM_WORLD,
+                                                                     bool split = true);
+    std::map<IndexCombination4, std::vector<ComplexType>>
+    computeAll_nosplit(bool clearTerms, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+    std::map<IndexCombination4, std::vector<ComplexType>>
+    computeAll_split(bool clearTerms, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
 
 protected:
-
-    friend class IndexContainer4<TwoParticleGF,TwoParticleGFContainer>;
+    friend class IndexContainer4<TwoParticleGF, TwoParticleGFContainer>;
     std::shared_ptr<TwoParticleGF> createElement(IndexCombination4 const& Indices) const;
 
     StatesClassification const& S;

--- a/include/pomerol/TwoParticleGFPart.hpp
+++ b/include/pomerol/TwoParticleGFPart.hpp
@@ -29,11 +29,10 @@ namespace Pomerol {
  */
 class TwoParticleGFPart : public Thermal, ComputableObject {
 
-friend class TwoParticleGF;
-friend class TwoParticleGFContainer;
+    friend class TwoParticleGF;
+    friend class TwoParticleGFContainer;
 
 public:
-
     /** A non-resonant term has the following form:
      * \f[
      * \frac{C}{(z_1-P_1)(z_2-P_2)(z_3-P_3)}
@@ -61,21 +60,17 @@ public:
         struct Compare {
             double Tolerance;
             Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
-            bool real_eq(RealType x1, RealType x2) const {
-                return std::abs(x1 - x2) < Tolerance;
-            }
+            bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             bool operator()(NonResonantTerm const& t1, NonResonantTerm const& t2) const {
-                if (t1.isz4 == t2.isz4) {
-                    return !real_eq(t1.Poles[0], t2.Poles[0]) ? t1.Poles[0] < t2.Poles[0] : (
-                           !real_eq(t1.Poles[1], t2.Poles[1]) ? t1.Poles[1] < t2.Poles[1] : (
-                            t2.Poles[2] - t1.Poles[2] >= Tolerance
-                           ));
+                if(t1.isz4 == t2.isz4) {
+                    return !real_eq(t1.Poles[0], t2.Poles[0]) ?
+                               t1.Poles[0] < t2.Poles[0] :
+                               (!real_eq(t1.Poles[1], t2.Poles[1]) ? t1.Poles[1] < t2.Poles[1] :
+                                                                     (t2.Poles[2] - t1.Poles[2] >= Tolerance));
                 } else
                     return t1.isz4 < t2.isz4;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         /** Does term have a negligible residue? */
@@ -85,9 +80,7 @@ public:
             bool operator()(NonResonantTerm const& t, std::size_t ToleranceDivisor) const {
                 return std::abs(t.Coeff) < Tolerance / ToleranceDivisor;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         NonResonantTerm() = default;
@@ -99,10 +92,12 @@ public:
         * \param[in] P3 Pole P3.
         * \param[in] isz4 Are we using \f$ z_4 \f$ instead of \f$ z_2 \f$ in this term?
         */
-        inline NonResonantTerm(ComplexType Coeff, RealType P1, RealType P2, RealType P3, bool isz4) :
-            Coeff(Coeff), isz4(isz4)
-        {
-            Poles[0] = P1; Poles[1] = P2; Poles[2] = P3; Weight = 1;
+        inline NonResonantTerm(ComplexType Coeff, RealType P1, RealType P2, RealType P3, bool isz4)
+            : Coeff(Coeff), isz4(isz4) {
+            Poles[0] = P1;
+            Poles[1] = P2;
+            Poles[2] = P3;
+            Weight = 1;
         }
 
         /** Returns a contribution to the two-particle Green's function made by this term.
@@ -150,21 +145,17 @@ public:
         struct Compare {
             double Tolerance;
             Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
-            bool real_eq(RealType x1, RealType x2) const {
-                return std::abs(x1 - x2) < Tolerance;
-            }
+            bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             bool operator()(ResonantTerm const& t1, ResonantTerm const& t2) const {
-                if (t1.isz1z2 == t2.isz1z2) {
-                    return !real_eq(t1.Poles[0], t2.Poles[0]) ? t1.Poles[0] < t2.Poles[0] : (
-                           !real_eq(t1.Poles[1], t2.Poles[1]) ? t1.Poles[1] < t2.Poles[1] : (
-                            t2.Poles[2] - t1.Poles[2] >= Tolerance
-                           ));
+                if(t1.isz1z2 == t2.isz1z2) {
+                    return !real_eq(t1.Poles[0], t2.Poles[0]) ?
+                               t1.Poles[0] < t2.Poles[0] :
+                               (!real_eq(t1.Poles[1], t2.Poles[1]) ? t1.Poles[1] < t2.Poles[1] :
+                                                                     (t2.Poles[2] - t1.Poles[2] >= Tolerance));
                 } else
                     return t1.isz1z2 < t2.isz1z2;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         /** Does term have a negligible residue? */
@@ -175,9 +166,7 @@ public:
                 return std::abs(t.ResCoeff) < Tolerance / ToleranceDivisor &&
                        std::abs(t.NonResCoeff) < Tolerance / ToleranceDivisor;
             }
-            void broadcast(MPI_Comm const& comm, int root) {
-                MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm);
-            }
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
         };
 
         ResonantTerm() = default;
@@ -190,10 +179,17 @@ public:
         * \param[in] P3 Pole P3.
         * \param[in] isz1z2 Are we using \f$ \delta(z_1+z_2-P_1-P_2) \f$ resonance condition?
         */
-        inline ResonantTerm(ComplexType ResCoeff, ComplexType NonResCoeff, RealType P1, RealType P2, RealType P3, bool isz1z2):
-            ResCoeff(ResCoeff), NonResCoeff(NonResCoeff), isz1z2(isz1z2)
-        {
-            Poles[0] = P1; Poles[1] = P2; Poles[2] = P3; Weight=1;
+        inline ResonantTerm(ComplexType ResCoeff,
+                            ComplexType NonResCoeff,
+                            RealType P1,
+                            RealType P2,
+                            RealType P3,
+                            bool isz1z2)
+            : ResCoeff(ResCoeff), NonResCoeff(NonResCoeff), isz1z2(isz1z2) {
+            Poles[0] = P1;
+            Poles[1] = P2;
+            Poles[2] = P3;
+            Weight = 1;
         }
 
         /** Returns a contribution to the two-particle Green's function made by this term.
@@ -201,7 +197,8 @@ public:
         * \param[in] z2 Complex frequency \f$ z_2 \f$.
         * \param[in] z3 Complex frequency \f$ z_3 \f$.
         */
-        ComplexType operator()(ComplexType z1, ComplexType z2, ComplexType z3, RealType KroneckerSymbolTolerance = 1e-16) const;
+        ComplexType
+        operator()(ComplexType z1, ComplexType z2, ComplexType z3, RealType KroneckerSymbolTolerance = 1e-16) const;
 
         /** This operator add a non-resonant term to this one.
         * It does not check the similarity of the terms!
@@ -214,7 +211,6 @@ public:
     };
 
 private:
-
     /** A reference to a part of the first operator. */
     MonomialOperatorPart const& O1;
     /** A reference to a part of the second operator. */
@@ -292,9 +288,16 @@ private:
     * \param[in] Wl The fourth weight \f$ w_l \f$.
     * \param[in] Permutation A reference to a permutation of operators for this part.
     */
-    void addMultiterm(ComplexType Coeff, RealType beta,
-                      RealType Ei, RealType Ej, RealType Ek, RealType El,
-                      RealType Wi, RealType Wj, RealType Wk, RealType Wl);
+    void addMultiterm(ComplexType Coeff,
+                      RealType beta,
+                      RealType Ei,
+                      RealType Ej,
+                      RealType Ek,
+                      RealType El,
+                      RealType Wi,
+                      RealType Wj,
+                      RealType Wk,
+                      RealType Wl);
 
     /** A difference in energies with magnitude less than this value is treated as zero. default = 1e-8. */
     RealType ReduceResonanceTolerance = 1e-8;
@@ -303,7 +306,7 @@ private:
     /** Minimal magnitude of the coefficient of a term to take it into account with respect to amount of terms. default = 1e-5. */
     RealType MultiTermCoefficientTolerance = 1e-5;
 
-    template<bool Complex> void computeImpl();
+    template <bool Complex> void computeImpl();
 
 public:
     /** Constructor.
@@ -321,12 +324,18 @@ public:
      * \param[in] DMpart4 A reference to the fourth part of a density matrix.
      * \param[in] Permutation A permutation of the operators for this part.
      */
-    TwoParticleGFPart(MonomialOperatorPart const& O1, MonomialOperatorPart const& O2,
-                      MonomialOperatorPart const& O3, MonomialOperatorPart const& CX4,
-                      HamiltonianPart const& Hpart1, HamiltonianPart const& Hpart2,
-                      HamiltonianPart const& Hpart3, HamiltonianPart const& Hpart4,
-                      DensityMatrixPart const& DMpart1, DensityMatrixPart const& DMpart2,
-                      DensityMatrixPart const& DMpart3, DensityMatrixPart const& DMpart4,
+    TwoParticleGFPart(MonomialOperatorPart const& O1,
+                      MonomialOperatorPart const& O2,
+                      MonomialOperatorPart const& O3,
+                      MonomialOperatorPart const& CX4,
+                      HamiltonianPart const& Hpart1,
+                      HamiltonianPart const& Hpart2,
+                      HamiltonianPart const& Hpart3,
+                      HamiltonianPart const& Hpart4,
+                      DensityMatrixPart const& DMpart1,
+                      DensityMatrixPart const& DMpart2,
+                      DensityMatrixPart const& DMpart3,
+                      DensityMatrixPart const& DMpart4,
                       Permutation3 Permutation);
 
     /** Actually computes the part. */
@@ -362,25 +371,25 @@ public:
     TermList<TwoParticleGFPart::NonResonantTerm> const& getNonResonantTerms() const { return NonResonantTerms; }
 };
 
-inline
-ComplexType TwoParticleGFPart::NonResonantTerm::operator()(ComplexType z1, ComplexType z2, ComplexType z3) const
-{
-    return isz4 ? Coeff / ((z1-Poles[0])*(z1+z2+z3-Poles[0]-Poles[1]-Poles[2])*(z3-Poles[2])) :
-                  Coeff / ((z1-Poles[0])*(z2-Poles[1])*(z3-Poles[2]));
+inline ComplexType
+TwoParticleGFPart::NonResonantTerm::operator()(ComplexType z1, ComplexType z2, ComplexType z3) const {
+    return isz4 ? Coeff / ((z1 - Poles[0]) * (z1 + z2 + z3 - Poles[0] - Poles[1] - Poles[2]) * (z3 - Poles[2])) :
+                  Coeff / ((z1 - Poles[0]) * (z2 - Poles[1]) * (z3 - Poles[2]));
 }
 
-inline
-ComplexType TwoParticleGFPart::ResonantTerm::operator()(ComplexType z1, ComplexType z2, ComplexType z3, RealType KroneckerSymbolTolerance) const
-{
+inline ComplexType TwoParticleGFPart::ResonantTerm::operator()(ComplexType z1,
+                                                               ComplexType z2,
+                                                               ComplexType z3,
+                                                               RealType KroneckerSymbolTolerance) const {
     ComplexType Diff;
     if(isz1z2) {
         Diff = z1 + z2 - Poles[0] - Poles[1];
-        return (std::abs(Diff) < KroneckerSymbolTolerance ? ResCoeff : (NonResCoeff/Diff) )
-                /((z1-Poles[0])*(z3-Poles[2]));
+        return (std::abs(Diff) < KroneckerSymbolTolerance ? ResCoeff : (NonResCoeff / Diff)) /
+               ((z1 - Poles[0]) * (z3 - Poles[2]));
     } else {
         Diff = z2 + z3 - Poles[1] - Poles[2];
-        return (std::abs(Diff) < KroneckerSymbolTolerance ? ResCoeff : (NonResCoeff/Diff) )
-                /((z1-Poles[0])*(z3-Poles[2]));
+        return (std::abs(Diff) < KroneckerSymbolTolerance ? ResCoeff : (NonResCoeff / Diff)) /
+               ((z1 - Poles[0]) * (z3 - Poles[2]));
     }
 }
 

--- a/include/pomerol/Vertex4.hpp
+++ b/include/pomerol/Vertex4.hpp
@@ -8,9 +8,9 @@
 #define POMEROL_INCLUDE_VERTEX4_H
 
 #include "ComputableObject.hpp"
+#include "GreensFunction.hpp"
 #include "MatsubaraContainers.hpp"
 #include "Misc.hpp"
-#include "GreensFunction.hpp"
 #include "Thermal.hpp"
 #include "TwoParticleGF.hpp"
 
@@ -28,12 +28,12 @@ class Vertex4 : public Thermal, public ComputableObject {
     mutable MatsubaraContainer4<Vertex4> Storage;
     friend class MatsubaraContainer4<Vertex4>;
 
-
 public:
-
     Vertex4(TwoParticleGF const& Chi4,
-            GreensFunction const& G13, GreensFunction const& G24,
-            GreensFunction const& G14, GreensFunction const& G23);
+            GreensFunction const& G13,
+            GreensFunction const& G24,
+            GreensFunction const& G14,
+            GreensFunction const& G23);
 
     void compute(long NumberOfMatsubaras = 0);
 

--- a/prog/anderson_model.hpp
+++ b/prog/anderson_model.hpp
@@ -21,74 +21,73 @@ using namespace Pomerol;
  *
  * @author iskakoff
  */
-class anderson_model: public quantum_model {
+class anderson_model : public quantum_model {
 
 public:
-
-  anderson_model(int argc, char* argv[]) :
-    quantum_model(argc, argv, "Full-ED of the Anderson model"),
+    anderson_model(int argc, char* argv[])
+        : quantum_model(argc, argv, "Full-ED of the Anderson model"),
+          // clang-format off
     args_options_anderson{{args_parser, "U", "Interaction constant U", {"U"}, 10.0},
                           {args_parser, "ed", "Energy level of the impurity", {"ed"}, 0},
                           {args_parser, "levels", "Energy levels of the bath sites", {"levels"}, {}},
                           {args_parser, "hoppings", "Hopping to the bath sites", {"hoppings"}, {}}}
-  {
-    parse_args(argc, argv);
+    // clang-format on
+    {
+        parse_args(argc, argv);
 
-    levels = args::get(args_options_anderson.levels);
-    hoppings = args::get(args_options_anderson.hoppings);
+        levels = args::get(args_options_anderson.levels);
+        hoppings = args::get(args_options_anderson.hoppings);
 
-    if(levels.size() != hoppings.size()) {
-      MPI_Finalize();
-      std::cerr << "Number of levels != number of hoppings" << std::endl;
-      exit(2);
+        if(levels.size() != hoppings.size()) {
+            MPI_Finalize();
+            std::cerr << "Number of levels != number of hoppings" << std::endl;
+            exit(2);
+        }
+
+        L = levels.size();
+        mpi_cout << "Diagonalization of 1+" << L << " sites" << std::endl;
+
+        init_hamiltonian();
     }
 
-    L = levels.size();
-    mpi_cout << "Diagonalization of 1+" << L << " sites" << std::endl;
-
-    init_hamiltonian();
-  }
-
-  virtual std::pair<ParticleIndex, ParticleIndex>
-  get_node(IndexInfoType const& IndexInfo) override {
-    ParticleIndex d0 = IndexInfo.getIndex("A",0,LatticePresets::down);
-    ParticleIndex u0 = IndexInfo.getIndex("A",0,LatticePresets::up);
-    return std::make_pair(d0, u0);
-  }
-
-  virtual void prepare_indices(ParticleIndex d0,
-                               ParticleIndex u0,
-                               std::set<IndexCombination2> &indices2,
-                               std::set<ParticleIndex>& f,
-                               IndexInfoType const& IndexInfo) override {
-    indices2.insert(IndexCombination2(d0, d0)); // evaluate only G_{\down \down}
-  }
-
-  virtual void init_hamiltonian() override {
-    HExpr += LatticePresets::CoulombS("A",
-                                      args::get(args_options_anderson.U),
-                                      args::get(args_options_anderson.ed));
-
-    std::vector<std::string> names(L);
-    for (std::size_t i=0; i<L; i++) {
-      names[i] = "b" + std::to_string(i);
-      HExpr += LatticePresets::Hopping("A", names[i], hoppings[i]);
-      HExpr += LatticePresets::Level(names[i], levels[i]);
+    virtual std::pair<ParticleIndex, ParticleIndex> get_node(IndexInfoType const& IndexInfo) override {
+        ParticleIndex d0 = IndexInfo.getIndex("A", 0, LatticePresets::down);
+        ParticleIndex u0 = IndexInfo.getIndex("A", 0, LatticePresets::up);
+        return std::make_pair(d0, u0);
     }
 
-    if (!rank) mpi_cout << "Hamiltonian:\n" << HExpr << std::endl;
-  }
+    virtual void prepare_indices(ParticleIndex d0,
+                                 ParticleIndex u0,
+                                 std::set<IndexCombination2>& indices2,
+                                 std::set<ParticleIndex>& f,
+                                 IndexInfoType const& IndexInfo) override {
+        indices2.insert(IndexCombination2(d0, d0)); // evaluate only G_{\down \down}
+    }
 
-  struct {
-    args::ValueFlag<double> U;
-    args::ValueFlag<double> ed;
-    args::ValueFlag<std::vector<double>, VectorReader> levels;
-    args::ValueFlag<std::vector<double>, VectorReader> hoppings;
-  } args_options_anderson;
+    virtual void init_hamiltonian() override {
+        HExpr += LatticePresets::CoulombS("A", args::get(args_options_anderson.U), args::get(args_options_anderson.ed));
 
-  std::size_t L;
-  std::vector<double> levels;
-  std::vector<double> hoppings;
+        std::vector<std::string> names(L);
+        for(std::size_t i = 0; i < L; i++) {
+            names[i] = "b" + std::to_string(i);
+            HExpr += LatticePresets::Hopping("A", names[i], hoppings[i]);
+            HExpr += LatticePresets::Level(names[i], levels[i]);
+        }
+
+        if(!rank)
+            mpi_cout << "Hamiltonian:\n" << HExpr << std::endl;
+    }
+
+    struct {
+        args::ValueFlag<double> U;
+        args::ValueFlag<double> ed;
+        args::ValueFlag<std::vector<double>, VectorReader> levels;
+        args::ValueFlag<std::vector<double>, VectorReader> hoppings;
+    } args_options_anderson;
+
+    std::size_t L;
+    std::vector<double> levels;
+    std::vector<double> hoppings;
 };
 
 #endif // #ifndef POMEROL_PROG_ANDERSON_MODEL_H

--- a/prog/hubbard2d_model.hpp
+++ b/prog/hubbard2d_model.hpp
@@ -13,8 +13,8 @@
 #include <limits>
 #include <set>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 using namespace Pomerol;
 
@@ -23,111 +23,119 @@ using namespace Pomerol;
  *
  * @author iskakoff
  */
-class hubbard2d_model: public quantum_model {
+class hubbard2d_model : public quantum_model {
 
 public:
-
-  hubbard2d_model(int argc, char* argv[]) :
-    quantum_model(argc, argv, "Full-ED of the MxM Hubbard cluster"),
+    hubbard2d_model(int argc, char* argv[])
+        : quantum_model(argc, argv, "Full-ED of the MxM Hubbard cluster"),
+          // clang-format off
     args_options_hubbard2d{{args_parser, "U", "Hubbard constant U", {"U"}, 10.0},
                            {args_parser, "mu", "Chemical potential", {"mu"}, std::numeric_limits<double>::quiet_NaN()},
                            {args_parser, "t", "NN hopping constant t", {"t"}, 1.0},
                            {args_parser, "tp", "NNN hopping constant t'", {"tp"}, 0.0},
                            {args_parser, "x", "Size over x", {"x"}, 2},
-                           {args_parser, "y", "Size over y", {"y"}, 2}}
-  {
-    args_options_hubbard2d.mu.HelpDefault("U/2");
-    parse_args(argc, argv);
+                           {args_parser, "y", "Size over y", {"y"}, 2}} // clang-format on
+    {
+        args_options_hubbard2d.mu.HelpDefault("U/2");
+        parse_args(argc, argv);
 
-    size_x = args::get(args_options_hubbard2d.x);
-    size_y = args::get(args_options_hubbard2d.y);
+        size_x = args::get(args_options_hubbard2d.x);
+        size_y = args::get(args_options_hubbard2d.y);
 
-    init_hamiltonian();
-  }
-
-  virtual std::pair<ParticleIndex, ParticleIndex>
-  get_node(IndexInfoType const& IndexInfo) override {
-    ParticleIndex d0 = IndexInfo.getIndex("S0",0,LatticePresets::down);
-    ParticleIndex u0 = IndexInfo.getIndex("S0",0,LatticePresets::up);
-    return std::make_pair(d0, u0);
-  };
-
-  virtual void init_hamiltonian() override {
-    int L = size_x*size_y;
-    INFO("Diagonalization of " << L << "=" << size_x << "*" << size_y << " sites");
-
-    /* Add sites */
-    names.resize(L);
-    for (std::size_t y=0; y<size_y; y++) {
-      for (std::size_t x = 0; x < size_x; x++) {
-        auto i = SiteIndexF(x, y);
-        names[i] = "S" + std::to_string(i);
-      }
+        init_hamiltonian();
     }
 
-    /* Add interaction on each site*/
-    double U = args::get(args_options_hubbard2d.U);
-    double mu = args::get(args_options_hubbard2d.mu);
-    if(std::isnan(mu)) mu = U / 2;
+    virtual std::pair<ParticleIndex, ParticleIndex> get_node(IndexInfoType const& IndexInfo) override {
+        ParticleIndex d0 = IndexInfo.getIndex("S0", 0, LatticePresets::down);
+        ParticleIndex u0 = IndexInfo.getIndex("S0", 0, LatticePresets::up);
+        return std::make_pair(d0, u0);
+    };
 
-    for (std::size_t i=0; i<L; i++)
-      HExpr += LatticePresets::CoulombS(names[i], U, -mu);
+    virtual void init_hamiltonian() override {
+        int L = size_x * size_y;
+        INFO("Diagonalization of " << L << "=" << size_x << "*" << size_y << " sites");
 
-    /* Add hopping */
-    double t = args::get(args_options_hubbard2d.t);
-    double tp = args::get(args_options_hubbard2d.tp);
-
-    for (std::size_t y=0; y<size_y; y++) {
-      for (std::size_t x=0; x<size_x; x++) {
-        auto pos = SiteIndexF(x,y);
-        auto pos_right = SiteIndexF((x+1)%size_x,y); /*if (x == size_x - 1) pos_right = SiteIndexF(0,y); */
-        auto pos_up = SiteIndexF(x,(y+1)%size_y);
-        auto pos_dia_right = SiteIndexF((x+1)%size_x,(y+1)%size_y);
-        auto pos_dia_left  = SiteIndexF((x+1)%size_x,(y-1)%size_y);
-        std::cout<<pos_dia_right<<" "<<pos_dia_left<<std::endl;
-        if (size_x > 1)
-          HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_right]), std::max(names[pos], names[pos_right]), -t);
-        if (size_y > 1)
-          HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_up]), std::max(names[pos], names[pos_up]), -t);
-        if (std::abs(tp)>1e-10 && size_x > 1 && size_y>1) {
-          HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_dia_right]), std::max(names[pos], names[pos_dia_right]), tp);
-          HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_dia_left]), std::max(names[pos], names[pos_dia_left]), tp);
+        /* Add sites */
+        names.resize(L);
+        for(std::size_t y = 0; y < size_y; y++) {
+            for(std::size_t x = 0; x < size_x; x++) {
+                auto i = SiteIndexF(x, y);
+                names[i] = "S" + std::to_string(i);
+            }
         }
-      }
+
+        /* Add interaction on each site*/
+        double U = args::get(args_options_hubbard2d.U);
+        double mu = args::get(args_options_hubbard2d.mu);
+        if(std::isnan(mu))
+            mu = U / 2;
+
+        for(std::size_t i = 0; i < L; i++)
+            HExpr += LatticePresets::CoulombS(names[i], U, -mu);
+
+        /* Add hopping */
+        double t = args::get(args_options_hubbard2d.t);
+        double tp = args::get(args_options_hubbard2d.tp);
+
+        for(std::size_t y = 0; y < size_y; y++) {
+            for(std::size_t x = 0; x < size_x; x++) {
+                auto pos = SiteIndexF(x, y);
+                auto pos_right = SiteIndexF((x + 1) % size_x, y); /*if (x == size_x - 1) pos_right = SiteIndexF(0,y); */
+                auto pos_up = SiteIndexF(x, (y + 1) % size_y);
+                auto pos_dia_right = SiteIndexF((x + 1) % size_x, (y + 1) % size_y);
+                auto pos_dia_left = SiteIndexF((x + 1) % size_x, (y - 1) % size_y);
+                std::cout << pos_dia_right << " " << pos_dia_left << std::endl;
+                if(size_x > 1)
+                    HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_right]),
+                                                     std::max(names[pos], names[pos_right]),
+                                                     -t);
+                if(size_y > 1)
+                    HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_up]),
+                                                     std::max(names[pos], names[pos_up]),
+                                                     -t);
+                if(std::abs(tp) > 1e-10 && size_x > 1 && size_y > 1) {
+                    HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_dia_right]),
+                                                     std::max(names[pos], names[pos_dia_right]),
+                                                     tp);
+                    HExpr += LatticePresets::Hopping(std::min(names[pos], names[pos_dia_left]),
+                                                     std::max(names[pos], names[pos_dia_left]),
+                                                     tp);
+                }
+            }
+        }
+
+        auto rank = pMPI::rank(comm);
+        if(!rank)
+            mpi_cout << "Hamiltonian:\n" << HExpr << std::endl;
     }
 
-    auto rank = pMPI::rank(comm);
-    if (!rank) mpi_cout << "Hamiltonian:\n" << HExpr << std::endl;
-  }
-
-  virtual void prepare_indices(ParticleIndex d0,
-                               ParticleIndex u0,
-                               std::set<IndexCombination2> &indices2,
-                               std::set<ParticleIndex>& f,
-                               IndexInfoType const& IndexInfo) override {
-    for (std::size_t x=0; x<size_x; x++) {
-      ParticleIndex ind = IndexInfo.getIndex(names[SiteIndexF(x,0)],0,LatticePresets::down);
-      f.insert(ind);
-      indices2.insert(IndexCombination2(d0,ind));
+    virtual void prepare_indices(ParticleIndex d0,
+                                 ParticleIndex u0,
+                                 std::set<IndexCombination2>& indices2,
+                                 std::set<ParticleIndex>& f,
+                                 IndexInfoType const& IndexInfo) override {
+        for(std::size_t x = 0; x < size_x; x++) {
+            ParticleIndex ind = IndexInfo.getIndex(names[SiteIndexF(x, 0)], 0, LatticePresets::down);
+            f.insert(ind);
+            indices2.insert(IndexCombination2(d0, ind));
+        }
     }
-  }
 
 private:
+    struct {
+        args::ValueFlag<double> U;
+        args::ValueFlag<double> mu;
+        args::ValueFlag<double> t;
+        args::ValueFlag<double> tp;
+        args::ValueFlag<int> x;
+        args::ValueFlag<int> y;
+    } args_options_hubbard2d;
 
-  struct {
-    args::ValueFlag<double> U;
-    args::ValueFlag<double> mu;
-    args::ValueFlag<double> t;
-    args::ValueFlag<double> tp;
-    args::ValueFlag<int> x;
-    args::ValueFlag<int> y;
-  } args_options_hubbard2d;
+    int size_x;
+    int size_y;
+    std::vector<std::string> names;
 
-  int size_x;
-  int size_y;
-  std::vector<std::string> names;
-
-  std::size_t SiteIndexF(std::size_t x, std::size_t y) { return y * size_x + x; }
+    std::size_t SiteIndexF(std::size_t x, std::size_t y) { return y * size_x + x; }
 };
 
 #endif // #ifndef POMEROL_PROG_HUBBARD2D_MODEL_H

--- a/prog/main.cpp
+++ b/prog/main.cpp
@@ -31,15 +31,14 @@
 #include "hubbard2d_model.hpp"
 #endif
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
 #ifdef POMEROL_ANDERSON
-  anderson_model m(argc, argv);
+    anderson_model m(argc, argv);
 #endif
 #ifdef POMEROL_HUBBARD2D
-  hubbard2d_model m(argc, argv);
+    hubbard2d_model m(argc, argv);
 #endif
 
-  m.compute();
-  return 0;
+    m.compute();
+    return 0;
 }

--- a/prog/quantum_model.cpp
+++ b/prog/quantum_model.cpp
@@ -15,8 +15,9 @@
 using namespace Pomerol;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-quantum_model::quantum_model(int argc, char* argv[], std::string const& prog_desc) :
-  args_parser(prog_desc),
+quantum_model::quantum_model(int argc, char* argv[], std::string const& prog_desc)
+    : args_parser(prog_desc),
+      // clang-format off
   args_options{{args_parser, "help", "Display this help menu", {'h', "help"}},
                {args_parser, "beta", "Inverse temperature", {"beta"}, 1.0},
                {args_parser, "calc_gf", "Calculate Green's functions", {"calc_gf"}},
@@ -33,210 +34,212 @@ quantum_model::quantum_model(int argc, char* argv[], std::string const& prog_des
                {args_parser, "tol", "Tolerance on nominators in 2PGF", {"2pgf.coeff_tol"}, 1e-12},
                {args_parser, "tol", "How often to reduce terms in 2PGF", {"2pgf.multiterm_tol"}, 1e-6}
   },
-  comm(MPI_COMM_WORLD) {
-  MPI_Init(&argc, &argv);
-  rank = pMPI::rank(comm);
-  // Print defaults in the usage message
-  args_parser.helpParams.addDefault = true;
+      // clang-format on
+      comm(MPI_COMM_WORLD) {
+    MPI_Init(&argc, &argv);
+    rank = pMPI::rank(comm);
+    // Print defaults in the usage message
+    args_parser.helpParams.addDefault = true;
 }
 
 quantum_model::~quantum_model() {
-  MPI_Finalize();
+    MPI_Finalize();
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
 void quantum_model::parse_args(int argc, char* argv[]) {
-  try {
-    args_parser.ParseCLI(argc, argv);
-  } catch (args::Help) {
-    std::cout << args_parser;
-    exit(0);
-  }
-  catch (args::ParseError& e)
-  {
-    std::cerr << e.what() << std::endl;
-    std::cerr << args_parser;
-    exit(1);
-  }
-  catch (args::ValidationError& e)
-  {
-    std::cerr << e.what() << std::endl;
-    std::cerr << args_parser;
-    exit(1);
-  }
+    try {
+        args_parser.ParseCLI(argc, argv);
+    } catch(args::Help) {
+        std::cout << args_parser;
+        exit(0);
+    } catch(args::ParseError& e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << args_parser;
+        exit(1);
+    } catch(args::ValidationError& e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << args_parser;
+        exit(1);
+    }
 
-  beta = args::get(args_options.beta);
-  calc_gf = args::get(args_options.calc_gf);
-  calc_2pgf = args::get(args_options.calc_2pgf);
-  calc_gf = calc_gf || calc_2pgf;
+    beta = args::get(args_options.beta);
+    calc_gf = args::get(args_options.calc_gf);
+    calc_2pgf = args::get(args_options.calc_2pgf);
+    calc_gf = calc_gf || calc_2pgf;
 }
 
 void quantum_model::compute() {
 
-  using gftools::tools::is_float_equal;
-  using gftools::grid_object;
-  using gftools::fmatsubara_grid;
-  using gftools::bmatsubara_grid;
-  using gftools::real_grid;
+    using gftools::tools::is_float_equal;
+    using gftools::grid_object;
+    using gftools::fmatsubara_grid;
+    using gftools::bmatsubara_grid;
+    using gftools::real_grid;
 
-  IndexInfoType IndexInfo = MakeIndexClassification(HExpr);
-  if (!rank) {
-    print_section("Indices");
-    std::cout << IndexInfo << std::endl;
-  };
+    IndexInfoType IndexInfo = MakeIndexClassification(HExpr);
+    if(!rank) {
+        print_section("Indices");
+        std::cout << IndexInfo << std::endl;
+    };
 
-  auto HS = MakeHilbertSpace(IndexInfo, HExpr);
-  HS.compute();
+    auto HS = MakeHilbertSpace(IndexInfo, HExpr);
+    HS.compute();
 
-  StatesClassification S;
-  S.compute(HS);
+    StatesClassification S;
+    S.compute(HS);
 
-  Hamiltonian H(S);
-  H.prepare(HExpr, HS, MPI_COMM_WORLD);
-  H.compute(MPI_COMM_WORLD);
+    Hamiltonian H(S);
+    H.prepare(HExpr, HS, MPI_COMM_WORLD);
+    H.compute(MPI_COMM_WORLD);
 
-  if(!rank) {
-    gftools::grid_object<double, gftools::enum_grid> evals1(gftools::enum_grid(0, static_cast<int>(S.getNumberOfStates())));
-    RealVectorType evals (H.getEigenValues());
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::sort(evals.data(), evals.data() + H.getEigenValues().size());
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    std::copy(evals.data(), evals.data() + S.getNumberOfStates(), evals1.data().data());
-    evals1.savetxt("spectrum.dat");
-  }
-  DensityMatrix rho(S,H,beta); // create Density Matrix
-  rho.prepare();
-  rho.compute(); // evaluate thermal weights with respect to ground energy, i.e exp(-beta(e-e_0))/Z
-
-  std::pair<ParticleIndex, ParticleIndex> pair = get_node(IndexInfo);
-  ParticleIndex d0 = pair.first;//IndexInfo.getIndex("A",0,down); // find the indices of the impurity, i.e. spin up index
-  ParticleIndex u0 = pair.second;//IndexInfo.getIndex("A",0,up);
-
-  // Green's function calculation starts here
-
-  if (calc_gf) {
-    print_section("1-particle Green's functions calc");
-    std::set<ParticleIndex> f; // a set of indices to evaluate c and c^+
-    std::set<IndexCombination2> indices2; // a set of pairs of indices to evaluate Green's function
-
-    double eta = args::get(args_options.gf_eta);
-    double step = args::get(args_options.gf_step);
-    double hbw = args::get(args_options.gf_D);
-
-    int wf_min = args::get(args_options.wf_min);
-    int wf_max = args::get(args_options.wf_max);
-    int wb_min = args::get(args_options.wb_min);
-    int wb_max = args::get(args_options.wb_max);
-
-    // Take only impurity spin up and spin down indices
-    f.insert(u0);
-    f.insert(d0);
-    prepare_indices(d0, u0, indices2, f, IndexInfo);
-
-    // Create a container for c and c^+ in the eigenstate basis
-    FieldOperatorContainer Operators(IndexInfo, HS, S, H, f);
-    Operators.prepareAll(HS);
-    Operators.computeAll(); // evaluate c, c^+ for chosen indices
-
-    GFContainer G(IndexInfo,S,H,rho,Operators);
-
-    G.prepareAll(indices2); // identify all non-vanishing block connections in the Green's function
-    G.computeAll(); // Evaluate all GF terms, i.e. resonances and weights of expressions in Lehmans representation of the Green's function
-
-    if (!rank) // dump gf into a file
-      // loops over all components (pairs of indices) of the Green's function
-      for (auto const& ind2 : indices2) {
-        GreensFunction const& GF = G(ind2);
-        // Save Matsubara GF from pi/beta to pi/beta*(4*wf_max + 1)
-        std::cout << "Saving imfreq G" << ind2 << " on " << 4 * wf_max << " Matsubara freqs. " << std::endl;
-        grid_object<std::complex<double>, fmatsubara_grid> gf_imfreq (fmatsubara_grid(wf_min, wf_max*4, beta, true));
-        std::string ind_str = std::to_string(ind2.Index1)+ std::to_string(ind2.Index2);
-        for (auto p : gf_imfreq.grid().points()) { gf_imfreq[p] = GF(p.value()); }
-        gf_imfreq.savetxt("gw_imfreq_"+ ind_str +".dat");
-
-        real_grid freq_grid(-hbw, hbw, 2*static_cast<std::size_t>(hbw/step)+1, true);
-        grid_object<std::complex<double>, real_grid> gf_refreq(freq_grid);
-        for (auto p : freq_grid.points()) {
-          ComplexType val = GF(ComplexType(p.value()) + I*eta);
-          gf_refreq[p] = val;
-        };
-        gf_refreq.savetxt("gw_refreq_"+ ind_str +".dat");
-      }
-
-    // Start Two-particle GF calculation
-
-    if (calc_2pgf) {
-      print_section("2-Particle Green's function calc");
-
-      std::vector<std::size_t> indices_2pgf = args::get(args_options._2pgf_indices);
-
-      if (indices_2pgf.size() != 4)
-        throw std::runtime_error("Need 4 indices for 2PGF");
-
-      // a set of four indices to evaluate the 2pgf
-      IndexCombination4 index_comb(indices_2pgf[0], indices_2pgf[1], indices_2pgf[2], indices_2pgf[3]);
-
-      std::set<IndexCombination4> indices4;
-      // 2PGF = <T c c c^+ c^+>
-      indices4.insert(index_comb);
-      std::string ind_str = std::to_string(index_comb.Index1)
-                          + std::to_string(index_comb.Index2)
-                          + std::to_string(index_comb.Index3)
-                          + std::to_string(index_comb.Index4);
-
-      AnnihilationOperator const& C1 = Operators.getAnnihilationOperator(index_comb.Index1);
-      AnnihilationOperator const& C2 = Operators.getAnnihilationOperator(index_comb.Index2);
-      CreationOperator const&    CX3 = Operators.getCreationOperator(index_comb.Index3);
-      CreationOperator const&    CX4 = Operators.getCreationOperator(index_comb.Index4);
-      TwoParticleGF G4(S, H, C1, C2, CX3, CX4, rho);
-
-      /* Some knobs to make calc faster - the larger the values of tolerances, the faster is calc, but rounding errors may show up. */
-      /** A difference in energies with magnitude less than this value is treated as zero - resolution of energy resonances. */
-      G4.ReduceResonanceTolerance = args::get(args_options._2pgf_reduce_tol);
-      /** Minimal magnitude of the coefficient of a term to take it into account - resolution of thermal weight. */
-      G4.CoefficientTolerance = args::get(args_options._2pgf_coeff_tol);
-      /** Minimal magnitude of the coefficient of a term to take it into account with respect to amount of terms. */
-      G4.MultiTermCoefficientTolerance = args::get(args_options._2pgf_multiterm_tol);
-
-      G4.prepare();
-      MPI_Barrier(comm);
-      std::vector<std::tuple<ComplexType, ComplexType, ComplexType>> freqs_2pgf;
-      fmatsubara_grid fgrid(wf_min, wf_max, beta, true);
-      bmatsubara_grid bgrid(wb_min, wb_max, beta, true);
-      freqs_2pgf.reserve(fgrid.size() * fgrid.size() * bgrid.size());
-      for (auto W : bgrid.values()) {
-        for (auto w3 : fgrid.values()) {
-          for (auto w2 : fgrid.values()) {
-            ComplexType w1 = W+w3;
-            freqs_2pgf.emplace_back(w1, w2, w3);
-          }
-        }
-      }
-      mpi_cout << "2PGF : " << freqs_2pgf.size() << " freqs to evaluate" << std::endl;
-
-      std::vector<ComplexType> chi_freq_data = G4.compute(true, freqs_2pgf, comm);
-
-      // dump 2PGF into files - loop through 2pgf components
-      if (!rank) {
-        mpi_cout << "Saving 2PGF " << index_comb << std::endl;
-        grid_object<std::complex<double>, bmatsubara_grid, fmatsubara_grid, fmatsubara_grid> full_vertex(std::forward_as_tuple(bgrid, fgrid, fgrid));
-        grid_object<std::complex<double>, fmatsubara_grid, fmatsubara_grid> full_vertex_1freq(std::forward_as_tuple(fgrid, fgrid));
-        std::size_t w_ind = 0;
-        for (auto W : bgrid.points()) {
-          for (auto w3 : fgrid.points()) {
-            for (auto w2 : fgrid.points()) {
-              std::complex<double> val = chi_freq_data[w_ind];
-              full_vertex[W][w3.index()][w2.index()] = val;
-              full_vertex_1freq[w3.index()][w2.index()] = val;
-              if (!is_float_equal(std::get<0>(freqs_2pgf[w_ind]), W.value()+w3.value()))
-                throw std::logic_error("2PGF freq mismatch");
-              ++w_ind;
-            }
-          }
-          std::string fv1_name = "chi"+ind_str+"_W"+std::to_string(std::imag(W.value()))+".dat";
-          full_vertex_1freq.savetxt(fv1_name);
-        }
-      }
+    if(!rank) {
+        gftools::grid_object<double, gftools::enum_grid> evals1(
+            gftools::enum_grid(0, static_cast<int>(S.getNumberOfStates())));
+        RealVectorType evals(H.getEigenValues());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        std::sort(evals.data(), evals.data() + H.getEigenValues().size());
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        std::copy(evals.data(), evals.data() + S.getNumberOfStates(), evals1.data().data());
+        evals1.savetxt("spectrum.dat");
     }
-  }
+    DensityMatrix rho(S, H, beta); // create Density Matrix
+    rho.prepare();
+    rho.compute(); // evaluate thermal weights with respect to ground energy, i.e exp(-beta(e-e_0))/Z
+
+    std::pair<ParticleIndex, ParticleIndex> pair = get_node(IndexInfo);
+    ParticleIndex d0 =
+        pair.first; //IndexInfo.getIndex("A",0,down); // find the indices of the impurity, i.e. spin up index
+    ParticleIndex u0 = pair.second; //IndexInfo.getIndex("A",0,up);
+
+    // Green's function calculation starts here
+
+    if(calc_gf) {
+        print_section("1-particle Green's functions calc");
+        std::set<ParticleIndex> f;            // a set of indices to evaluate c and c^+
+        std::set<IndexCombination2> indices2; // a set of pairs of indices to evaluate Green's function
+
+        double eta = args::get(args_options.gf_eta);
+        double step = args::get(args_options.gf_step);
+        double hbw = args::get(args_options.gf_D);
+
+        int wf_min = args::get(args_options.wf_min);
+        int wf_max = args::get(args_options.wf_max);
+        int wb_min = args::get(args_options.wb_min);
+        int wb_max = args::get(args_options.wb_max);
+
+        // Take only impurity spin up and spin down indices
+        f.insert(u0);
+        f.insert(d0);
+        prepare_indices(d0, u0, indices2, f, IndexInfo);
+
+        // Create a container for c and c^+ in the eigenstate basis
+        FieldOperatorContainer Operators(IndexInfo, HS, S, H, f);
+        Operators.prepareAll(HS);
+        Operators.computeAll(); // evaluate c, c^+ for chosen indices
+
+        GFContainer G(IndexInfo, S, H, rho, Operators);
+
+        G.prepareAll(indices2); // identify all non-vanishing block connections in the Green's function
+        G.computeAll(); // Evaluate all GF terms, i.e. resonances and weights of expressions in Lehmans representation of the Green's function
+
+        if(!rank) // dump gf into a file
+            // loops over all components (pairs of indices) of the Green's function
+            for(auto const& ind2 : indices2) {
+                GreensFunction const& GF = G(ind2);
+                // Save Matsubara GF from pi/beta to pi/beta*(4*wf_max + 1)
+                std::cout << "Saving imfreq G" << ind2 << " on " << 4 * wf_max << " Matsubara freqs. " << std::endl;
+                grid_object<std::complex<double>, fmatsubara_grid> gf_imfreq(
+                    fmatsubara_grid(wf_min, wf_max * 4, beta, true));
+                std::string ind_str = std::to_string(ind2.Index1) + std::to_string(ind2.Index2);
+                for(auto p : gf_imfreq.grid().points()) {
+                    gf_imfreq[p] = GF(p.value());
+                }
+                gf_imfreq.savetxt("gw_imfreq_" + ind_str + ".dat");
+
+                real_grid freq_grid(-hbw, hbw, 2 * static_cast<std::size_t>(hbw / step) + 1, true);
+                grid_object<std::complex<double>, real_grid> gf_refreq(freq_grid);
+                for(auto p : freq_grid.points()) {
+                    ComplexType val = GF(ComplexType(p.value()) + I * eta);
+                    gf_refreq[p] = val;
+                };
+                gf_refreq.savetxt("gw_refreq_" + ind_str + ".dat");
+            }
+
+        // Start Two-particle GF calculation
+
+        if(calc_2pgf) {
+            print_section("2-Particle Green's function calc");
+
+            std::vector<std::size_t> indices_2pgf = args::get(args_options._2pgf_indices);
+
+            if(indices_2pgf.size() != 4)
+                throw std::runtime_error("Need 4 indices for 2PGF");
+
+            // a set of four indices to evaluate the 2pgf
+            IndexCombination4 index_comb(indices_2pgf[0], indices_2pgf[1], indices_2pgf[2], indices_2pgf[3]);
+
+            std::set<IndexCombination4> indices4;
+            // 2PGF = <T c c c^+ c^+>
+            indices4.insert(index_comb);
+            std::string ind_str = std::to_string(index_comb.Index1) + std::to_string(index_comb.Index2) +
+                                  std::to_string(index_comb.Index3) + std::to_string(index_comb.Index4);
+
+            AnnihilationOperator const& C1 = Operators.getAnnihilationOperator(index_comb.Index1);
+            AnnihilationOperator const& C2 = Operators.getAnnihilationOperator(index_comb.Index2);
+            CreationOperator const& CX3 = Operators.getCreationOperator(index_comb.Index3);
+            CreationOperator const& CX4 = Operators.getCreationOperator(index_comb.Index4);
+            TwoParticleGF G4(S, H, C1, C2, CX3, CX4, rho);
+
+            /* Some knobs to make calc faster - the larger the values of tolerances, the faster is calc, but rounding errors may show up. */
+            /** A difference in energies with magnitude less than this value is treated as zero - resolution of energy resonances. */
+            G4.ReduceResonanceTolerance = args::get(args_options._2pgf_reduce_tol);
+            /** Minimal magnitude of the coefficient of a term to take it into account - resolution of thermal weight. */
+            G4.CoefficientTolerance = args::get(args_options._2pgf_coeff_tol);
+            /** Minimal magnitude of the coefficient of a term to take it into account with respect to amount of terms. */
+            G4.MultiTermCoefficientTolerance = args::get(args_options._2pgf_multiterm_tol);
+
+            G4.prepare();
+            MPI_Barrier(comm);
+            std::vector<std::tuple<ComplexType, ComplexType, ComplexType>> freqs_2pgf;
+            fmatsubara_grid fgrid(wf_min, wf_max, beta, true);
+            bmatsubara_grid bgrid(wb_min, wb_max, beta, true);
+            freqs_2pgf.reserve(fgrid.size() * fgrid.size() * bgrid.size());
+            for(auto W : bgrid.values()) {
+                for(auto w3 : fgrid.values()) {
+                    for(auto w2 : fgrid.values()) {
+                        ComplexType w1 = W + w3;
+                        freqs_2pgf.emplace_back(w1, w2, w3);
+                    }
+                }
+            }
+            mpi_cout << "2PGF : " << freqs_2pgf.size() << " freqs to evaluate" << std::endl;
+
+            std::vector<ComplexType> chi_freq_data = G4.compute(true, freqs_2pgf, comm);
+
+            // dump 2PGF into files - loop through 2pgf components
+            if(!rank) {
+                mpi_cout << "Saving 2PGF " << index_comb << std::endl;
+                grid_object<std::complex<double>, bmatsubara_grid, fmatsubara_grid, fmatsubara_grid> full_vertex(
+                    std::forward_as_tuple(bgrid, fgrid, fgrid));
+                grid_object<std::complex<double>, fmatsubara_grid, fmatsubara_grid> full_vertex_1freq(
+                    std::forward_as_tuple(fgrid, fgrid));
+                std::size_t w_ind = 0;
+                for(auto W : bgrid.points()) {
+                    for(auto w3 : fgrid.points()) {
+                        for(auto w2 : fgrid.points()) {
+                            std::complex<double> val = chi_freq_data[w_ind];
+                            full_vertex[W][w3.index()][w2.index()] = val;
+                            full_vertex_1freq[w3.index()][w2.index()] = val;
+                            if(!is_float_equal(std::get<0>(freqs_2pgf[w_ind]), W.value() + w3.value()))
+                                throw std::logic_error("2PGF freq mismatch");
+                            ++w_ind;
+                        }
+                    }
+                    std::string fv1_name = "chi" + ind_str + "_W" + std::to_string(std::imag(W.value())) + ".dat";
+                    full_vertex_1freq.savetxt(fv1_name);
+                }
+            }
+        }
+    }
 }

--- a/prog/quantum_model.hpp
+++ b/prog/quantum_model.hpp
@@ -17,21 +17,21 @@
 #include <utility>
 #include <vector>
 
-#define mpi_cout if(!pMPI::rank(comm)) std::cout
+#define mpi_cout                                                                                                       \
+    if(!pMPI::rank(comm))                                                                                              \
+    std::cout
 
 // Vector value reader for args
 struct VectorReader {
-  template<typename T> void operator()(std::string const&,
-                                       std::string const& value,
-                                       std::vector<T> &destination) {
-    std::stringstream ss(value);
-    std::string token;
-    T element;
-    while(std::getline(ss, token, ',')) {
-      std::stringstream(token) >> element;
-      destination.emplace_back(element);
+    template <typename T> void operator()(std::string const&, std::string const& value, std::vector<T>& destination) {
+        std::stringstream ss(value);
+        std::string token;
+        T element;
+        while(std::getline(ss, token, ',')) {
+            std::stringstream(token) >> element;
+            destination.emplace_back(element);
+        }
     }
-  }
 };
 
 /**
@@ -42,75 +42,67 @@ struct VectorReader {
 class quantum_model {
 
 public:
+    using IndexInfoType = Pomerol::IndexClassification<std::string, unsigned short, Pomerol::LatticePresets::spin>;
 
-  using IndexInfoType = Pomerol::IndexClassification<
-      std::string,
-      unsigned short,
-      Pomerol::LatticePresets::spin
-  >;
+    quantum_model(int argc, char* argv[], std::string const& prog_desc);
+    ~quantum_model();
 
-  quantum_model(int argc, char* argv[], std::string const& prog_desc);
-  ~quantum_model();
+    void parse_args(int argc, char* argv[]);
 
-  void parse_args(int argc, char* argv[]);
+    virtual void init_hamiltonian() = 0;
 
-  virtual void init_hamiltonian() = 0;
+    void compute();
 
-  void compute();
+    virtual std::pair<Pomerol::ParticleIndex, Pomerol::ParticleIndex> get_node(IndexInfoType const& IndexInfo) = 0;
 
-  virtual std::pair<Pomerol::ParticleIndex, Pomerol::ParticleIndex>
-  get_node(IndexInfoType const& IndexInfo) = 0;
+    double FMatsubara(int n, double beta) { return M_PI / beta * (2. * n + 1); }
+    double BMatsubara(int n, double beta) { return M_PI / beta * (2. * n); }
 
-  double FMatsubara(int n, double beta){ return M_PI/beta*(2.*n+1); }
-  double BMatsubara(int n, double beta){ return M_PI/beta*(2.*n); }
+    virtual void prepare_indices(Pomerol::ParticleIndex d0,
+                                 Pomerol::ParticleIndex u0,
+                                 std::set<Pomerol::IndexCombination2>& indices2,
+                                 std::set<Pomerol::ParticleIndex>& f,
+                                 IndexInfoType const& IndexInfo) = 0;
 
-  virtual void prepare_indices(Pomerol::ParticleIndex d0,
-                               Pomerol::ParticleIndex u0,
-                               std::set<Pomerol::IndexCombination2> &indices2,
-                               std::set<Pomerol::ParticleIndex> & f,
-                               IndexInfoType const& IndexInfo) = 0;
 private:
-
-  // Simulation parameters
-  Pomerol::RealType beta = {};
-  bool calc_gf = false;
-  bool calc_2pgf = false;
+    // Simulation parameters
+    Pomerol::RealType beta = {};
+    bool calc_gf = false;
+    bool calc_2pgf = false;
 
 protected:
+    // Command line parsing
+    args::ArgumentParser args_parser;
+    struct {
+        args::HelpFlag help;
+        args::ValueFlag<double> beta;
+        args::Flag calc_gf;
+        args::Flag calc_2pgf;
+        args::ValueFlag<double> gf_eta;
+        args::ValueFlag<double> gf_step;
+        args::ValueFlag<double> gf_D;
+        args::ValueFlag<int> wf_min;
+        args::ValueFlag<int> wf_max;
+        args::ValueFlag<int> wb_min;
+        args::ValueFlag<int> wb_max;
+        args::ValueFlag<std::vector<std::size_t>, VectorReader> _2pgf_indices;
+        args::ValueFlag<double> _2pgf_reduce_tol;
+        args::ValueFlag<double> _2pgf_coeff_tol;
+        args::ValueFlag<double> _2pgf_multiterm_tol;
+    } args_options;
 
-  // Command line parsing
-  args::ArgumentParser args_parser;
-  struct {
-    args::HelpFlag help;
-    args::ValueFlag<double> beta;
-    args::Flag calc_gf;
-    args::Flag calc_2pgf;
-    args::ValueFlag<double> gf_eta;
-    args::ValueFlag<double> gf_step;
-    args::ValueFlag<double> gf_D;
-    args::ValueFlag<int> wf_min;
-    args::ValueFlag<int> wf_max;
-    args::ValueFlag<int> wb_min;
-    args::ValueFlag<int> wb_max;
-    args::ValueFlag<std::vector<std::size_t>, VectorReader> _2pgf_indices;
-    args::ValueFlag<double> _2pgf_reduce_tol;
-    args::ValueFlag<double> _2pgf_coeff_tol;
-    args::ValueFlag<double> _2pgf_multiterm_tol;
-  } args_options;
+    MPI_Comm comm;
+    int rank;
 
-  MPI_Comm comm;
-  int rank;
+    Pomerol::LatticePresets::RealExpr HExpr;
 
-  Pomerol::LatticePresets::RealExpr HExpr;
-
-  void print_section(std::string const& str)
-  {
-    if (!rank) {
-      std::cout << std::string(str.size(),'=') << std::endl;
-      std::cout << str << std::endl;
-      std::cout << std::string(str.size(),'=') << std::endl;
+    void print_section(std::string const& str) {
+        if(!rank) {
+            std::cout << std::string(str.size(), '=') << std::endl;
+            std::cout << str << std::endl;
+            std::cout << std::string(str.size(), '=') << std::endl;
+        }
     }
-  }
 };
 
 #endif // #ifndef POMEROL_PROG_QUANTUM_MODEL_H

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# TODO: tutorial/
+
+SOURCES="include/*.hpp          \
+         include/*/*.hpp        \
+         include/*/*.hpp.in     \
+         src/*/*.cpp            \
+         prog/*.hpp             \
+         prog/*.cpp             \
+         test/*.hpp             \
+         test/*.cpp             \
+         test/catch2/catch2-*"
+
+clang-format --verbose -i $SOURCES

--- a/src/pomerol/DensityMatrix.cpp
+++ b/src/pomerol/DensityMatrix.cpp
@@ -4,13 +4,12 @@
 
 namespace Pomerol {
 
-DensityMatrix::DensityMatrix(StatesClassification const& S, Hamiltonian const& H, RealType beta) :
-    Thermal(beta), ComputableObject(), S(S), H(H)
-{}
+DensityMatrix::DensityMatrix(StatesClassification const& S, Hamiltonian const& H, RealType beta)
+    : Thermal(beta), ComputableObject(), S(S), H(H) {}
 
-void DensityMatrix::prepare()
-{
-    if(getStatus() >= Prepared) return;
+void DensityMatrix::prepare() {
+    if(getStatus() >= Prepared)
+        return;
     BlockNumber NumOfBlocks = S.getNumberOfBlocks();
     parts.reserve(NumOfBlocks);
     RealType GroundEnergy = H.getGroundEnergy();
@@ -21,55 +20,54 @@ void DensityMatrix::prepare()
     setStatus(Prepared);
 }
 
-void DensityMatrix::compute()
-{
-    if(getStatus() >= Computed) return;
+void DensityMatrix::compute() {
+    if(getStatus() >= Computed)
+        return;
     RealType Z = 0;
     // A total partition function is a sum over partition functions of
     // all non-normalized parts.
-    for(auto & p : parts)
+    for(auto& p : parts)
         Z += p.computeUnnormalized();
 
     // Divide the density matrix by Z.
-    for(auto & p : parts)
+    for(auto& p : parts)
         p.normalize(Z);
 
     setStatus(Computed);
 }
 
-RealType DensityMatrix::getWeight(QuantumState state) const
-{
-    if(getStatus() < Computed) { throw StatusMismatch("DensityMatrix is not computed yet."); };
+RealType DensityMatrix::getWeight(QuantumState state) const {
+    if(getStatus() < Computed) {
+        throw StatusMismatch("DensityMatrix is not computed yet.");
+    };
     BlockNumber Block = S.getBlockNumber(state);
     InnerQuantumState InnerState = S.getInnerState(state);
 
     return parts[Block].getWeight(InnerState);
 }
 
-DensityMatrixPart const& DensityMatrix::getPart(BlockNumber in) const
-{
+DensityMatrixPart const& DensityMatrix::getPart(BlockNumber in) const {
     return parts[in];
 }
 
-RealType DensityMatrix::getAverageEnergy() const
-{
-    if(getStatus() < Computed) { throw StatusMismatch("DensityMatrix is not computed yet."); }
-    return std::accumulate(parts.begin(),
-                           parts.end(),
-                           .0,
-                           [](double E, DensityMatrixPart const& p) { return E + p.getAverageEnergy(); });
+RealType DensityMatrix::getAverageEnergy() const {
+    if(getStatus() < Computed) {
+        throw StatusMismatch("DensityMatrix is not computed yet.");
+    }
+    return std::accumulate(parts.begin(), parts.end(), .0, [](double E, DensityMatrixPart const& p) {
+        return E + p.getAverageEnergy();
+    });
 }
 
-void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose)
-{
-    for(auto & p : parts)
+void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose) {
+    for(auto& p : parts)
         p.truncate(Tolerance);
 
-    if(verbose){
+    if(verbose) {
         // count retained blocks and states included in those blocks
         QuantumState n_blocks_retained = 0, n_states_retained = 0;
         for(BlockNumber i = 0; i < S.getNumberOfBlocks(); ++i)
-            if(isRetained(i)){
+            if(isRetained(i)) {
                 ++n_blocks_retained;
                 n_states_retained += S.getBlockSize(i);
             }
@@ -78,8 +76,7 @@ void DensityMatrix::truncateBlocks(RealType Tolerance, bool verbose)
     }
 }
 
-bool DensityMatrix::isRetained(BlockNumber in) const
-{
+bool DensityMatrix::isRetained(BlockNumber in) const {
     return parts[in].isRetained();
 }
 

--- a/src/pomerol/DensityMatrixPart.cpp
+++ b/src/pomerol/DensityMatrixPart.cpp
@@ -2,34 +2,28 @@
 
 namespace Pomerol {
 
-DensityMatrixPart::DensityMatrixPart(HamiltonianPart const& H, RealType beta, RealType GroundEnergy) :
-    Thermal(beta), H(H), GroundEnergy(GroundEnergy), weights(H.getSize())
-{}
+DensityMatrixPart::DensityMatrixPart(HamiltonianPart const& H, RealType beta, RealType GroundEnergy)
+    : Thermal(beta), H(H), GroundEnergy(GroundEnergy), weights(H.getSize()) {}
 
-RealType DensityMatrixPart::computeUnnormalized()
-{
-    weights = exp(-beta*(H.getEigenValues().array() - GroundEnergy));
+RealType DensityMatrixPart::computeUnnormalized() {
+    weights = exp(-beta * (H.getEigenValues().array() - GroundEnergy));
     return weights.sum();
 }
 
-void DensityMatrixPart::normalize(RealType Z)
-{
+void DensityMatrixPart::normalize(RealType Z) {
     weights /= Z;
     Z_part /= Z;
 }
 
-RealType DensityMatrixPart::getAverageEnergy() const
-{
+RealType DensityMatrixPart::getAverageEnergy() const {
     return weights.dot(H.getEigenValues());
 }
 
-RealType DensityMatrixPart::getWeight(InnerQuantumState s) const
-{
+RealType DensityMatrixPart::getWeight(InnerQuantumState s) const {
     return weights(static_cast<Eigen::Index>(s));
 }
 
-void DensityMatrixPart::truncate(RealType Tolerance)
-{
+void DensityMatrixPart::truncate(RealType Tolerance) {
     Retained = false;
     InnerQuantumState partSize = weights.size();
     for(InnerQuantumState s = 0; s < partSize; ++s) {

--- a/src/pomerol/EnsembleAverage.cpp
+++ b/src/pomerol/EnsembleAverage.cpp
@@ -2,18 +2,18 @@
 
 namespace Pomerol {
 
-EnsembleAverage::EnsembleAverage(StatesClassification const& S, Hamiltonian const& H,
-                                 MonomialOperator const& A, DensityMatrix const& DM) :
-    Thermal(DM.beta), ComputableObject(), S(S), H(H), A(A), DM(DM)
-{}
+EnsembleAverage::EnsembleAverage(StatesClassification const& S,
+                                 Hamiltonian const& H,
+                                 MonomialOperator const& A,
+                                 DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), S(S), H(H), A(A), DM(DM) {}
 
-EnsembleAverage::EnsembleAverage(EnsembleAverage const& EA) :
-    Thermal(EA.beta), ComputableObject(EA), S(EA.S), H(EA.H), A(EA.A), DM(EA.DM), Result(EA.Result)
-{}
+EnsembleAverage::EnsembleAverage(EnsembleAverage const& EA)
+    : Thermal(EA.beta), ComputableObject(EA), S(EA.S), H(EA.H), A(EA.A), DM(EA.DM), Result(EA.Result) {}
 
-void EnsembleAverage::compute()
-{
-    if(getStatus() >= Prepared) return;
+void EnsembleAverage::compute() {
+    if(getStatus() >= Prepared)
+        return;
 
     // Find out non-trivial blocks of A.
     MonomialOperator::BlocksBimap const& ANontrivialBlocks = A.getBlockMapping();
@@ -24,13 +24,15 @@ void EnsembleAverage::compute()
         BlockNumber Aright = Aiter->second;
 
         // Only diagonal blocks
-        if(Aleft == Aright){
+        if(Aleft == Aright) {
             // check if retained blocks are included. If not, do not push.
             if(DM.isRetained(Aleft)) {
                 if(A.isComplex())
-                    Result += computeImpl<true>((MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft), DM.getPart(Aleft));
+                    Result +=
+                        computeImpl<true>((MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft), DM.getPart(Aleft));
                 else
-                    Result += computeImpl<false>((MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft), DM.getPart(Aleft));
+                    Result +=
+                        computeImpl<false>((MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft), DM.getPart(Aleft));
             }
         }
     }
@@ -39,10 +41,8 @@ void EnsembleAverage::compute()
 }
 
 // This function is called directly in prepare()
-template<bool Complex>
-ComplexType EnsembleAverage::computeImpl(MonomialOperatorPart const& Apart,
-                                         DensityMatrixPart const& DMpart)
-{
+template <bool Complex>
+ComplexType EnsembleAverage::computeImpl(MonomialOperatorPart const& Apart, DensityMatrixPart const& DMpart) {
     // Blocks (submatrices) of A
     RowMajorMatrixType<Complex> const& Amatrix = Apart.getRowMajorValue<Complex>();
 

--- a/src/pomerol/FieldOperatorContainer.cpp
+++ b/src/pomerol/FieldOperatorContainer.cpp
@@ -4,26 +4,24 @@
 
 namespace Pomerol {
 
-void FieldOperatorContainer::computeAll()
-{
-    for(auto & cdag_p : mapCreationOperators) {
-        auto & cdag = cdag_p.second;
+void FieldOperatorContainer::computeAll() {
+    for(auto& cdag_p : mapCreationOperators) {
+        auto& cdag = cdag_p.second;
         cdag.compute();
 
-        auto & c = mapAnnihilationOperators.find(cdag_p.first)->second;
+        auto& c = mapAnnihilationOperators.find(cdag_p.first)->second;
 
         auto const& cdag_block_map = cdag_p.second.getBlockMapping();
         for(auto cdag_map_it = cdag_block_map.right.begin(); cdag_map_it != cdag_block_map.right.end(); ++cdag_map_it) {
-            auto & cPart = c.getPartFromRightIndex(cdag_map_it->second);
-            auto & cdagPart = cdag.getPartFromRightIndex(cdag_map_it->first);
+            auto& cPart = c.getPartFromRightIndex(cdag_map_it->second);
+            auto& cdagPart = cdag.getPartFromRightIndex(cdag_map_it->first);
             cPart.setFromAdjoint(cdagPart);
         }
         c.setStatus(ComputableObject::Computed);
     }
 }
 
-CreationOperator const& FieldOperatorContainer::getCreationOperator(ParticleIndex in) const
-{
+CreationOperator const& FieldOperatorContainer::getCreationOperator(ParticleIndex in) const {
     auto it = mapCreationOperators.find(in);
     if(it == mapCreationOperators.end())
         throw std::runtime_error("Creation operator not found.");
@@ -31,8 +29,7 @@ CreationOperator const& FieldOperatorContainer::getCreationOperator(ParticleInde
         return it->second;
 }
 
-AnnihilationOperator const& FieldOperatorContainer::getAnnihilationOperator(ParticleIndex in) const
-{
+AnnihilationOperator const& FieldOperatorContainer::getAnnihilationOperator(ParticleIndex in) const {
     auto it = mapAnnihilationOperators.find(in);
     if(it == mapAnnihilationOperators.end())
         throw std::runtime_error("Annihilation operator not found.");

--- a/src/pomerol/GFContainer.cpp
+++ b/src/pomerol/GFContainer.cpp
@@ -2,28 +2,23 @@
 
 namespace Pomerol {
 
-void GFContainer::prepareAll(std::set<IndexCombination2> const& InitialIndices)
-{
+void GFContainer::prepareAll(std::set<IndexCombination2> const& InitialIndices) {
     fill(InitialIndices);
-    for(auto & el : ElementsMap)
+    for(auto& el : ElementsMap)
         el.second->prepare();
 }
 
-void GFContainer::computeAll()
-{
-    for(auto & el : ElementsMap)
+void GFContainer::computeAll() {
+    for(auto& el : ElementsMap)
         el.second->compute();
 }
 
-std::shared_ptr<GreensFunction> GFContainer::createElement(IndexCombination2 const& Indices) const
-{
-    return std::make_shared<GreensFunction>(
-        S,
-        H,
-        Operators.getAnnihilationOperator(Indices.Index1),
-        Operators.getCreationOperator(Indices.Index2),
-        DM
-    );
+std::shared_ptr<GreensFunction> GFContainer::createElement(IndexCombination2 const& Indices) const {
+    return std::make_shared<GreensFunction>(S,
+                                            H,
+                                            Operators.getAnnihilationOperator(Indices.Index1),
+                                            Operators.getCreationOperator(Indices.Index2),
+                                            DM);
 }
 
 } // namespace Pomerol

--- a/src/pomerol/GreensFunction.cpp
+++ b/src/pomerol/GreensFunction.cpp
@@ -5,21 +5,27 @@
 
 namespace Pomerol {
 
-GreensFunction::GreensFunction(StatesClassification const& S, Hamiltonian const& H,
-                               AnnihilationOperator const& C, CreationOperator const& CX,
-                               DensityMatrix const& DM) :
-    Thermal(DM.beta), ComputableObject(), S(S), H(H), C(C), CX(CX), DM(DM)
-{
-}
+GreensFunction::GreensFunction(StatesClassification const& S,
+                               Hamiltonian const& H,
+                               AnnihilationOperator const& C,
+                               CreationOperator const& CX,
+                               DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), S(S), H(H), C(C), CX(CX), DM(DM) {}
 
-GreensFunction::GreensFunction(GreensFunction const& GF) :
-    Thermal(GF.beta), ComputableObject(GF), S(GF.S), H(GF.H), C(GF.C), CX(GF.CX), DM(GF.DM), Vanishing(GF.Vanishing), parts(GF.parts)
-{
-}
+GreensFunction::GreensFunction(GreensFunction const& GF)
+    : Thermal(GF.beta),
+      ComputableObject(GF),
+      S(GF.S),
+      H(GF.H),
+      C(GF.C),
+      CX(GF.CX),
+      DM(GF.DM),
+      Vanishing(GF.Vanishing),
+      parts(GF.parts) {}
 
-void GreensFunction::prepare()
-{
-    if(getStatus() >= Prepared) return;
+void GreensFunction::prepare() {
+    if(getStatus() >= Prepared)
+        return;
 
     // Find out non-trivial blocks of C and CX.
     MonomialOperator::BlocksBimap const& CNontrivialBlocks = C.getBlockMapping();
@@ -28,7 +34,7 @@ void GreensFunction::prepare()
     auto Citer = CNontrivialBlocks.left.begin();
     auto CXiter = CXNontrivialBlocks.right.begin();
 
-    while(Citer != CNontrivialBlocks.left.end() && CXiter != CXNontrivialBlocks.right.end()){
+    while(Citer != CNontrivialBlocks.left.end() && CXiter != CXNontrivialBlocks.right.end()) {
         // <Cleft|C|Cright><CXleft|CX|CXright>
         BlockNumber Cleft = Citer->first;
         BlockNumber Cright = Citer->second;
@@ -36,22 +42,25 @@ void GreensFunction::prepare()
         BlockNumber CXright = CXiter->first;
 
         // Select a relevant 'world stripe' (sequence of blocks).
-        if(Cleft == CXright && Cright == CXleft){
+        if(Cleft == CXright && Cright == CXleft) {
             // check if retained blocks are included. If not, do not push.
-            if (DM.isRetained(Cleft) || DM.isRetained(Cright)) {
-                parts.emplace_back(
-                              C.getPartFromLeftIndex(Cleft),
-                              CX.getPartFromRightIndex(CXright),
-                              H.getPart(Cright), H.getPart(Cleft),
-                              DM.getPart(Cright), DM.getPart(Cleft));
+            if(DM.isRetained(Cleft) || DM.isRetained(Cright)) {
+                parts.emplace_back(C.getPartFromLeftIndex(Cleft),
+                                   CX.getPartFromRightIndex(CXright),
+                                   H.getPart(Cright),
+                                   H.getPart(Cleft),
+                                   DM.getPart(Cright),
+                                   DM.getPart(Cleft));
             }
         }
 
         unsigned long CleftInt = Cleft;
         unsigned long CXrightInt = CXright;
 
-        if(CleftInt <= CXrightInt) Citer++;
-        if(CleftInt >= CXrightInt) CXiter++;
+        if(CleftInt <= CXrightInt)
+            Citer++;
+        if(CleftInt >= CXrightInt)
+            CXiter++;
     }
     if(!parts.empty())
         Vanishing = false;
@@ -59,26 +68,25 @@ void GreensFunction::prepare()
     setStatus(Prepared);
 }
 
-void GreensFunction::compute()
-{
-    if(getStatus() >= Computed) return;
+void GreensFunction::compute() {
+    if(getStatus() >= Computed)
+        return;
     if(getStatus() < Prepared)
         prepare();
 
-    if(getStatus() < Computed){
-        for(auto & p : parts)
+    if(getStatus() < Computed) {
+        for(auto& p : parts)
             p.compute();
     }
 
     setStatus(Computed);
 }
 
-unsigned short GreensFunction::getIndex(std::size_t Position) const
-{
-    switch(Position){
-        case 0: return C.getIndex();
-        case 1: return CX.getIndex();
-        default: throw std::runtime_error("GreensFunction: Wrong operator");
+unsigned short GreensFunction::getIndex(std::size_t Position) const {
+    switch(Position) {
+    case 0: return C.getIndex();
+    case 1: return CX.getIndex();
+    default: throw std::runtime_error("GreensFunction: Wrong operator");
     }
 }
 

--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -8,12 +8,11 @@
 
 namespace Pomerol {
 
-template<bool C>
-void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& comm)
-{
+template <bool C> void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& comm) {
     BlockNumber NumberOfBlocks = S.getNumberOfBlocks();
     int comm_rank = pMPI::rank(comm);
-    if(!comm_rank) INFO_NONEWLINE("Preparing Hamiltonian parts...");
+    if(!comm_rank)
+        INFO_NONEWLINE("Preparing Hamiltonian parts...");
 
     parts.reserve(NumberOfBlocks);
     for(BlockNumber CurrentBlock = 0; CurrentBlock < NumberOfBlocks; ++CurrentBlock) {
@@ -22,7 +21,7 @@ void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& com
 
     pMPI::mpi_skel<pMPI::PrepareWrap<HamiltonianPart>> skel;
     skel.parts.reserve(parts.size());
-    for(auto & part: parts) {
+    for(auto& part : parts) {
         skel.parts.emplace_back(pMPI::PrepareWrap<HamiltonianPart>(part));
     }
     std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, false);
@@ -31,17 +30,17 @@ void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& com
     MPI_Datatype H_dt = C ? MPI_CXX_DOUBLE_COMPLEX : MPI_DOUBLE;
 
     for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
-        auto & part = parts[p];
-        if (comm_rank == job_map[p]) {
-            if (part.getStatus() != HamiltonianPart::Prepared) {
-                ERROR ("Worker" << comm_rank << " didn't calculate part" << p);
+        auto& part = parts[p];
+        if(comm_rank == job_map[p]) {
+            if(part.getStatus() != HamiltonianPart::Prepared) {
+                ERROR("Worker" << comm_rank << " didn't calculate part" << p);
                 throw std::logic_error("Worker didn't calculate this part.");
             }
-            auto & H = part.getMatrix<C>();
+            auto& H = part.getMatrix<C>();
             MPI_Bcast(H.data(), H.size(), H_dt, comm_rank, comm);
         } else {
             part.initHMatrix<C>();
-            auto & H = part.getMatrix<C>();
+            auto& H = part.getMatrix<C>();
             MPI_Bcast(H.data(), H.rows() * H.cols(), H_dt, job_map[p], comm);
             part.setStatus(HamiltonianPart::Prepared);
         }
@@ -51,14 +50,12 @@ void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& com
 template void Hamiltonian::prepareImpl<true>(LOperatorTypeRC<true> const&, MPI_Comm const&);
 template void Hamiltonian::prepareImpl<false>(LOperatorTypeRC<false> const&, MPI_Comm const&);
 
-template<bool C>
-void Hamiltonian::computeImpl(MPI_Comm const& comm)
-{
+template <bool C> void Hamiltonian::computeImpl(MPI_Comm const& comm) {
     // Create a "skeleton" class with pointers to part that can call a compute method
     pMPI::mpi_skel<pMPI::ComputeWrap<HamiltonianPart>> skel;
     skel.parts.reserve(parts.size());
-    for (auto & part: parts) {
-      skel.parts.emplace_back(pMPI::ComputeWrap<HamiltonianPart>(part, static_cast<int>(part.getSize())));
+    for(auto& part : parts) {
+        skel.parts.emplace_back(pMPI::ComputeWrap<HamiltonianPart>(part, static_cast<int>(part.getSize())));
     }
     std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, true);
     int comm_rank = pMPI::rank(comm);
@@ -66,38 +63,28 @@ void Hamiltonian::computeImpl(MPI_Comm const& comm)
     // Start distributing data
     MPI_Barrier(comm);
     MPI_Datatype H_dt = C ? MPI_CXX_DOUBLE_COMPLEX : MPI_DOUBLE;
-    for (int p = 0; p < static_cast<int>(parts.size()); ++p) {
-        auto & part = parts[p];
-        auto & H = part.getMatrix<C>();
-        if (comm_rank == job_map[p]){
-            if (part.Status != HamiltonianPart::Computed) {
-                ERROR ("Worker" << comm_rank << " didn't calculate part" << p);
+    for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
+        auto& part = parts[p];
+        auto& H = part.getMatrix<C>();
+        if(comm_rank == job_map[p]) {
+            if(part.Status != HamiltonianPart::Computed) {
+                ERROR("Worker" << comm_rank << " didn't calculate part" << p);
                 throw std::logic_error("Worker didn't calculate this part.");
             }
             MPI_Bcast(H.data(), H.size(), H_dt, comm_rank, comm);
-            MPI_Bcast(part.Eigenvalues.data(),
-                      static_cast<int>(part.Eigenvalues.size()),
-                      MPI_DOUBLE,
-                      comm_rank,
-                      comm
-                    );
+            MPI_Bcast(part.Eigenvalues.data(), static_cast<int>(part.Eigenvalues.size()), MPI_DOUBLE, comm_rank, comm);
         } else {
             part.Eigenvalues.resize(H.rows());
             MPI_Bcast(H.data(), H.size(), H_dt, job_map[p], comm);
-            MPI_Bcast(part.Eigenvalues.data(),
-                      static_cast<int>(part.Eigenvalues.size()),
-                      MPI_DOUBLE,
-                      job_map[p],
-                      comm
-                     );
+            MPI_Bcast(part.Eigenvalues.data(), static_cast<int>(part.Eigenvalues.size()), MPI_DOUBLE, job_map[p], comm);
             part.Status = HamiltonianPart::Computed;
         }
     }
 }
 
-void Hamiltonian::compute(MPI_Comm const& comm)
-{
-    if (getStatus() >= Computed) return;
+void Hamiltonian::compute(MPI_Comm const& comm) {
+    if(getStatus() >= Computed)
+        return;
 
     if(Complex)
         computeImpl<true>(comm);
@@ -109,38 +96,32 @@ void Hamiltonian::compute(MPI_Comm const& comm)
     setStatus(Computed);
 }
 
-void Hamiltonian::reduce(RealType Cutoff)
-{
+void Hamiltonian::reduce(RealType Cutoff) {
     INFO("Performing EV cutoff at " << Cutoff << " level");
-    for(auto & part : parts)
+    for(auto& part : parts)
         part.reduce(GroundEnergy + Cutoff);
 }
 
-InnerQuantumState Hamiltonian::getBlockSize(BlockNumber Block) const
-{
+InnerQuantumState Hamiltonian::getBlockSize(BlockNumber Block) const {
     return parts[Block].getSize();
 }
 
-void Hamiltonian::computeGroundEnergy()
-{
+void Hamiltonian::computeGroundEnergy() {
     RealVectorType lev(S.getNumberOfBlocks());
     for(BlockNumber b = 0; b < parts.size(); ++b)
         lev(b) = parts[b].getMinimumEigenvalue();
     GroundEnergy = lev.minCoeff();
 }
 
-RealType Hamiltonian::getEigenValue(QuantumState state) const
-{
+RealType Hamiltonian::getEigenValue(QuantumState state) const {
     return parts[S.getBlockNumber(state)].getEigenValue(S.getInnerState(state));
 }
 
-RealVectorType const& Hamiltonian::getEigenValues(BlockNumber Block) const
-{
+RealVectorType const& Hamiltonian::getEigenValues(BlockNumber Block) const {
     return parts[Block].getEigenValues();
 }
 
-RealVectorType Hamiltonian::getEigenValues() const
-{
+RealVectorType Hamiltonian::getEigenValues() const {
     RealVectorType out(S.getNumberOfStates());
     long copied_size = 0;
     for(auto const& part : parts) {

--- a/src/pomerol/HamiltonianPart.cpp
+++ b/src/pomerol/HamiltonianPart.cpp
@@ -19,15 +19,14 @@
 
 namespace Pomerol {
 
-template<bool C>
-void HamiltonianPart::initHMatrix() {
+template <bool C> void HamiltonianPart::initHMatrix() {
     InnerQuantumState BlockSize = S.getBlockSize(Block);
     HMatrix = std::make_shared<MatrixType<C>>(BlockSize, BlockSize);
 }
 
-void HamiltonianPart::prepare()
-{
-    if(getStatus() >= Prepared) return;
+void HamiltonianPart::prepare() {
+    if(getStatus() >= Prepared)
+        return;
 
     if(isComplex())
         prepareImpl<true>();
@@ -37,12 +36,11 @@ void HamiltonianPart::prepare()
     setStatus(Prepared);
 }
 
-template<bool C> void HamiltonianPart::prepareImpl()
-{
+template <bool C> void HamiltonianPart::prepareImpl() {
     initHMatrix<C>();
 
     auto const& HOp_ = *static_cast<LOperatorTypeRC<C> const*>(HOp);
-    auto & HMatrix_ = getMatrix<C>();
+    auto& HMatrix_ = getMatrix<C>();
 
     auto mapper = libcommute::basis_mapper(S.getFockStates(Block));
 
@@ -57,13 +55,12 @@ template<bool C> void HamiltonianPart::prepareImpl()
         ket(st) = .0; // cppcheck-suppress redundantAssignment
     }
 
-    assert((HMatrix_.adjoint() - HMatrix_).array().abs().maxCoeff()
-           < 100*std::numeric_limits<RealType>::epsilon());
+    assert((HMatrix_.adjoint() - HMatrix_).array().abs().maxCoeff() < 100 * std::numeric_limits<RealType>::epsilon());
 }
 
-void HamiltonianPart::compute()
-{
-    if(getStatus() >= Computed) return;
+void HamiltonianPart::compute() {
+    if(getStatus() >= Computed)
+        return;
 
     if(isComplex())
         computeImpl<true>();
@@ -73,14 +70,13 @@ void HamiltonianPart::compute()
     setStatus(Computed);
 }
 
-template<bool C> void HamiltonianPart::computeImpl()
-{
-    auto & HMatrix_ = getMatrix<C>();
-    if (HMatrix_.rows() == 1) {
-        assert (std::abs(HMatrix_(0,0) - std::real(HMatrix_(0,0))) < std::numeric_limits<RealType>::epsilon());
+template <bool C> void HamiltonianPart::computeImpl() {
+    auto& HMatrix_ = getMatrix<C>();
+    if(HMatrix_.rows() == 1) {
+        assert(std::abs(HMatrix_(0, 0) - std::real(HMatrix_(0, 0))) < std::numeric_limits<RealType>::epsilon());
         Eigenvalues.resize(1);
-        Eigenvalues << std::real(HMatrix_(0,0));
-        HMatrix_(0,0) = 1;
+        Eigenvalues << std::real(HMatrix_(0, 0));
+        HMatrix_(0, 0) = 1;
     } else {
         Eigen::SelfAdjointEigenSolver<MatrixType<C>> Solver(HMatrix_, Eigen::ComputeEigenvectors);
         HMatrix_ = Solver.eigenvectors();
@@ -88,7 +84,7 @@ template<bool C> void HamiltonianPart::computeImpl()
     }
 }
 
-template<bool C> MatrixType<C> const& HamiltonianPart::getMatrix() const {
+template <bool C> MatrixType<C> const& HamiltonianPart::getMatrix() const {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<const MatrixType<C>>(HMatrix);
@@ -96,7 +92,7 @@ template<bool C> MatrixType<C> const& HamiltonianPart::getMatrix() const {
 template MatrixType<true> const& HamiltonianPart::getMatrix<true>() const;
 template MatrixType<false> const& HamiltonianPart::getMatrix<false>() const;
 
-template<bool C> MatrixType<C>& HamiltonianPart::getMatrix() {
+template <bool C> MatrixType<C>& HamiltonianPart::getMatrix() {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<MatrixType<C>>(HMatrix);
@@ -104,58 +100,51 @@ template<bool C> MatrixType<C>& HamiltonianPart::getMatrix() {
 template MatrixType<true>& HamiltonianPart::getMatrix<true>();
 template MatrixType<false>& HamiltonianPart::getMatrix<false>();
 
-void HamiltonianPart::checkComputed() const
-{
+void HamiltonianPart::checkComputed() const {
     if(getStatus() < Computed)
         throw StatusMismatch("HamiltonianPart is not computed yet.");
 }
 
-RealType HamiltonianPart::getEigenValue(InnerQuantumState state) const
-{
+RealType HamiltonianPart::getEigenValue(InnerQuantumState state) const {
     checkComputed();
     return Eigenvalues(static_cast<Eigen::Index>(state));
 }
 
-RealVectorType const& HamiltonianPart::getEigenValues() const
-{
+RealVectorType const& HamiltonianPart::getEigenValues() const {
     checkComputed();
     return Eigenvalues;
 }
 
-InnerQuantumState HamiltonianPart::getSize() const
-{
+InnerQuantumState HamiltonianPart::getSize() const {
     return S.getBlockSize(Block);
 }
 
-template<bool C>
-VectorType<C> HamiltonianPart::getEigenState(InnerQuantumState state) const
-{
+template <bool C> VectorType<C> HamiltonianPart::getEigenState(InnerQuantumState state) const {
     checkComputed();
     return getMatrix<C>()->col(state);
 }
 
-RealType HamiltonianPart::getMinimumEigenvalue() const
-{
+RealType HamiltonianPart::getMinimumEigenvalue() const {
     checkComputed();
     return Eigenvalues.minCoeff();
 }
 
-bool HamiltonianPart::reduce(RealType ActualCutoff)
-{
+bool HamiltonianPart::reduce(RealType ActualCutoff) {
     checkComputed();
 
     Eigen::Index counter = 0;
-    for (counter=0; counter < Eigenvalues.size() && Eigenvalues[counter]<=ActualCutoff; ++counter);
+    for(counter = 0; counter < Eigenvalues.size() && Eigenvalues[counter] <= ActualCutoff; ++counter)
+        ;
     INFO("Left " << counter << " eigenvalues : ");
 
-    if (counter) {
+    if(counter) {
         INFO(Eigenvalues.head(counter) << std::endl << "_________");
         Eigenvalues = Eigenvalues.head(counter);
         if(isComplex()) {
-            auto & HMatrix_ = getMatrix<true>();
+            auto& HMatrix_ = getMatrix<true>();
             HMatrix_ = HMatrix_.topLeftCorner(counter, counter);
         } else {
-            auto & HMatrix_ = getMatrix<false>();
+            auto& HMatrix_ = getMatrix<false>();
             HMatrix_ = HMatrix_.topLeftCorner(counter, counter);
         }
         return true;
@@ -164,4 +153,3 @@ bool HamiltonianPart::reduce(RealType ActualCutoff)
 }
 
 } // namespace Pomerol
-

--- a/src/pomerol/LatticePresets.cpp
+++ b/src/pomerol/LatticePresets.cpp
@@ -15,12 +15,11 @@ using Operators::a;
 // spin
 //
 
-std::ostream & operator<<(std::ostream & os, spin s)
-{
+std::ostream& operator<<(std::ostream& os, spin s) {
     switch(s) {
-      case undef: return os;
-      case up: return os << "up";
-      case down: return os << "dn";
+    case undef: return os;
+    case up: return os << "up";
+    case down: return os << "dn";
     }
 }
 
@@ -28,17 +27,14 @@ std::ostream & operator<<(std::ostream & os, spin s)
 // 2-index presets
 //
 
-RealExpr Level(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin)
-{
+RealExpr Level(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin) {
     return Value * n(Label, Orbital, Spin);
 }
-ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin)
-{
+ComplexExpr Level(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin) {
     return Value * n(Label, Orbital, Spin);
 }
 
-RealExpr Level(std::string const& Label, RealType Level, unsigned short NOrbitals)
-{
+RealExpr Level(std::string const& Label, RealType Level, unsigned short NOrbitals) {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Level(Label, Level, Orbital, up);
@@ -47,8 +43,7 @@ RealExpr Level(std::string const& Label, RealType Level, unsigned short NOrbital
     return res;
 }
 
-ComplexExpr Level(std::string const& Label, ComplexType Level, unsigned short NOrbitals)
-{
+ComplexExpr Level(std::string const& Label, ComplexType Level, unsigned short NOrbitals) {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Level(Label, Level, Orbital, up);
@@ -57,35 +52,51 @@ ComplexExpr Level(std::string const& Label, ComplexType Level, unsigned short NO
     return res;
 }
 
-RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+RealExpr Hopping(std::string const& Label1,
+                 std::string const& Label2,
+                 RealType t,
+                 unsigned short Orbital1,
+                 unsigned short Orbital2,
+                 spin Spin1,
+                 spin Spin2) {
     return (t * c_dag(Label1, Orbital1, Spin1) * c(Label2, Orbital2, Spin2)) + Operators::hc;
 }
-ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+ComplexExpr Hopping(std::string const& Label1,
+                    std::string const& Label2,
+                    ComplexType t,
+                    unsigned short Orbital1,
+                    unsigned short Orbital2,
+                    spin Spin1,
+                    spin Spin2) {
     return (t * c_dag(Label1, Orbital1, Spin1) * c(Label2, Orbital2, Spin2)) + Operators::hc;
 }
 
-RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital, spin Spin)
-{
+RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital, spin Spin) {
     return Hopping(Label1, Label2, t, Orbital, Orbital, Spin, Spin);
 }
-ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital, spin Spin)
-{
+ComplexExpr
+Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short Orbital, spin Spin) {
     return Hopping(Label1, Label2, t, Orbital, Orbital, Spin, Spin);
 }
 
-RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short Orbital1, unsigned short Orbital2)
-{
-    return Hopping(Label1, Label2, t, Orbital1, Orbital2, up, up) + Hopping(Label1, Label2, t, Orbital1, Orbital2, down, down);
+RealExpr Hopping(std::string const& Label1,
+                 std::string const& Label2,
+                 RealType t,
+                 unsigned short Orbital1,
+                 unsigned short Orbital2) {
+    return Hopping(Label1, Label2, t, Orbital1, Orbital2, up, up) +
+           Hopping(Label1, Label2, t, Orbital1, Orbital2, down, down);
 }
-ComplexExpr Hopping(std::string const&Label1, std::string const& Label2, ComplexType t, unsigned short Orbital1, unsigned short Orbital2)
-{
-    return Hopping(Label1, Label2, t, Orbital1, Orbital2, up, up) + Hopping(Label1, Label2, t, Orbital1, Orbital2, down, down);
+ComplexExpr Hopping(std::string const& Label1,
+                    std::string const& Label2,
+                    ComplexType t,
+                    unsigned short Orbital1,
+                    unsigned short Orbital2) {
+    return Hopping(Label1, Label2, t, Orbital1, Orbital2, up, up) +
+           Hopping(Label1, Label2, t, Orbital1, Orbital2, down, down);
 }
 
-RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short NOrbitals)
-{
+RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType t, unsigned short NOrbitals) {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Hopping(Label1, Label2, t, Orbital, up);
@@ -93,8 +104,7 @@ RealExpr Hopping(std::string const& Label1, std::string const& Label2, RealType 
     }
     return res;
 }
-ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short NOrbitals)
-{
+ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, ComplexType t, unsigned short NOrbitals) {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Hopping(Label1, Label2, t, Orbital, up);
@@ -107,101 +117,133 @@ ComplexExpr Hopping(std::string const& Label1, std::string const& Label2, Comple
 // 4-index presets
 //
 
-RealExpr NupNdown(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+RealExpr NupNdown(std::string const& Label1,
+                  std::string const& Label2,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1,
+                  spin Spin2) {
     return Value * n(Label1, Orbital1, Spin1) * n(Label2, Orbital2, Spin2);
 }
-ComplexExpr NupNdown(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+ComplexExpr NupNdown(std::string const& Label1,
+                     std::string const& Label2,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2) {
     return Value * n(Label1, Orbital1, Spin1) * n(Label2, Orbital2, Spin2);
 }
 
-RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+RealExpr NupNdown(std::string const& Label,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1,
+                  spin Spin2) {
     return NupNdown(Label, Label, Value, Orbital1, Orbital2, Spin1, Spin2);
 }
-ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
+ComplexExpr NupNdown(std::string const& Label,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2) {
     return NupNdown(Label, Label, Value, Orbital1, Orbital2, Spin1, Spin2);
 }
 
-RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2)
-{
+RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2) {
     return NupNdown(Label, Label, Value, Orbital1, Orbital2, up, down);
 }
-ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2)
-{
+ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2) {
     return NupNdown(Label, Label, Value, Orbital1, Orbital2, up, down);
 }
 
-RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin1, spin Spin2)
-{
+RealExpr NupNdown(std::string const& Label, RealType Value, unsigned short Orbital, spin Spin1, spin Spin2) {
     return NupNdown(Label, Label, Value, Orbital, Orbital, Spin1, Spin2);
 }
-ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin1, spin Spin2)
-{
+ComplexExpr NupNdown(std::string const& Label, ComplexType Value, unsigned short Orbital, spin Spin1, spin Spin2) {
     return NupNdown(Label, Label, Value, Orbital, Orbital, Spin1, Spin2);
 }
 
-RealExpr Spinflip(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
-    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital2, Spin2) * c(Label, Orbital2, Spin1) * c(Label, Orbital1, Spin2);
+RealExpr Spinflip(std::string const& Label,
+                  RealType Value,
+                  unsigned short Orbital1,
+                  unsigned short Orbital2,
+                  spin Spin1,
+                  spin Spin2) {
+    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital2, Spin2) * c(Label, Orbital2, Spin1) *
+           c(Label, Orbital1, Spin2);
 }
-ComplexExpr Spinflip(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
-    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital2, Spin2) * c(Label, Orbital2, Spin1) * c(Label, Orbital1, Spin2);
-}
-
-RealExpr PairHopping(std::string const& Label, RealType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
-    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital1, Spin2) * c(Label, Orbital2, Spin1) * c(Label, Orbital2, Spin2);
-}
-ComplexExpr PairHopping(std::string const& Label, ComplexType Value, unsigned short Orbital1, unsigned short Orbital2, spin Spin1, spin Spin2)
-{
-    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital1, Spin2) * c(Label, Orbital2, Spin1) * c(Label, Orbital2, Spin2);
-}
-
-RealExpr SplusSminus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital)
-{
-    return Value * c_dag(Label1, Orbital, up) * c(Label1, Orbital, down) * c_dag(Label2, Orbital, down) * c(Label2, Orbital, up);
-}
-ComplexExpr SplusSminus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital)
-{
-    return Value * c_dag(Label1, Orbital, up) * c(Label1, Orbital, down) * c_dag(Label2, Orbital, down) * c(Label2, Orbital, up);
+ComplexExpr Spinflip(std::string const& Label,
+                     ComplexType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2) {
+    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital2, Spin2) * c(Label, Orbital2, Spin1) *
+           c(Label, Orbital1, Spin2);
 }
 
-RealExpr SminusSplus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital)
-{
-    return Value * c_dag(Label1, Orbital, down) * c(Label1, Orbital, up) * c_dag(Label2, Orbital, up) * c(Label2, Orbital, down);
+RealExpr PairHopping(std::string const& Label,
+                     RealType Value,
+                     unsigned short Orbital1,
+                     unsigned short Orbital2,
+                     spin Spin1,
+                     spin Spin2) {
+    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital1, Spin2) * c(Label, Orbital2, Spin1) *
+           c(Label, Orbital2, Spin2);
 }
-ComplexExpr SminusSplus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital)
-{
-    return Value * c_dag(Label1, Orbital, down) * c(Label1, Orbital, up) * c_dag(Label2, Orbital, up) * c(Label2, Orbital, down);
+ComplexExpr PairHopping(std::string const& Label,
+                        ComplexType Value,
+                        unsigned short Orbital1,
+                        unsigned short Orbital2,
+                        spin Spin1,
+                        spin Spin2) {
+    return Value * c_dag(Label, Orbital1, Spin1) * c_dag(Label, Orbital1, Spin2) * c(Label, Orbital2, Spin1) *
+           c(Label, Orbital2, Spin2);
 }
 
-RealExpr CoulombS(std::string const& Label, RealType U, RealType Level, unsigned short NOrbitals)
-{
+RealExpr SplusSminus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital) {
+    return Value * c_dag(Label1, Orbital, up) * c(Label1, Orbital, down) * c_dag(Label2, Orbital, down) *
+           c(Label2, Orbital, up);
+}
+ComplexExpr
+SplusSminus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital) {
+    return Value * c_dag(Label1, Orbital, up) * c(Label1, Orbital, down) * c_dag(Label2, Orbital, down) *
+           c(Label2, Orbital, up);
+}
+
+RealExpr SminusSplus(std::string const& Label1, std::string const& Label2, RealType Value, unsigned short Orbital) {
+    return Value * c_dag(Label1, Orbital, down) * c(Label1, Orbital, up) * c_dag(Label2, Orbital, up) *
+           c(Label2, Orbital, down);
+}
+ComplexExpr
+SminusSplus(std::string const& Label1, std::string const& Label2, ComplexType Value, unsigned short Orbital) {
+    return Value * c_dag(Label1, Orbital, down) * c(Label1, Orbital, up) * c_dag(Label2, Orbital, up) *
+           c(Label2, Orbital, down);
+}
+
+RealExpr CoulombS(std::string const& Label, RealType U, RealType Level, unsigned short NOrbitals) {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
-        res += LatticePresets::Level(Label, Level, Orbital, up)
-             + LatticePresets::Level(Label, Level, Orbital, down)
-             + LatticePresets::NupNdown(Label, U, Orbital, Orbital, up, down);
+        res += LatticePresets::Level(Label, Level, Orbital, up) + LatticePresets::Level(Label, Level, Orbital, down) +
+               LatticePresets::NupNdown(Label, U, Orbital, Orbital, up, down);
     }
     return res;
 }
-ComplexExpr CoulombS(std::string const& Label, ComplexType U, ComplexType Level, unsigned short NOrbitals)
-{
+ComplexExpr CoulombS(std::string const& Label, ComplexType U, ComplexType Level, unsigned short NOrbitals) {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
-        res += LatticePresets::Level(Label, Level, Orbital, up)
-             + LatticePresets::Level(Label, Level, Orbital, down)
-             + LatticePresets::NupNdown(Label, U, Orbital, Orbital, up, down);
+        res += LatticePresets::Level(Label, Level, Orbital, up) + LatticePresets::Level(Label, Level, Orbital, down) +
+               LatticePresets::NupNdown(Label, U, Orbital, Orbital, up, down);
     }
     return res;
 }
 
-RealExpr CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J, RealType Level, unsigned short NOrbitals)
-{
+RealExpr
+CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J, RealType Level, unsigned short NOrbitals) {
     if(NOrbitals < 2)
         throw std::runtime_error("Cannot add multiorbital interaction to a site with 1 orbital");
     RealExpr res;
@@ -209,10 +251,11 @@ RealExpr CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J
         for(spin s1 : {up, down}) {
             res += LatticePresets::Level(Label, Level, Orbital1, s1);
             for(unsigned short Orbital2 = 0; Orbital2 < NOrbitals; ++Orbital2)
-                if (Orbital1 != Orbital2)
+                if(Orbital1 != Orbital2)
                     res += LatticePresets::NupNdown(Label, (U_p - J) / 2.0, Orbital1, Orbital2, s1, s1);
             for(spin s2 : {up, down}) {
-                if(s2 >= s1) continue;
+                if(s2 >= s1)
+                    continue;
                 res += LatticePresets::NupNdown(Label, U, Orbital1, Orbital1, s1, s2);
                 for(unsigned short Orbital2 = 0; Orbital2 < NOrbitals; ++Orbital2) {
                     if(Orbital1 != Orbital2) {
@@ -226,8 +269,12 @@ RealExpr CoulombP(std::string const& Label, RealType U, RealType U_p, RealType J
     }
     return res;
 }
-ComplexExpr CoulombP(std::string const& Label, ComplexType U, ComplexType U_p, ComplexType J, ComplexType Level, unsigned short NOrbitals)
-{
+ComplexExpr CoulombP(std::string const& Label,
+                     ComplexType U,
+                     ComplexType U_p,
+                     ComplexType J,
+                     ComplexType Level,
+                     unsigned short NOrbitals) {
     if(NOrbitals < 2)
         throw std::runtime_error("Cannot add multiorbital interaction to a site with 1 orbital");
     ComplexExpr res;
@@ -235,10 +282,11 @@ ComplexExpr CoulombP(std::string const& Label, ComplexType U, ComplexType U_p, C
         for(spin s1 : {up, down}) {
             res += LatticePresets::Level(Label, Level, Orbital1, s1);
             for(unsigned short Orbital2 = 0; Orbital2 < NOrbitals; ++Orbital2)
-                if (Orbital1 != Orbital2)
+                if(Orbital1 != Orbital2)
                     res += LatticePresets::NupNdown(Label, (U_p - J) / 2.0, Orbital1, Orbital2, s1, s1);
             for(spin s2 : {up, down}) {
-                if(s2 >= s1) continue;
+                if(s2 >= s1)
+                    continue;
                 res += LatticePresets::NupNdown(Label, U, Orbital1, Orbital1, s1, s2);
                 for(unsigned short Orbital2 = 0; Orbital2 < NOrbitals; ++Orbital2) {
                     if(Orbital1 != Orbital2) {
@@ -253,17 +301,15 @@ ComplexExpr CoulombP(std::string const& Label, ComplexType U, ComplexType U_p, C
     return res;
 }
 
-RealExpr CoulombP(std::string const& Label, RealType U, RealType J, RealType Level, unsigned short NOrbitals)
-{
+RealExpr CoulombP(std::string const& Label, RealType U, RealType J, RealType Level, unsigned short NOrbitals) {
     return CoulombP(Label, U, U - 2.0 * J, J, Level, NOrbitals);
 }
-ComplexExpr addCoulombP(std::string const& Label, ComplexType U, ComplexType J, ComplexType Level, unsigned short NOrbitals)
-{
+ComplexExpr
+addCoulombP(std::string const& Label, ComplexType U, ComplexType J, ComplexType Level, unsigned short NOrbitals) {
     return CoulombP(Label, U, U - 2.0 * J, J, Level, NOrbitals);
 }
 
-RealExpr Magnetization(std::string const& Label, RealType Magnetization, unsigned short NOrbitals)
-{
+RealExpr Magnetization(std::string const& Label, RealType Magnetization, unsigned short NOrbitals) {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Level(Label, Magnetization, Orbital, up);
@@ -272,8 +318,7 @@ RealExpr Magnetization(std::string const& Label, RealType Magnetization, unsigne
     return res;
 }
 
-ComplexExpr Magnetization(std::string const& Label, ComplexType Magnetization, unsigned short NOrbitals)
-{
+ComplexExpr Magnetization(std::string const& Label, ComplexType Magnetization, unsigned short NOrbitals) {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         res += LatticePresets::Level(Label, Magnetization, Orbital, up);
@@ -282,8 +327,7 @@ ComplexExpr Magnetization(std::string const& Label, ComplexType Magnetization, u
     return res;
 }
 
-RealExpr SzSz(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals)
-{
+RealExpr SzSz(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals) {
     RealExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         LatticePresets::NupNdown(Label1, Label2, -ExchJ / 4., Orbital, Orbital, up, down);
@@ -299,8 +343,7 @@ RealExpr SzSz(std::string const& Label1, std::string const& Label2, RealType Exc
     return res;
 }
 
-ComplexExpr SzSz(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals)
-{
+ComplexExpr SzSz(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals) {
     ComplexExpr res;
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         LatticePresets::NupNdown(Label1, Label2, -ExchJ / 4., Orbital, Orbital, up, down);
@@ -316,8 +359,7 @@ ComplexExpr SzSz(std::string const& Label1, std::string const& Label2, ComplexTy
     return res;
 }
 
-RealExpr SS(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals)
-{
+RealExpr SS(std::string const& Label1, std::string const& Label2, RealType ExchJ, unsigned short NOrbitals) {
     RealExpr res = SzSz(Label1, Label2, ExchJ, NOrbitals);
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         LatticePresets::SplusSminus(Label1, Label2, ExchJ / 2., Orbital);
@@ -326,8 +368,7 @@ RealExpr SS(std::string const& Label1, std::string const& Label2, RealType ExchJ
     return res;
 }
 
-ComplexExpr SS(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals)
-{
+ComplexExpr SS(std::string const& Label1, std::string const& Label2, ComplexType ExchJ, unsigned short NOrbitals) {
     ComplexExpr res = SzSz(Label1, Label2, ExchJ, NOrbitals);
     for(unsigned short Orbital = 0; Orbital < NOrbitals; ++Orbital) {
         LatticePresets::SplusSminus(Label1, Label2, ExchJ / 2., Orbital);
@@ -336,39 +377,37 @@ ComplexExpr SS(std::string const& Label1, std::string const& Label2, ComplexType
     return res;
 }
 
-RealExpr BosonLevel(std::string const& Label, RealType Value, unsigned short ExtraIndex)
-{
+RealExpr BosonLevel(std::string const& Label, RealType Value, unsigned short ExtraIndex) {
     return Value * a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
 }
 
-ComplexExpr BosonLevel(std::string const& Label, ComplexType Value, unsigned short ExtraIndex)
-{
+ComplexExpr BosonLevel(std::string const& Label, ComplexType Value, unsigned short ExtraIndex) {
     return Value * a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
 }
 
-RealExpr BosonInteraction(std::string const& Label, RealType Value, unsigned short ExtraIndex)
-{
+RealExpr BosonInteraction(std::string const& Label, RealType Value, unsigned short ExtraIndex) {
     auto nb = a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
     return 0.5 * Value * nb * (nb - 1.0);
 }
 
-ComplexExpr BosonInteraction(std::string const& Label, ComplexType Value, unsigned short ExtraIndex)
-{
+ComplexExpr BosonInteraction(std::string const& Label, ComplexType Value, unsigned short ExtraIndex) {
     auto nb = a_dag(Label, ExtraIndex, undef) * a(Label, ExtraIndex, undef);
     return 0.5 * Value * nb * (nb - 1.0);
 }
 
-RealExpr HolsteinInteraction(std::string const& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex)
-{
+RealExpr
+HolsteinInteraction(std::string const& Label, RealType Value, unsigned short Orbital, unsigned short BosonExtraIndex) {
     auto N = n(Label, Orbital, up) + n(Label, Orbital, down);
     return Value * N * (a_dag(Label, BosonExtraIndex, undef) + a(Label, BosonExtraIndex, undef));
 }
 
-ComplexExpr HolsteinInteraction(std::string const& Label, ComplexType Value, unsigned short Orbital, unsigned short BosonExtraIndex)
-{
+ComplexExpr HolsteinInteraction(std::string const& Label,
+                                ComplexType Value,
+                                unsigned short Orbital,
+                                unsigned short BosonExtraIndex) {
     auto N = n(Label, Orbital, up) + n(Label, Orbital, down);
     return Value * N * (a_dag(Label, BosonExtraIndex, undef) + a(Label, BosonExtraIndex, undef));
 }
 
-} // namespace Pomerol::LatticePresets
+} // namespace LatticePresets
 } // namespace Pomerol

--- a/src/pomerol/Misc.cpp
+++ b/src/pomerol/Misc.cpp
@@ -5,55 +5,45 @@ namespace Pomerol {
 //////////////////
 // Permutation3 //
 //////////////////
-bool Permutation3::operator==(Permutation3 const& rhs) const
-{
-    return (sign==rhs.sign && perm[0] == rhs.perm[0] && perm[1]==rhs.perm[1]);
+bool Permutation3::operator==(Permutation3 const& rhs) const {
+    return (sign == rhs.sign && perm[0] == rhs.perm[0] && perm[1] == rhs.perm[1]);
 }
 
-bool Permutation3::operator!=(Permutation3 const& rhs) const
-{
-    return !(*this==rhs);
+bool Permutation3::operator!=(Permutation3 const& rhs) const {
+    return !(*this == rhs);
 }
 
-std::ostream& operator<<(std::ostream& out, Permutation3 const& p)
-{
-    if(p.sign == -1) out << "-";
-    return out << p.perm[0]+1 << p.perm[1]+1 << p.perm[2]+1;
+std::ostream& operator<<(std::ostream& out, Permutation3 const& p) {
+    if(p.sign == -1)
+        out << "-";
+    return out << p.perm[0] + 1 << p.perm[1] + 1 << p.perm[2] + 1;
 }
 
-std::array<Permutation3, 6> const permutations3 = {{
-    {{0,1,2},1},
-    {{0,2,1},-1},
-    {{1,0,2},-1},
-    {{1,2,0},1},
-    {{2,0,1},1},
-    {{2,1,0},-1}
-}};
+std::array<Permutation3, 6> const permutations3 = {
+    {{{0, 1, 2}, 1}, {{0, 2, 1}, -1}, {{1, 0, 2}, -1}, {{1, 2, 0}, 1}, {{2, 0, 1}, 1}, {{2, 1, 0}, -1}}};
 
 //////////////////
 // Permutation4 //
 //////////////////
-bool Permutation4::operator==(Permutation4 const& rhs) const
-{
-    return (sign==rhs.sign && perm[0] == rhs.perm[0] && perm[1]==rhs.perm[1] && perm[2] == rhs.perm[2]);
+bool Permutation4::operator==(Permutation4 const& rhs) const {
+    return (sign == rhs.sign && perm[0] == rhs.perm[0] && perm[1] == rhs.perm[1] && perm[2] == rhs.perm[2]);
 }
 
-bool Permutation4::operator!=(Permutation4 const& rhs) const
-{
-    return !(*this==rhs);
+bool Permutation4::operator!=(Permutation4 const& rhs) const {
+    return !(*this == rhs);
 }
 
-std::ostream& operator<<(std::ostream& out, Permutation4 const& p)
-{
-    if(p.sign == -1) out << "-";
-    return out << p.perm[0]+1 << p.perm[1]+1 << p.perm[2]+1 << p.perm[3]+1;
+std::ostream& operator<<(std::ostream& out, Permutation4 const& p) {
+    if(p.sign == -1)
+        out << "-";
+    return out << p.perm[0] + 1 << p.perm[1] + 1 << p.perm[2] + 1 << p.perm[3] + 1;
 }
 
-std::array<Permutation4, 24> const permutations4 = {{
-    {{0,1,2,3}, 1},  {{0,1,3,2},-1},  {{0,2,1,3},-1},  {{0,2,3,1}, 1},  {{0,3,1,2}, 1},  {{0,3,2,1},-1},
-    {{1,0,2,3},-1},  {{1,0,3,2}, 1},  {{1,2,0,3}, 1},  {{1,2,3,0},-1},  {{1,3,0,2},-1},  {{1,3,2,0}, 1},
-    {{2,0,1,3}, 1},  {{2,0,3,1},-1},  {{2,1,0,3},-1},  {{2,1,3,0}, 1},  {{2,3,0,1}, 1},  {{2,3,1,0},-1},
-    {{3,0,1,2},-1},  {{3,0,2,1}, 1},  {{3,1,0,2}, 1},  {{3,1,2,0},-1},  {{3,2,0,1},-1},  {{3,2,1,0}, 1}
-}};
+std::array<Permutation4, 24> const permutations4 = {
+    {{{0, 1, 2, 3}, 1},  {{0, 1, 3, 2}, -1}, {{0, 2, 1, 3}, -1}, {{0, 2, 3, 1}, 1},  {{0, 3, 1, 2}, 1},
+     {{0, 3, 2, 1}, -1}, {{1, 0, 2, 3}, -1}, {{1, 0, 3, 2}, 1},  {{1, 2, 0, 3}, 1},  {{1, 2, 3, 0}, -1},
+     {{1, 3, 0, 2}, -1}, {{1, 3, 2, 0}, 1},  {{2, 0, 1, 3}, 1},  {{2, 0, 3, 1}, -1}, {{2, 1, 0, 3}, -1},
+     {{2, 1, 3, 0}, 1},  {{2, 3, 0, 1}, 1},  {{2, 3, 1, 0}, -1}, {{3, 0, 1, 2}, -1}, {{3, 0, 2, 1}, 1},
+     {{3, 1, 0, 2}, 1},  {{3, 1, 2, 0}, -1}, {{3, 2, 0, 1}, -1}, {{3, 2, 1, 0}, 1}}};
 
 } // namespace Pomerol

--- a/src/pomerol/MonomialOperator.cpp
+++ b/src/pomerol/MonomialOperator.cpp
@@ -4,68 +4,60 @@
 
 namespace Pomerol {
 
-void MonomialOperator::checkPrepared() const
-{
+void MonomialOperator::checkPrepared() const {
     if(getStatus() < Prepared) {
         throw StatusMismatch("MonomialOperator is not prepared yet.");
     }
 }
 
-MonomialOperator::BlocksBimap const& MonomialOperator::getBlockMapping() const
-{
+MonomialOperator::BlocksBimap const& MonomialOperator::getBlockMapping() const {
     checkPrepared();
     return LeftRightBlocks;
 }
 
-void MonomialOperator::compute(MPI_Comm const& comm)
-{
+void MonomialOperator::compute(MPI_Comm const& comm) {
     checkPrepared();
-    if(getStatus() >= Computed) return;
+    if(getStatus() >= Computed)
+        return;
 
     std::size_t Size = parts.size();
-    for(std::size_t BlockIn = 0; BlockIn < Size; BlockIn++){
-        INFO_NONEWLINE( (int) ((1.0*BlockIn/Size) * 100 ) << "  " << std::flush);
+    for(std::size_t BlockIn = 0; BlockIn < Size; BlockIn++) {
+        INFO_NONEWLINE((int)((1.0 * BlockIn / Size) * 100) << "  " << std::flush);
         parts[BlockIn].compute();
     };
 
     setStatus(Computed);
 }
 
-MonomialOperatorPart& MonomialOperator::getPartFromRightIndex(BlockNumber out)
-{
+MonomialOperatorPart& MonomialOperator::getPartFromRightIndex(BlockNumber out) {
     checkPrepared();
     return parts[mapPartsFromRight.find(out)->second];
 }
 
-MonomialOperatorPart const& MonomialOperator::getPartFromRightIndex(BlockNumber out) const
-{
+MonomialOperatorPart const& MonomialOperator::getPartFromRightIndex(BlockNumber out) const {
     checkPrepared();
     return parts[mapPartsFromRight.find(out)->second];
 }
 
-MonomialOperatorPart& MonomialOperator::getPartFromLeftIndex(BlockNumber in)
-{
+MonomialOperatorPart& MonomialOperator::getPartFromLeftIndex(BlockNumber in) {
     checkPrepared();
     return parts[mapPartsFromLeft.find(in)->second];
 }
 
-MonomialOperatorPart const& MonomialOperator::getPartFromLeftIndex(BlockNumber in) const
-{
+MonomialOperatorPart const& MonomialOperator::getPartFromLeftIndex(BlockNumber in) const {
     checkPrepared();
     return parts[mapPartsFromLeft.find(in)->second];
 }
 
-BlockNumber MonomialOperator::getRightIndex(BlockNumber LeftIndex) const
-{
+BlockNumber MonomialOperator::getRightIndex(BlockNumber LeftIndex) const {
     checkPrepared();
-    auto it =  LeftRightBlocks.left.find(LeftIndex);
+    auto it = LeftRightBlocks.left.find(LeftIndex);
     return it != LeftRightBlocks.left.end() ? it->second : INVALID_BLOCK_NUMBER;
 }
 
-BlockNumber MonomialOperator::getLeftIndex(BlockNumber RightIndex) const
-{
+BlockNumber MonomialOperator::getLeftIndex(BlockNumber RightIndex) const {
     checkPrepared();
-    auto it =  LeftRightBlocks.right.find(RightIndex);
+    auto it = LeftRightBlocks.right.find(RightIndex);
     return (it != LeftRightBlocks.right.end()) ? it->second : INVALID_BLOCK_NUMBER;
 }
 

--- a/src/pomerol/MonomialOperatorPart.cpp
+++ b/src/pomerol/MonomialOperatorPart.cpp
@@ -1,7 +1,9 @@
 #include "pomerol/MonomialOperatorPart.hpp"
 
+// clang-format off
 #include <libcommute/loperator/state_vector_eigen3.hpp>
 #include <libcommute/loperator/mapped_basis_view.hpp>
+// clang-format on
 
 #include <cassert>
 #include <cstddef>
@@ -11,9 +13,9 @@
 
 namespace Pomerol {
 
-void MonomialOperatorPart::compute()
-{
-    if(getStatus() >= Computed) return;
+void MonomialOperatorPart::compute() {
+    if(getStatus() >= Computed)
+        return;
 
     if(MOpComplex && HFrom.isComplex())
         computeImpl<true, true>();
@@ -27,8 +29,7 @@ void MonomialOperatorPart::compute()
     setStatus(Computed);
 }
 
-template<bool MOpC, bool HC>
-void MonomialOperatorPart::computeImpl() {
+template <bool MOpC, bool HC> void MonomialOperatorPart::computeImpl() {
     constexpr bool C = MOpC || HC;
 
     BlockNumber to = HTo.getBlockNumber();
@@ -49,7 +50,7 @@ void MonomialOperatorPart::computeImpl() {
 
     auto const& U = HFrom.getMatrix<HC>();
 
-    auto const& MOp_ = *static_cast<LOperatorTypeRC<MOpC> const *>(MOp);
+    auto const& MOp_ = *static_cast<LOperatorTypeRC<MOpC> const*>(MOp);
 
     for(InnerQuantumState st = 0; st < fromStates.size(); ++st) {
         auto fromView = fromMapper.make_const_view_no_ref(U.col(st));
@@ -63,19 +64,15 @@ void MonomialOperatorPart::computeImpl() {
 // https://gitlab.com/libeigen/eigen/-/issues/1224
 //
 // Affected versions are some betas of 3.3 but not the 3.3 release
-#if EIGEN_VERSION_AT_LEAST(3,2,90) && EIGEN_MAJOR_VERSION<3
-    elementsRowMajor = std::make_shared<RowMajorMatrixType<C>>(
-        MatrixType<C>(ULeft * OURight).sparseView(MatrixElementTolerance)
-    );
+#if EIGEN_VERSION_AT_LEAST(3, 2, 90) && EIGEN_MAJOR_VERSION < 3
+    elementsRowMajor =
+        std::make_shared<RowMajorMatrixType<C>>(MatrixType<C>(ULeft * OURight).sparseView(MatrixElementTolerance));
 #else
-    elementsRowMajor = std::make_shared<RowMajorMatrixType<C>>(
-        (ULeft * OURight).sparseView(MatrixElementTolerance)
-    );
+    elementsRowMajor = std::make_shared<RowMajorMatrixType<C>>((ULeft * OURight).sparseView(MatrixElementTolerance));
 #endif
 
     elementsColMajor = std::make_shared<ColMajorMatrixType<C>>(
-        *std::static_pointer_cast<RowMajorMatrixType<C> const>(elementsRowMajor)
-    );
+        *std::static_pointer_cast<RowMajorMatrixType<C> const>(elementsRowMajor));
 }
 
 void MonomialOperatorPart::setFromAdjoint(MonomialOperatorPart const& part) {
@@ -83,7 +80,8 @@ void MonomialOperatorPart::setFromAdjoint(MonomialOperatorPart const& part) {
     assert(getLeftIndex() == part.getRightIndex());
     assert(getRightIndex() == part.getLeftIndex());
 
-    if(getStatus() >= Computed) return;
+    if(getStatus() >= Computed)
+        return;
 
     if(isComplex()) {
         elementsRowMajor = std::make_shared<RowMajorMatrixType<true>>(part.getColMajorValue<true>().adjoint());
@@ -96,9 +94,7 @@ void MonomialOperatorPart::setFromAdjoint(MonomialOperatorPart const& part) {
     setStatus(Computed);
 }
 
-template<bool C>
-ColMajorMatrixType<C>& MonomialOperatorPart::getColMajorValue()
-{
+template <bool C> ColMajorMatrixType<C>& MonomialOperatorPart::getColMajorValue() {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<ColMajorMatrixType<C>>(elementsColMajor);
@@ -106,9 +102,7 @@ ColMajorMatrixType<C>& MonomialOperatorPart::getColMajorValue()
 template ColMajorMatrixType<true>& MonomialOperatorPart::getColMajorValue<true>();
 template ColMajorMatrixType<false>& MonomialOperatorPart::getColMajorValue<false>();
 
-template<bool C>
-ColMajorMatrixType<C> const& MonomialOperatorPart::getColMajorValue() const
-{
+template <bool C> ColMajorMatrixType<C> const& MonomialOperatorPart::getColMajorValue() const {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<ColMajorMatrixType<C> const>(elementsColMajor);
@@ -116,9 +110,7 @@ ColMajorMatrixType<C> const& MonomialOperatorPart::getColMajorValue() const
 template ColMajorMatrixType<true> const& MonomialOperatorPart::getColMajorValue<true>() const;
 template ColMajorMatrixType<false> const& MonomialOperatorPart::getColMajorValue<false>() const;
 
-template<bool C>
-RowMajorMatrixType<C>& MonomialOperatorPart::getRowMajorValue()
-{
+template <bool C> RowMajorMatrixType<C>& MonomialOperatorPart::getRowMajorValue() {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<RowMajorMatrixType<C>>(elementsRowMajor);
@@ -126,9 +118,7 @@ RowMajorMatrixType<C>& MonomialOperatorPart::getRowMajorValue()
 template RowMajorMatrixType<true>& MonomialOperatorPart::getRowMajorValue<true>();
 template RowMajorMatrixType<false>& MonomialOperatorPart::getRowMajorValue<false>();
 
-template<bool C>
-RowMajorMatrixType<C> const& MonomialOperatorPart::getRowMajorValue() const
-{
+template <bool C> RowMajorMatrixType<C> const& MonomialOperatorPart::getRowMajorValue() const {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
     return *std::static_pointer_cast<const RowMajorMatrixType<C>>(elementsRowMajor);
@@ -136,9 +126,8 @@ RowMajorMatrixType<C> const& MonomialOperatorPart::getRowMajorValue() const
 template RowMajorMatrixType<true> const& MonomialOperatorPart::getRowMajorValue<true>() const;
 template RowMajorMatrixType<false> const& MonomialOperatorPart::getRowMajorValue<false>() const;
 
-template<bool C>
-void MonomialOperatorPart::streamOutputImpl(std::ostream & os) const {
-    BlockNumber to   = HTo.getBlockNumber();
+template <bool C> void MonomialOperatorPart::streamOutputImpl(std::ostream& os) const {
+    BlockNumber to = HTo.getBlockNumber();
     BlockNumber from = HFrom.getBlockNumber();
     auto const& mat = getColMajorValue<C>();
 
@@ -150,7 +139,7 @@ void MonomialOperatorPart::streamOutputImpl(std::ostream & os) const {
         }
     }
 }
-template void MonomialOperatorPart::streamOutputImpl<true>(std::ostream & os) const;
-template void MonomialOperatorPart::streamOutputImpl<false>(std::ostream & os) const;
+template void MonomialOperatorPart::streamOutputImpl<true>(std::ostream& os) const;
+template void MonomialOperatorPart::streamOutputImpl<false>(std::ostream& os) const;
 
 } // namespace Pomerol

--- a/src/pomerol/StatesClassification.cpp
+++ b/src/pomerol/StatesClassification.cpp
@@ -24,28 +24,27 @@ void StatesClassification::initMultipleBlocks(libcommute::space_partition const&
     foreach(partition, [this](QuantumState State, BlockNumber Block) {
         StateBlockIndex[State] = Block;
         StatesContainer[Block].push_back(State);
-    });
+    })
+        ;
 }
 
-void StatesClassification::checkComputed() const
-{
-    if(getStatus() < Computed) { throw StatusMismatch("StatesClassification is not computed yet."); }
+void StatesClassification::checkComputed() const {
+    if(getStatus() < Computed) {
+        throw StatusMismatch("StatesClassification is not computed yet.");
+    }
 }
 
-unsigned long StatesClassification::getBlockSize(BlockNumber in) const
-{
+unsigned long StatesClassification::getBlockSize(BlockNumber in) const {
     checkComputed();
     return static_cast<InnerQuantumState>(getFockStates(in).size());
 }
 
-std::vector<QuantumState> const& StatesClassification::getFockStates(BlockNumber in) const
-{
+std::vector<QuantumState> const& StatesClassification::getFockStates(BlockNumber in) const {
     checkComputed();
     return StatesContainer[in];
 }
 
-QuantumState StatesClassification::getFockState(BlockNumber in, InnerQuantumState m) const
-{
+QuantumState StatesClassification::getFockState(BlockNumber in, InnerQuantumState m) const {
     checkComputed();
     if(int(in) < StatesContainer.size())
         if(m < StatesContainer[in].size())
@@ -53,8 +52,7 @@ QuantumState StatesClassification::getFockState(BlockNumber in, InnerQuantumStat
     throw std::runtime_error("Wrong inner state " + std::to_string(m));
 }
 
-BlockNumber StatesClassification::getBlockNumber(QuantumState in) const
-{
+BlockNumber StatesClassification::getBlockNumber(QuantumState in) const {
     checkComputed();
     if(in >= StateBlockIndex.size()) {
         throw std::runtime_error("Wrong state " + std::to_string(in));
@@ -62,8 +60,7 @@ BlockNumber StatesClassification::getBlockNumber(QuantumState in) const
     return StateBlockIndex[in];
 }
 
-InnerQuantumState StatesClassification::getInnerState(QuantumState in) const
-{
+InnerQuantumState StatesClassification::getInnerState(QuantumState in) const {
     checkComputed();
     if(in >= StateBlockIndex.size()) {
         throw std::runtime_error("Wrong state " + std::to_string(in));

--- a/src/pomerol/Susceptibility.cpp
+++ b/src/pomerol/Susceptibility.cpp
@@ -2,24 +2,30 @@
 
 namespace Pomerol {
 
-Susceptibility::Susceptibility(StatesClassification const& S, Hamiltonian const& H,
-                               MonomialOperator const& A, MonomialOperator const& B,
-                               DensityMatrix const& DM) :
-    Thermal(DM.beta), ComputableObject(), S(S), H(H), A(A), B(B), DM(DM)
-{
-}
+Susceptibility::Susceptibility(StatesClassification const& S,
+                               Hamiltonian const& H,
+                               MonomialOperator const& A,
+                               MonomialOperator const& B,
+                               DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), S(S), H(H), A(A), B(B), DM(DM) {}
 
-Susceptibility::Susceptibility(Susceptibility const& Chi) :
-    Thermal(Chi.beta), ComputableObject(Chi), S(Chi.S), H(Chi.H), A(Chi.A), B(Chi.B), DM(Chi.DM),
-    Vanishing(Chi.Vanishing),
-    parts(Chi.parts),
-    SubtractDisconnected(Chi.SubtractDisconnected), ave_A(Chi.ave_A), ave_B(Chi.ave_B)
-{
-}
+Susceptibility::Susceptibility(Susceptibility const& Chi)
+    : Thermal(Chi.beta),
+      ComputableObject(Chi),
+      S(Chi.S),
+      H(Chi.H),
+      A(Chi.A),
+      B(Chi.B),
+      DM(Chi.DM),
+      Vanishing(Chi.Vanishing),
+      parts(Chi.parts),
+      SubtractDisconnected(Chi.SubtractDisconnected),
+      ave_A(Chi.ave_A),
+      ave_B(Chi.ave_B) {}
 
-void Susceptibility::prepare()
-{
-    if(getStatus() >= Prepared) return;
+void Susceptibility::prepare() {
+    if(getStatus() >= Prepared)
+        return;
 
     // Find out non-trivial blocks of A and B.
     auto const& ANontrivialBlocks = A.getBlockMapping();
@@ -28,7 +34,7 @@ void Susceptibility::prepare()
     auto Aiter = ANontrivialBlocks.left.begin();
     auto Biter = BNontrivialBlocks.right.begin();
 
-    while(Aiter != ANontrivialBlocks.left.end() && Biter != BNontrivialBlocks.right.end()){
+    while(Aiter != ANontrivialBlocks.left.end() && Biter != BNontrivialBlocks.right.end()) {
         // <Aleft|A|Aright><Bleft|B|Bright>
         BlockNumber Aleft = Aiter->first;
         BlockNumber Aright = Aiter->second;
@@ -36,21 +42,24 @@ void Susceptibility::prepare()
         BlockNumber Bright = Biter->first;
 
         // Select a relevant 'world stripe' (sequence of blocks).
-        if(Aleft == Bright && Aright == Bleft){
+        if(Aleft == Bright && Aright == Bleft) {
             // check if retained blocks are included. If not, do not push.
-            if ( DM.isRetained(Aleft) || DM.isRetained(Aright) )
-                parts.emplace_back(
-                              (MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft),
-                              (MonomialOperatorPart&)B.getPartFromRightIndex(Bright),
-                              H.getPart(Aright), H.getPart(Aleft),
-                              DM.getPart(Aright), DM.getPart(Aleft));
+            if(DM.isRetained(Aleft) || DM.isRetained(Aright))
+                parts.emplace_back((MonomialOperatorPart&)A.getPartFromLeftIndex(Aleft),
+                                   (MonomialOperatorPart&)B.getPartFromRightIndex(Bright),
+                                   H.getPart(Aright),
+                                   H.getPart(Aleft),
+                                   DM.getPart(Aright),
+                                   DM.getPart(Aleft));
         }
 
         unsigned long AleftInt = Aleft;
         unsigned long BrightInt = Bright;
 
-        if(AleftInt <= BrightInt) Aiter++;
-        if(AleftInt >= BrightInt) Biter++;
+        if(AleftInt <= BrightInt)
+            Aiter++;
+        if(AleftInt >= BrightInt)
+            Biter++;
     }
 
     if(!parts.empty())
@@ -59,34 +68,32 @@ void Susceptibility::prepare()
     setStatus(Prepared);
 }
 
-void Susceptibility::compute()
-{
-    if(getStatus() >= Computed) return;
-    if(getStatus() < Prepared) prepare();
+void Susceptibility::compute() {
+    if(getStatus() >= Computed)
+        return;
+    if(getStatus() < Prepared)
+        prepare();
 
-    if(getStatus() < Computed){
-        for(auto & p : parts)
+    if(getStatus() < Computed) {
+        for(auto& p : parts)
             p.compute();
     }
     setStatus(Computed);
 }
 
-void Susceptibility::subtractDisconnected()
-{
+void Susceptibility::subtractDisconnected() {
     EnsembleAverage EA_A(S, H, A, DM);
     EnsembleAverage EA_B(S, H, B, DM);
     subtractDisconnected(EA_A, EA_B);
 }
 
-void Susceptibility::subtractDisconnected(ComplexType ave_A, ComplexType ave_B)
-{
+void Susceptibility::subtractDisconnected(ComplexType ave_A, ComplexType ave_B) {
     SubtractDisconnected = true;
     this->ave_A = ave_A;
     this->ave_B = ave_B;
 }
 
-void Susceptibility::subtractDisconnected(EnsembleAverage &EA_A, EnsembleAverage &EA_B)
-{
+void Susceptibility::subtractDisconnected(EnsembleAverage& EA_A, EnsembleAverage& EA_B) {
     EA_A.compute();
     EA_B.compute();
     subtractDisconnected(EA_A.getResult(), EA_B.getResult());

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -9,99 +9,99 @@
 
 namespace Pomerol {
 
-TwoParticleGF::TwoParticleGF(StatesClassification const& S, Hamiltonian const& H,
-                AnnihilationOperator const& C1, AnnihilationOperator const& C2,
-                CreationOperator const& CX3, CreationOperator const& CX4,
-                DensityMatrix const& DM) :
-    Thermal(DM.beta), ComputableObject(),
-    S(S), H(H), C1(C1), C2(C2), CX3(CX3), CX4(CX4), DM(DM)
-{
-}
+TwoParticleGF::TwoParticleGF(StatesClassification const& S,
+                             Hamiltonian const& H,
+                             AnnihilationOperator const& C1,
+                             AnnihilationOperator const& C2,
+                             CreationOperator const& CX3,
+                             CreationOperator const& CX4,
+                             DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), S(S), H(H), C1(C1), C2(C2), CX3(CX3), CX4(CX4), DM(DM) {}
 
-BlockNumber TwoParticleGF::getLeftIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber RightIndex) const
-{
+BlockNumber
+TwoParticleGF::getLeftIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber RightIndex) const {
     switch(permutations3[PermutationNumber].perm[OperatorPosition]) {
-        case 0: return C1.getLeftIndex(RightIndex);
-        case 1: return C2.getLeftIndex(RightIndex);
-        case 2: return CX3.getLeftIndex(RightIndex);
-        default: return INVALID_BLOCK_NUMBER;
+    case 0: return C1.getLeftIndex(RightIndex);
+    case 1: return C2.getLeftIndex(RightIndex);
+    case 2: return CX3.getLeftIndex(RightIndex);
+    default: return INVALID_BLOCK_NUMBER;
     }
 }
 
-BlockNumber TwoParticleGF::getRightIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const
-{
+BlockNumber
+TwoParticleGF::getRightIndex(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const {
     switch(permutations3[PermutationNumber].perm[OperatorPosition]) {
-        case 0: return C1.getRightIndex(LeftIndex);
-        case 1: return C2.getRightIndex(LeftIndex);
-        case 2: return CX3.getRightIndex(LeftIndex);
-        default: return INVALID_BLOCK_NUMBER;
+    case 0: return C1.getRightIndex(LeftIndex);
+    case 1: return C2.getRightIndex(LeftIndex);
+    case 2: return CX3.getRightIndex(LeftIndex);
+    default: return INVALID_BLOCK_NUMBER;
     }
 }
 
-MonomialOperatorPart const& TwoParticleGF::OperatorPartAtPosition(std::size_t PermutationNumber, std::size_t OperatorPosition, BlockNumber LeftIndex) const
-{
-    switch(permutations3[PermutationNumber].perm[OperatorPosition]){
-        case 0: return C1.getPartFromLeftIndex(LeftIndex);
-        case 1: return C2.getPartFromLeftIndex(LeftIndex);
-        case 2: return CX3.getPartFromLeftIndex(LeftIndex);
-        default: throw std::runtime_error("TwoParticleGF: Could not find operator part");
+MonomialOperatorPart const& TwoParticleGF::OperatorPartAtPosition(std::size_t PermutationNumber,
+                                                                  std::size_t OperatorPosition,
+                                                                  BlockNumber LeftIndex) const {
+    switch(permutations3[PermutationNumber].perm[OperatorPosition]) {
+    case 0: return C1.getPartFromLeftIndex(LeftIndex);
+    case 1: return C2.getPartFromLeftIndex(LeftIndex);
+    case 2: return CX3.getPartFromLeftIndex(LeftIndex);
+    default: throw std::runtime_error("TwoParticleGF: Could not find operator part");
     }
 }
 
-void TwoParticleGF::prepare()
-{
-    if(getStatus() >= Prepared) return;
+void TwoParticleGF::prepare() {
+    if(getStatus() >= Prepared)
+        return;
 
     // Find out non-trivial blocks of CX4.
     MonomialOperator::BlocksBimap const& CX4NontrivialBlocks = CX4.getBlockMapping();
-    for(auto outer_iter = CX4NontrivialBlocks.right.begin();
-        outer_iter != CX4NontrivialBlocks.right.end(); outer_iter++){ // Iterate over the outermost index.
-            for(std::size_t p = 0; p < 6; ++p) { // Choose a permutation
-                  std::array<BlockNumber, 4> LeftIndices{};
-                  LeftIndices[0] = outer_iter->first;
-                  LeftIndices[3] = outer_iter->second;
-                  LeftIndices[2] = getLeftIndex(p,2,LeftIndices[3]);
-                  LeftIndices[1] = getRightIndex(p,0,LeftIndices[0]);
-                  // < LeftIndices[0] | O_1 | LeftIndices[1] >
-                  // < LeftIndices[1] | O_2 | getRightIndex(p,1,LeftIndices[1]) >
-                  // < LeftIndices[2]| O_3 | LeftIndices[3] >
-                  // < LeftIndices[3] | CX4 | LeftIndices[0] >
-                  // Select a relevant 'world stripe' (sequence of blocks).
-                  if(getRightIndex(p,1,LeftIndices[1]) == LeftIndices[2] &&
-                      (LeftIndices[1] != INVALID_BLOCK_NUMBER) &&
-                      (LeftIndices[2] != INVALID_BLOCK_NUMBER)) {
-                      { // check if retained blocks are included. If not, do not push.
-                          bool include_block_retained=false;
-                          for(int k = 0; k < 4; ++k)
-                              if (DM.isRetained(LeftIndices[k]))  include_block_retained=true;
-                          if(!include_block_retained) continue;
-                      }
-                      // DEBUG
-                      /*DEBUG("new part: "  << S.getBlockInfo(LeftIndices[0]) << " "
-                                          << S.getBlockInfo(LeftIndices[1]) << " "
-                                          << S.getBlockInfo(LeftIndices[2]) << " "
-                                          << S.getBlockInfo(LeftIndices[3]) << " "
-                      <<"BlockNumbers part: "  << LeftIndices[0] << " " << LeftIndices[1] << " " << LeftIndices[2] << " " << LeftIndices[3]);
-                      */
-                      parts.emplace_back(
-                          OperatorPartAtPosition(p,0,LeftIndices[0]),
-                          OperatorPartAtPosition(p,1,LeftIndices[1]),
-                          OperatorPartAtPosition(p,2,LeftIndices[2]),
-                          (MonomialOperatorPart&)CX4.getPartFromLeftIndex(LeftIndices[3]),
-                          H.getPart(LeftIndices[0]), H.getPart(LeftIndices[1]), H.getPart(LeftIndices[2]), H.getPart(LeftIndices[3]),
-                          DM.getPart(LeftIndices[0]), DM.getPart(LeftIndices[1]), DM.getPart(LeftIndices[2]), DM.getPart(LeftIndices[3]),
-                          permutations3[p]
-                      );
-
-                      parts.back().ReduceResonanceTolerance = ReduceResonanceTolerance;
-                      parts.back().CoefficientTolerance = CoefficientTolerance;
-                      parts.back().MultiTermCoefficientTolerance = MultiTermCoefficientTolerance;
+    for(auto outer_iter = CX4NontrivialBlocks.right.begin(); outer_iter != CX4NontrivialBlocks.right.end();
+        outer_iter++) {                      // Iterate over the outermost index.
+        for(std::size_t p = 0; p < 6; ++p) { // Choose a permutation
+            std::array<BlockNumber, 4> LeftIndices{};
+            LeftIndices[0] = outer_iter->first;
+            LeftIndices[3] = outer_iter->second;
+            LeftIndices[2] = getLeftIndex(p, 2, LeftIndices[3]);
+            LeftIndices[1] = getRightIndex(p, 0, LeftIndices[0]);
+            // < LeftIndices[0] | O_1 | LeftIndices[1] >
+            // < LeftIndices[1] | O_2 | getRightIndex(p,1,LeftIndices[1]) >
+            // < LeftIndices[2]| O_3 | LeftIndices[3] >
+            // < LeftIndices[3] | CX4 | LeftIndices[0] >
+            // Select a relevant 'world stripe' (sequence of blocks).
+            if(getRightIndex(p, 1, LeftIndices[1]) == LeftIndices[2] && (LeftIndices[1] != INVALID_BLOCK_NUMBER) &&
+               (LeftIndices[2] != INVALID_BLOCK_NUMBER)) {
+                { // check if retained blocks are included. If not, do not push.
+                    bool include_block_retained = false;
+                    for(int k = 0; k < 4; ++k)
+                        if(DM.isRetained(LeftIndices[k]))
+                            include_block_retained = true;
+                    if(!include_block_retained)
+                        continue;
                 }
+                parts.emplace_back(OperatorPartAtPosition(p, 0, LeftIndices[0]),
+                                   OperatorPartAtPosition(p, 1, LeftIndices[1]),
+                                   OperatorPartAtPosition(p, 2, LeftIndices[2]),
+                                   (MonomialOperatorPart&)CX4.getPartFromLeftIndex(LeftIndices[3]),
+                                   H.getPart(LeftIndices[0]),
+                                   H.getPart(LeftIndices[1]),
+                                   H.getPart(LeftIndices[2]),
+                                   H.getPart(LeftIndices[3]),
+                                   DM.getPart(LeftIndices[0]),
+                                   DM.getPart(LeftIndices[1]),
+                                   DM.getPart(LeftIndices[2]),
+                                   DM.getPart(LeftIndices[3]),
+                                   permutations3[p]);
+
+                parts.back().ReduceResonanceTolerance = ReduceResonanceTolerance;
+                parts.back().CoefficientTolerance = CoefficientTolerance;
+                parts.back().MultiTermCoefficientTolerance = MultiTermCoefficientTolerance;
+            }
         }
     }
     if(!parts.empty()) {
         Vanishing = false;
-        INFO("TwoParticleGF(" << getIndex(0) << getIndex(1) << getIndex(2) << getIndex(3) << "): " << parts.size() << " parts will be calculated");
+        INFO("TwoParticleGF(" << getIndex(0) << getIndex(1) << getIndex(2) << getIndex(3) << "): " << parts.size()
+                              << " parts will be calculated");
     }
     setStatus(Prepared);
 }
@@ -109,49 +109,49 @@ void TwoParticleGF::prepare()
 // An mpi adapter to 1) compute 2pgf terms; 2) convert them to a Matsubara Container; 3) purge terms
 struct ComputeAndClearWrap {
     ComputeAndClearWrap(FreqVec const& freqs,
-                        std::vector<ComplexType> & data,
-                        TwoParticleGFPart & p,
+                        std::vector<ComplexType>& data,
+                        TwoParticleGFPart& p,
                         bool clear,
                         bool fill,
-                        int complexity = 1):
-        complexity(complexity), freqs_(freqs), data_(data), p(p),clear_(clear), fill_(fill) {}
+                        int complexity = 1)
+        : complexity(complexity), freqs_(freqs), data_(data), p(p), clear_(clear), fill_(fill) {}
 
     void run() {
         p.compute();
-        if (fill_) {
+        if(fill_) {
             std::size_t wsize = freqs_.size();
-            #ifdef POMEROL_USE_OPENMP
-            #pragma omp parallel for
-            #endif
-            for (int w = 0; w < wsize; ++w) {
+#ifdef POMEROL_USE_OPENMP
+#pragma omp parallel for
+#endif
+            for(int w = 0; w < wsize; ++w) {
                 data_[w] += p(std::get<0>(freqs_[w]), std::get<1>(freqs_[w]), std::get<2>(freqs_[w]));
             }
-            #ifdef POMEROL_USE_OPENMP
-            #pragma omp barrier
-            #endif
+#ifdef POMEROL_USE_OPENMP
+#pragma omp barrier
+#endif
         }
-        if(clear_) p.clear();
+        if(clear_)
+            p.clear();
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
     int const complexity;
 
 private:
-
     FreqVec const& freqs_;
-    std::vector<ComplexType> & data_;
-    TwoParticleGFPart & p;
+    std::vector<ComplexType>& data_;
+    TwoParticleGFPart& p;
     bool clear_;
     bool fill_;
 };
 
-std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs, MPI_Comm const& comm)
-{
+std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs, MPI_Comm const& comm) {
     if(getStatus() < Prepared)
         throw StatusMismatch("TwoParticleGF is not prepared yet.");
 
     std::vector<ComplexType> m_data;
-    if(getStatus() >= Computed) return m_data;
+    if(getStatus() >= Computed)
+        return m_data;
 
     if(!Vanishing) {
         // Create a "skeleton" class with pointers to part that can call a compute method
@@ -159,7 +159,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs
         bool fill_container = !freqs.empty();
         skel.parts.reserve(parts.size());
         m_data.resize(freqs.size(), 0.0);
-        for (auto & part : parts) {
+        for(auto& part : parts) {
             skel.parts.emplace_back(freqs, m_data, part, clear, fill_container, 1);
         }
         std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, true); // actual running - very costly
@@ -175,7 +175,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs
                       comm);
 
         // Optionally distribute terms to other processes
-        if (!clear) {
+        if(!clear) {
             for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
                 parts[p].NonResonantTerms.broadcast(comm, job_map[p]);
                 parts[p].ResonantTerms.broadcast(comm, job_map[p]);
@@ -190,22 +190,21 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs
     return m_data;
 }
 
-ParticleIndex TwoParticleGF::getIndex(std::size_t Position) const
-{
-    switch(Position){
-        case 0: return C1.getIndex();
-        case 1: return C2.getIndex();
-        case 2: return CX3.getIndex();
-        case 3: return CX4.getIndex();
-        default: assert(0);
+ParticleIndex TwoParticleGF::getIndex(std::size_t Position) const {
+    switch(Position) {
+    case 0: return C1.getIndex();
+    case 1: return C2.getIndex();
+    case 2: return CX3.getIndex();
+    case 3: return CX4.getIndex();
+    default: assert(0);
     }
     throw std::runtime_error("TwoParticleGF: Could not get operator index");
 }
 
-unsigned short TwoParticleGF::getPermutationNumber(Permutation3 const& in)
-{
+unsigned short TwoParticleGF::getPermutationNumber(Permutation3 const& in) {
     for(unsigned short i = 0; i < 6; ++i)
-        if (in == permutations3[i]) return i;
+        if(in == permutations3[i])
+            return i;
     ERROR("TwoParticleGF: Permutation " << in << " not found in all permutations3");
     return 0;
 }

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -14,19 +14,21 @@ std::mutex ResonantTerm_mpi_datatype_mutex;
 namespace Pomerol {
 
 // Make the lagging index catch up or outrun the leading index.
-template<bool Complex>
+template <bool Complex>
 inline bool chaseIndices(typename RowMajorMatrixType<Complex>::InnerIterator& index1_iter,
-                         typename ColMajorMatrixType<Complex>::InnerIterator& index2_iter)
-{
+                         typename ColMajorMatrixType<Complex>::InnerIterator& index2_iter) {
     InnerQuantumState index1 = index1_iter.index();
     InnerQuantumState index2 = index2_iter.index();
 
-    if(index1 == index2) return true;
+    if(index1 == index2)
+        return true;
 
     if(index1 < index2)
-        for(;InnerQuantumState(index1_iter.index())<index2 && index1_iter; ++index1_iter);
+        for(; InnerQuantumState(index1_iter.index()) < index2 && index1_iter; ++index1_iter)
+            ;
     else
-        for(;InnerQuantumState(index2_iter.index())<index1 && index2_iter; ++index2_iter);
+        for(; InnerQuantumState(index2_iter.index()) < index1 && index2_iter; ++index2_iter)
+            ;
 
     return false;
 }
@@ -34,13 +36,11 @@ inline bool chaseIndices(typename RowMajorMatrixType<Complex>::InnerIterator& in
 //
 // TwoParticleGFPart::NonResonantTerm
 //
-TwoParticleGFPart::NonResonantTerm& TwoParticleGFPart::NonResonantTerm::operator+=(
-    NonResonantTerm const& AnotherTerm)
-{
+TwoParticleGFPart::NonResonantTerm& TwoParticleGFPart::NonResonantTerm::operator+=(NonResonantTerm const& AnotherTerm) {
     long combinedWeight = Weight + AnotherTerm.Weight;
     for(unsigned short p = 0; p < 3; ++p)
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
-        Poles[p] = (Weight*Poles[p] + AnotherTerm.Weight*AnotherTerm.Poles[p])/combinedWeight;
+        Poles[p] = (Weight * Poles[p] + AnotherTerm.Weight * AnotherTerm.Poles[p]) / combinedWeight;
     Weight = combinedWeight;
     Coeff += AnotherTerm.Coeff;
     return *this;
@@ -64,19 +64,19 @@ MPI_Datatype TwoParticleGFPart::NonResonantTerm::mpi_datatype() {
     static bool type_committed = false;
     if(!type_committed) {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-        int blocklengths[] = {1,3,1,1};
+        int blocklengths[] = {1, 3, 1, 1};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Aint displacements[] = {offsetof(NonResonantTerm, Coeff),
                                     offsetof(NonResonantTerm, Poles),
                                     offsetof(NonResonantTerm, isz4),
-                                    offsetof(NonResonantTerm, Weight)
-                                   };
+                                    offsetof(NonResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-        MPI_Datatype types[] = {MPI_CXX_DOUBLE_COMPLEX, // ComplexType Coeff
-                                MPI_DOUBLE,             // RealType Poles[3]
-                                MPI_CXX_BOOL,           // bool isz4
-                                MPI_LONG                // long Weight
-                               };
+        MPI_Datatype types[] = {
+            MPI_CXX_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_DOUBLE,             // RealType Poles[3]
+            MPI_CXX_BOOL,           // bool isz4
+            MPI_LONG                // long Weight
+        };
         MPI_Type_create_struct(4, blocklengths, displacements, types, &dt);
         MPI_Type_commit(&dt);
         type_committed = true;
@@ -87,14 +87,12 @@ MPI_Datatype TwoParticleGFPart::NonResonantTerm::mpi_datatype() {
 //
 // TwoParticleGFPart::ResonantTerm
 //
-TwoParticleGFPart::ResonantTerm& TwoParticleGFPart::ResonantTerm::operator+=(
-                ResonantTerm const& AnotherTerm)
-{
-    long combinedWeight=Weight + AnotherTerm.Weight;
-    for (unsigned short p=0; p<3; ++p)
+TwoParticleGFPart::ResonantTerm& TwoParticleGFPart::ResonantTerm::operator+=(ResonantTerm const& AnotherTerm) {
+    long combinedWeight = Weight + AnotherTerm.Weight;
+    for(unsigned short p = 0; p < 3; ++p)
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
-        Poles[p]= (Weight*Poles[p] + AnotherTerm.Weight*AnotherTerm.Poles[p])/combinedWeight;
-    Weight=combinedWeight;
+        Poles[p] = (Weight * Poles[p] + AnotherTerm.Weight * AnotherTerm.Poles[p]) / combinedWeight;
+    Weight = combinedWeight;
     ResCoeff += AnotherTerm.ResCoeff;
     NonResCoeff += AnotherTerm.NonResCoeff;
     return *this;
@@ -118,21 +116,21 @@ MPI_Datatype TwoParticleGFPart::ResonantTerm::mpi_datatype() {
     static bool type_committed = false;
     if(!type_committed) {
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-        int blocklengths[] = {1,1,3,1,1};
+        int blocklengths[] = {1, 1, 3, 1, 1};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Aint displacements[] = {offsetof(ResonantTerm, ResCoeff),
                                     offsetof(ResonantTerm, NonResCoeff),
                                     offsetof(ResonantTerm, Poles),
                                     offsetof(ResonantTerm, isz1z2),
-                                    offsetof(ResonantTerm, Weight)
-                                   };
+                                    offsetof(ResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
-        MPI_Datatype types[] = {MPI_CXX_DOUBLE_COMPLEX, // ComplexType ResCoeff
-                                MPI_CXX_DOUBLE_COMPLEX, // ComplexType NonResCoeff
-                                MPI_DOUBLE,             // RealType Poles[3]
-                                MPI_CXX_BOOL,           // bool isz1z2
-                                MPI_LONG                // long Weight
-                               };
+        MPI_Datatype types[] = {
+            MPI_CXX_DOUBLE_COMPLEX, // ComplexType ResCoeff
+            MPI_CXX_DOUBLE_COMPLEX, // ComplexType NonResCoeff
+            MPI_DOUBLE,             // RealType Poles[3]
+            MPI_CXX_BOOL,           // bool isz1z2
+            MPI_LONG                // long Weight
+        };
         MPI_Type_create_struct(5, blocklengths, displacements, types, &dt);
         MPI_Type_commit(&dt);
         type_committed = true;
@@ -143,27 +141,40 @@ MPI_Datatype TwoParticleGFPart::ResonantTerm::mpi_datatype() {
 //
 // TwoParticleGFPart
 //
-TwoParticleGFPart::TwoParticleGFPart(
-                MonomialOperatorPart const& O1, MonomialOperatorPart const& O2,
-                MonomialOperatorPart const& O3, MonomialOperatorPart const& CX4,
-                HamiltonianPart const& Hpart1, HamiltonianPart const& Hpart2,
-                HamiltonianPart const& Hpart3, HamiltonianPart const& Hpart4,
-                DensityMatrixPart const& DMpart1, DensityMatrixPart const& DMpart2,
-                DensityMatrixPart const& DMpart3, DensityMatrixPart const& DMpart4,
-                Permutation3 Permutation) :
-    Thermal(DMpart1.beta),
-    ComputableObject(),
-    O1(O1), O2(O2), O3(O3), CX4(CX4),
-    Hpart1(Hpart1), Hpart2(Hpart2), Hpart3(Hpart3), Hpart4(Hpart4),
-    DMpart1(DMpart1), DMpart2(DMpart2), DMpart3(DMpart3), DMpart4(DMpart4),
-    Permutation(std::move(Permutation)),
-    NonResonantTerms(NonResonantTerm::Compare(), NonResonantTerm::IsNegligible()),
-    ResonantTerms(ResonantTerm::Compare(), ResonantTerm::IsNegligible())
-{}
+TwoParticleGFPart::TwoParticleGFPart(MonomialOperatorPart const& O1,
+                                     MonomialOperatorPart const& O2,
+                                     MonomialOperatorPart const& O3,
+                                     MonomialOperatorPart const& CX4,
+                                     HamiltonianPart const& Hpart1,
+                                     HamiltonianPart const& Hpart2,
+                                     HamiltonianPart const& Hpart3,
+                                     HamiltonianPart const& Hpart4,
+                                     DensityMatrixPart const& DMpart1,
+                                     DensityMatrixPart const& DMpart2,
+                                     DensityMatrixPart const& DMpart3,
+                                     DensityMatrixPart const& DMpart4,
+                                     Permutation3 Permutation)
+    : Thermal(DMpart1.beta),
+      ComputableObject(),
+      O1(O1),
+      O2(O2),
+      O3(O3),
+      CX4(CX4),
+      Hpart1(Hpart1),
+      Hpart2(Hpart2),
+      Hpart3(Hpart3),
+      Hpart4(Hpart4),
+      DMpart1(DMpart1),
+      DMpart2(DMpart2),
+      DMpart3(DMpart3),
+      DMpart4(DMpart4),
+      Permutation(std::move(Permutation)),
+      NonResonantTerms(NonResonantTerm::Compare(), NonResonantTerm::IsNegligible()),
+      ResonantTerms(ResonantTerm::Compare(), ResonantTerm::IsNegligible()) {}
 
-void TwoParticleGFPart::compute()
-{
-    if(getStatus() >= Computed) return;
+void TwoParticleGFPart::compute() {
+    if(getStatus() >= Computed)
+        return;
 
     if(O1.isComplex() || O2.isComplex() || O3.isComplex() || CX4.isComplex())
         computeImpl<true>();
@@ -171,9 +182,7 @@ void TwoParticleGFPart::compute()
         computeImpl<false>();
 }
 
-template<bool Complex>
-void TwoParticleGFPart::computeImpl()
-{
+template <bool Complex> void TwoParticleGFPart::computeImpl() {
     NonResonantTerms.clear();
     ResonantTerms.clear();
 
@@ -187,62 +196,60 @@ void TwoParticleGFPart::computeImpl()
     RowMajorMatrixType<Complex> const& O3matrix = O3.getRowMajorValue<Complex>();
     ColMajorMatrixType<Complex> const& CX4matrix = CX4.getColMajorValue<Complex>();
 
-    InnerQuantumState index1Max = CX4matrix.outerSize(); // One can not make a cutoff in external index for evaluating 2PGF
+    InnerQuantumState index1Max =
+        CX4matrix.outerSize(); // One can not make a cutoff in external index for evaluating 2PGF
     InnerQuantumState index3Max = O2matrix.outerSize();
 
     std::vector<InnerQuantumState> Index4List;
-    Index4List.reserve(index1Max*index3Max);
+    Index4List.reserve(index1Max * index3Max);
 
-    for(InnerQuantumState index1=0; index1<index1Max; ++index1)
-    for(InnerQuantumState index3=0; index3<index3Max; ++index3){
-        typename ColMajorMatrixType<Complex>::InnerIterator index4bra_iter(CX4matrix, index1);
-        typename RowMajorMatrixType<Complex>::InnerIterator index4ket_iter(O3matrix, index3);
-        Index4List.clear();
-        while (index4bra_iter && index4ket_iter){
-            if(chaseIndices<Complex>(index4ket_iter,index4bra_iter)){
-                Index4List.push_back(index4bra_iter.index());
-                ++index4bra_iter;
-                ++index4ket_iter;
-            }
-        };
+    for(InnerQuantumState index1 = 0; index1 < index1Max; ++index1)
+        for(InnerQuantumState index3 = 0; index3 < index3Max; ++index3) {
+            typename ColMajorMatrixType<Complex>::InnerIterator index4bra_iter(CX4matrix, index1);
+            typename RowMajorMatrixType<Complex>::InnerIterator index4ket_iter(O3matrix, index3);
+            Index4List.clear();
+            while(index4bra_iter && index4ket_iter) {
+                if(chaseIndices<Complex>(index4ket_iter, index4bra_iter)) {
+                    Index4List.push_back(index4bra_iter.index());
+                    ++index4bra_iter;
+                    ++index4ket_iter;
+                }
+            };
 
-        if(!Index4List.empty())
-        {
-            RealType E1 = Hpart1.getEigenValue(index1);
-            RealType E3 = Hpart3.getEigenValue(index3);
-            RealType weight1 = DMpart1.getWeight(index1);
-            RealType weight3 = DMpart3.getWeight(index3);
+            if(!Index4List.empty()) {
+                RealType E1 = Hpart1.getEigenValue(index1);
+                RealType E3 = Hpart3.getEigenValue(index3);
+                RealType weight1 = DMpart1.getWeight(index1);
+                RealType weight3 = DMpart3.getWeight(index3);
 
-            typename ColMajorMatrixType<Complex>::InnerIterator index2bra_iter(O2matrix,index3);
-            typename RowMajorMatrixType<Complex>::InnerIterator index2ket_iter(O1matrix,index1);
-            while(index2bra_iter && index2ket_iter) {
-                if(chaseIndices<Complex>(index2ket_iter,index2bra_iter)) {
+                typename ColMajorMatrixType<Complex>::InnerIterator index2bra_iter(O2matrix, index3);
+                typename RowMajorMatrixType<Complex>::InnerIterator index2ket_iter(O1matrix, index1);
+                while(index2bra_iter && index2ket_iter) {
+                    if(chaseIndices<Complex>(index2ket_iter, index2bra_iter)) {
 
-                    InnerQuantumState index2 = index2ket_iter.index();
-                    RealType E2 = Hpart2.getEigenValue(index2);
-                    RealType weight2 = DMpart2.getWeight(index2);
+                        InnerQuantumState index2 = index2ket_iter.index();
+                        RealType E2 = Hpart2.getEigenValue(index2);
+                        RealType weight2 = DMpart2.getWeight(index2);
 
-                    for (unsigned long index4 : Index4List)
-                    {
-                        RealType E4 = Hpart4.getEigenValue(index4);
-                        RealType weight4 = DMpart4.getWeight(index4);
-                        if (weight1 + weight2 + weight3 + weight4 >= CoefficientTolerance) {
-                            ComplexType MatrixElement = index2ket_iter.value()*
-                                                        index2bra_iter.value()*
-                                                        O3matrix.coeff(index3,index4)*
-                                                        CX4matrix.coeff(index4,index1);
+                        for(unsigned long index4 : Index4List) {
+                            RealType E4 = Hpart4.getEigenValue(index4);
+                            RealType weight4 = DMpart4.getWeight(index4);
+                            if(weight1 + weight2 + weight3 + weight4 >= CoefficientTolerance) {
+                                ComplexType MatrixElement = index2ket_iter.value() * index2bra_iter.value() *
+                                                            O3matrix.coeff(index3, index4) *
+                                                            CX4matrix.coeff(index4, index1);
 
-                            MatrixElement *= Permutation.sign;
+                                MatrixElement *= Permutation.sign;
 
-                            addMultiterm(MatrixElement,beta,E1,E2,E3,E4,weight1,weight2,weight3,weight4);
+                                addMultiterm(MatrixElement, beta, E1, E2, E3, E4, weight1, weight2, weight3, weight4);
+                            }
                         }
+                        ++index2bra_iter;
+                        ++index2ket_iter;
                     }
-                    ++index2bra_iter;
-                    ++index2ket_iter;
                 }
             }
         }
-    }
 
     INFO("Total " << NonResonantTerms.size() << "+" << ResonantTerms.size() << "="
                   << NonResonantTerms.size() + ResonantTerms.size() << " terms");
@@ -253,69 +260,67 @@ void TwoParticleGFPart::computeImpl()
     setStatus(Computed);
 }
 
-inline
-void TwoParticleGFPart::addMultiterm(ComplexType Coeff, RealType beta,
-                      RealType Ei, RealType Ej, RealType Ek, RealType El,
-                      RealType Wi, RealType Wj, RealType Wk, RealType Wl)
-{
+inline void TwoParticleGFPart::addMultiterm(ComplexType Coeff,
+                                            RealType beta,
+                                            RealType Ei,
+                                            RealType Ej,
+                                            RealType Ek,
+                                            RealType El,
+                                            RealType Wi,
+                                            RealType Wj,
+                                            RealType Wk,
+                                            RealType Wl) {
     RealType P1 = Ej - Ei;
     RealType P2 = Ek - Ej;
     RealType P3 = El - Ek;
 
     // Non-resonant part of the multiterm
-    ComplexType CoeffZ2 = -Coeff*(Wj + Wk);
+    ComplexType CoeffZ2 = -Coeff * (Wj + Wk);
     if(std::abs(CoeffZ2) > CoefficientTolerance)
-        NonResonantTerms.add_term(
-            NonResonantTerm(CoeffZ2,P1,P2,P3,false));
-    ComplexType CoeffZ4 = Coeff*(Wi + Wl);
+        NonResonantTerms.add_term(NonResonantTerm(CoeffZ2, P1, P2, P3, false));
+    ComplexType CoeffZ4 = Coeff * (Wi + Wl);
     if(std::abs(CoeffZ4) > CoefficientTolerance)
-        NonResonantTerms.add_term(
-            NonResonantTerm(CoeffZ4,P1,P2,P3,true));
+        NonResonantTerms.add_term(NonResonantTerm(CoeffZ4, P1, P2, P3, true));
 
     // Resonant part of the multiterm
-    ComplexType CoeffZ1Z2Res = Coeff*beta*Wi;
-    ComplexType CoeffZ1Z2NonRes = Coeff*(Wk - Wi);
+    ComplexType CoeffZ1Z2Res = Coeff * beta * Wi;
+    ComplexType CoeffZ1Z2NonRes = Coeff * (Wk - Wi);
     if(std::abs(CoeffZ1Z2Res) > CoefficientTolerance || abs(CoeffZ1Z2NonRes) > CoefficientTolerance)
-        ResonantTerms.add_term(
-            ResonantTerm(CoeffZ1Z2Res,CoeffZ1Z2NonRes,P1,P2,P3,true));
-    ComplexType CoeffZ2Z3Res = -Coeff*beta*Wj;
-    ComplexType CoeffZ2Z3NonRes = Coeff*(Wj - Wl);
+        ResonantTerms.add_term(ResonantTerm(CoeffZ1Z2Res, CoeffZ1Z2NonRes, P1, P2, P3, true));
+    ComplexType CoeffZ2Z3Res = -Coeff * beta * Wj;
+    ComplexType CoeffZ2Z3NonRes = Coeff * (Wj - Wl);
     if(std::abs(CoeffZ2Z3Res) > CoefficientTolerance || abs(CoeffZ2Z3NonRes) > CoefficientTolerance)
-        ResonantTerms.add_term(
-            ResonantTerm(CoeffZ2Z3Res,CoeffZ2Z3NonRes,P1,P2,P3,false));
+        ResonantTerms.add_term(ResonantTerm(CoeffZ2Z3Res, CoeffZ2Z3NonRes, P1, P2, P3, false));
 }
 
-ComplexType TwoParticleGFPart::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const
-{
-    long MatsubaraNumberOdd1 = 2*MatsubaraNumber1 + 1;
-    long MatsubaraNumberOdd2 = 2*MatsubaraNumber2 + 1;
-    long MatsubaraNumberOdd3 = 2*MatsubaraNumber3 + 1;
+ComplexType TwoParticleGFPart::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const {
+    long MatsubaraNumberOdd1 = 2 * MatsubaraNumber1 + 1;
+    long MatsubaraNumberOdd2 = 2 * MatsubaraNumber2 + 1;
+    long MatsubaraNumberOdd3 = 2 * MatsubaraNumber3 + 1;
     return (*this)(MatsubaraSpacing * RealType(MatsubaraNumberOdd1),
                    MatsubaraSpacing * RealType(MatsubaraNumberOdd2),
                    MatsubaraSpacing * RealType(MatsubaraNumberOdd3));
 }
 
-ComplexType TwoParticleGFPart::operator()(ComplexType z1, ComplexType z2, ComplexType z3) const
-{
+ComplexType TwoParticleGFPart::operator()(ComplexType z1, ComplexType z2, ComplexType z3) const {
     std::array<ComplexType, 3> Frequencies = {z1, z2, -z3};
 
     z1 = Frequencies[Permutation.perm[0]];
     z2 = Frequencies[Permutation.perm[1]];
     z3 = Frequencies[Permutation.perm[2]];
 
-    if (getStatus() != Computed) {
-        throw StatusMismatch("2PGFPart: Calling operator() on uncomputed container. Did you purge all the terms when called compute()?");
+    if(getStatus() != Computed) {
+        throw StatusMismatch(
+            "2PGFPart: Calling operator() on uncomputed container. Did you purge all the terms when called compute()?");
     }
 
     return NonResonantTerms(z1, z2, z3) + ResonantTerms(z1, z2, z3, ReduceResonanceTolerance);
 }
 
-void TwoParticleGFPart::clear()
-{
+void TwoParticleGFPart::clear() {
     NonResonantTerms.clear();
     ResonantTerms.clear();
     setStatus(Constructed);
 }
 
 } // namespace Pomerol
-

--- a/src/pomerol/Vertex4.cpp
+++ b/src/pomerol/Vertex4.cpp
@@ -3,34 +3,32 @@
 namespace Pomerol {
 
 Vertex4::Vertex4(TwoParticleGF const& Chi4,
-                 GreensFunction const& G13, GreensFunction const& G24,
-                 GreensFunction const& G14, GreensFunction const& G23) :
-    Thermal(Chi4.beta), ComputableObject(),
-    Chi4(Chi4), G13(G13), G24(G24), G14(G14), G23(G23), Storage(*this)
-{}
+                 GreensFunction const& G13,
+                 GreensFunction const& G24,
+                 GreensFunction const& G14,
+                 GreensFunction const& G23)
+    : Thermal(Chi4.beta), ComputableObject(), Chi4(Chi4), G13(G13), G24(G24), G14(G14), G23(G23), Storage(*this) {}
 
-void Vertex4::compute(long NumberOfMatsubaras)
-{
-    if(getStatus() >= Computed) return;
+void Vertex4::compute(long NumberOfMatsubaras) {
+    if(getStatus() >= Computed)
+        return;
     Storage.fill(NumberOfMatsubaras);
     setStatus(Computed);
 }
 
-ComplexType Vertex4::value(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const
-{
-    ComplexType Value = Chi4(MatsubaraNumber1,MatsubaraNumber2,MatsubaraNumber3);
+ComplexType Vertex4::value(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const {
+    ComplexType Value = Chi4(MatsubaraNumber1, MatsubaraNumber2, MatsubaraNumber3);
 
     if(MatsubaraNumber1 == MatsubaraNumber3)
-        Value += beta*  G13(MatsubaraNumber1)*G24(MatsubaraNumber2);
+        Value += beta * G13(MatsubaraNumber1) * G24(MatsubaraNumber2);
     if(MatsubaraNumber2 == MatsubaraNumber3)
-        Value -= beta*  G14(MatsubaraNumber1)*G23(MatsubaraNumber2);
+        Value -= beta * G14(MatsubaraNumber1) * G23(MatsubaraNumber2);
 
     return Value;
 }
 
-ComplexType Vertex4::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const
-{
-    return Storage(MatsubaraNumber1,MatsubaraNumber2,MatsubaraNumber3);
+ComplexType Vertex4::operator()(long MatsubaraNumber1, long MatsubaraNumber2, long MatsubaraNumber3) const {
+    return Storage(MatsubaraNumber1, MatsubaraNumber2, MatsubaraNumber3);
 }
 
 } // namespace Pomerol

--- a/test/AndersonComplexTest.cpp
+++ b/test/AndersonComplexTest.cpp
@@ -27,45 +27,44 @@ struct GF_ref {
     std::vector<RealType> E;
     std::vector<RealType> w;
     RealType Z = 0;
-    explicit GF_ref(ComplexType J) :
-        phi(std::arg(J)),
-        E{0, -mu-std::abs(J), -mu+std::abs(J), -2*mu+U} {
+    explicit GF_ref(ComplexType J) : phi(std::arg(J)), E{0, -mu - std::abs(J), -mu + std::abs(J), -2 * mu + U} {
         for(double e : E) {
             w.push_back(std::exp(-beta * e));
             Z += w.back();
         }
-        for(int i = 0; i < E.size(); ++i) w[i] /= Z;
+        for(int i = 0; i < E.size(); ++i)
+            w[i] /= Z;
     }
 
     ComplexType operator()(spin s1, spin s2, int n) const {
-        ComplexType iw = ComplexType(0,M_PI*(2*n+1)/beta);
+        ComplexType iw = ComplexType(0, M_PI * (2 * n + 1) / beta);
 
         using LatticePresets::up;
         using LatticePresets::down;
 
         ComplexType res = 0;
         if(s1 == up && s2 == up) {
-            res += 0.5*(w[1] + w[0])/(iw - (E[1] - E[0]));
-            res += 0.5*(w[2] + w[0])/(iw - (E[2] - E[0]));
-            res += 0.5*(w[3] + w[1])/(iw - (E[3] - E[1]));
-            res += 0.5*(w[3] + w[2])/(iw - (E[3] - E[2]));
+            res += 0.5 * (w[1] + w[0]) / (iw - (E[1] - E[0]));
+            res += 0.5 * (w[2] + w[0]) / (iw - (E[2] - E[0]));
+            res += 0.5 * (w[3] + w[1]) / (iw - (E[3] - E[1]));
+            res += 0.5 * (w[3] + w[2]) / (iw - (E[3] - E[2]));
         } else if(s1 == up && s2 == down) {
-            ComplexType u = std::exp(ComplexType(0,phi));
-            res += -u*0.5*(w[1] + w[0])/(iw - (E[1] - E[0]));
-            res += u*0.5*(w[2] + w[0])/(iw - (E[2] - E[0]));
-            res += u*0.5*(w[3] + w[1])/(iw - (E[3] - E[1]));
-            res += -u*0.5*(w[3] + w[2])/(iw - (E[3] - E[2]));
+            ComplexType u = std::exp(ComplexType(0, phi));
+            res += -u * 0.5 * (w[1] + w[0]) / (iw - (E[1] - E[0]));
+            res += u * 0.5 * (w[2] + w[0]) / (iw - (E[2] - E[0]));
+            res += u * 0.5 * (w[3] + w[1]) / (iw - (E[3] - E[1]));
+            res += -u * 0.5 * (w[3] + w[2]) / (iw - (E[3] - E[2]));
         } else if(s1 == down && s2 == up) {
-            ComplexType u = std::exp(ComplexType(0,-phi));
-            res += -u*0.5*(w[1] + w[0])/(iw - (E[1] - E[0]));
-            res += u*0.5*(w[2] + w[0])/(iw - (E[2] - E[0]));
-            res += u*0.5*(w[3] + w[1])/(iw - (E[3] - E[1]));
-            res += -u*0.5*(w[3] + w[2])/(iw - (E[3] - E[2]));
+            ComplexType u = std::exp(ComplexType(0, -phi));
+            res += -u * 0.5 * (w[1] + w[0]) / (iw - (E[1] - E[0]));
+            res += u * 0.5 * (w[2] + w[0]) / (iw - (E[2] - E[0]));
+            res += u * 0.5 * (w[3] + w[1]) / (iw - (E[3] - E[1]));
+            res += -u * 0.5 * (w[3] + w[2]) / (iw - (E[3] - E[2]));
         } else {
-            res += 0.5*(w[1] + w[0])/(iw - (E[1] - E[0]));
-            res += 0.5*(w[2] + w[0])/(iw - (E[2] - E[0]));
-            res += 0.5*(w[3] + w[1])/(iw - (E[3] - E[1]));
-            res += 0.5*(w[3] + w[2])/(iw - (E[3] - E[2]));
+            res += 0.5 * (w[1] + w[0]) / (iw - (E[1] - E[0]));
+            res += 0.5 * (w[2] + w[0]) / (iw - (E[2] - E[0]));
+            res += 0.5 * (w[3] + w[1]) / (iw - (E[3] - E[1]));
+            res += 0.5 * (w[3] + w[2]) / (iw - (E[3] - E[2]));
         }
         return res;
     }
@@ -77,12 +76,11 @@ TEST_CASE("Bare Anderson atom with complex spin mixing", "[AndersonComplex]") {
     auto J = GENERATE(ComplexType(0.1, 0),
                       ComplexType(-0.1, 0),
                       ComplexType(0, 0.1),
-                      ComplexType(0,-0.1),
+                      ComplexType(0, -0.1),
                       ComplexType(0.1, 0.1),
-                      ComplexType(0.1,-0.1),
-                      ComplexType(-0.1,0.1),
-                      ComplexType(-0.1,-0.1)
-                      );
+                      ComplexType(0.1, -0.1),
+                      ComplexType(-0.1, 0.1),
+                      ComplexType(-0.1, -0.1));
 
     using namespace LatticePresets;
 
@@ -115,14 +113,15 @@ TEST_CASE("Bare Anderson atom with complex spin mixing", "[AndersonComplex]") {
     // Reference
     GF_ref G_ref(J);
 
-    for(spin s1 : {down, up}){
-        for(spin s2 : {down, up}){
-            ParticleIndex index1 = IndexInfo.getIndex("C",0,s1);
-            ParticleIndex index2 = IndexInfo.getIndex("C",0,s2);
-            GreensFunction GF(S,H,
-                Operators.getAnnihilationOperator(index1),
-                Operators.getCreationOperator(index2),
-            rho);
+    for(spin s1 : {down, up}) {
+        for(spin s2 : {down, up}) {
+            ParticleIndex index1 = IndexInfo.getIndex("C", 0, s1);
+            ParticleIndex index2 = IndexInfo.getIndex("C", 0, s2);
+            GreensFunction GF(S,
+                              H,
+                              Operators.getAnnihilationOperator(index1),
+                              Operators.getCreationOperator(index2),
+                              rho);
             GF.prepare();
             GF.compute();
 

--- a/test/AndersonTest.cpp
+++ b/test/AndersonTest.cpp
@@ -22,27 +22,31 @@ TEST_CASE("Anderson model with 2 bath sites", "[Anderson]") {
 
     // Reference Green's functions
     ComplexVectorType G_ref_up(10);
-    G_ref_up << -0.7545439 -0.14723373*I,
-                -0.59517353-0.34478922*I,
-                -0.42646689-0.4031622*I,
-                -0.30758605-0.39519013*I,
-                -0.23068661-0.36811109*I,
-                -0.18013326-0.33885065*I,
-                -0.14541077-0.31208195*I,
-                -0.12043127-0.28860297*I,
-                -0.10171394-0.26815136*I, // cppcheck-suppress constStatement
-                -0.08721336-0.25025992*I;
+    // clang-format off
+    G_ref_up << -0.7545439 - 0.14723373 * I,
+                -0.59517353 - 0.34478922 * I,
+                -0.42646689 - 0.4031622 * I,
+                -0.30758605 - 0.39519013 * I,
+                -0.23068661 - 0.36811109 * I,
+                -0.18013326 - 0.33885065 * I,
+                -0.14541077 - 0.31208195 * I,
+                -0.12043127 - 0.28860297 * I,
+                -0.10171394 - 0.26815136 * I, // cppcheck-suppress constStatement
+                -0.08721336 - 0.25025992 * I;
+    // clang-format on
     ComplexVectorType G_ref_down(10);
-    G_ref_down << 0.49196891-0.07241433*I,
-                  0.44396903-0.18681652*I,
-                  0.37248532-0.24764566*I,
-                  0.30425235-0.26969548*I,
-                  0.24921656-0.27135953*I,
-                  0.20705484-0.26399883*I,
-                  0.1748209 -0.25319165*I,
-                  0.14976473-0.2414213*I,
-                  0.12986709-0.22973732*I, // cppcheck-suppress constStatement
-                  0.11373954-0.21855949*I;
+    // clang-format off
+    G_ref_down << 0.49196891 - 0.07241433 * I,
+                  0.44396903 - 0.18681652 * I,
+                  0.37248532 - 0.24764566 * I,
+                  0.30425235 - 0.26969548 * I,
+                  0.24921656 - 0.27135953 * I,
+                  0.20705484 - 0.26399883 * I,
+                  0.1748209 - 0.25319165 * I,
+                  0.14976473 - 0.2414213 * I,
+                  0.12986709 - 0.22973732 * I, // cppcheck-suppress constStatement
+                  0.11373954 - 0.21855949 * I;
+    // clang-format on
 
     using namespace LatticePresets;
 
@@ -79,18 +83,22 @@ TEST_CASE("Anderson model with 2 bath sites", "[Anderson]") {
     ParticleIndex C_down_index = IndexInfo.getIndex("C", 0, down);
     ParticleIndex C_up_index = IndexInfo.getIndex("C", 0, up);
 
-    GreensFunction GF_down(S, H,
-        Operators.getAnnihilationOperator(C_down_index),
-        Operators.getCreationOperator(C_down_index),
-    rho);
+    GreensFunction GF_down(S,
+                           H,
+                           Operators.getAnnihilationOperator(C_down_index),
+                           Operators.getCreationOperator(C_down_index),
+                           rho);
 
-    GreensFunction GF_up(S, H,
-        Operators.getAnnihilationOperator(C_up_index),
-        Operators.getCreationOperator(C_up_index),
-    rho);
+    GreensFunction GF_up(S,
+                         H,
+                         Operators.getAnnihilationOperator(C_up_index),
+                         Operators.getCreationOperator(C_up_index),
+                         rho);
 
-    GF_down.prepare(); GF_up.prepare();
-    GF_down.compute(); GF_up.compute();
+    GF_down.prepare();
+    GF_up.prepare();
+    GF_down.compute();
+    GF_up.compute();
 
     for(int n = 0; n < G_ref_up.size(); ++n) {
         REQUIRE_THAT(GF_up(n), IsCloseTo(G_ref_up[n], 1e-8));

--- a/test/BroadcastTest.cpp
+++ b/test/BroadcastTest.cpp
@@ -9,32 +9,24 @@
 
 namespace Pomerol {
 
-bool operator==(TwoParticleGFPart::NonResonantTerm const& t1,
-                TwoParticleGFPart::NonResonantTerm const& t2) {
-    return t1.Coeff == t2.Coeff &&
-           std::equal(t1.Poles.begin(), t1.Poles.end(), t2.Poles.begin()) &&
-           t1.isz4 == t2.isz4 &&
-           t1.Weight == t2.Weight;
+bool operator==(TwoParticleGFPart::NonResonantTerm const& t1, TwoParticleGFPart::NonResonantTerm const& t2) {
+    return t1.Coeff == t2.Coeff && std::equal(t1.Poles.begin(), t1.Poles.end(), t2.Poles.begin()) &&
+           t1.isz4 == t2.isz4 && t1.Weight == t2.Weight;
 }
-bool operator!=(TwoParticleGFPart::NonResonantTerm const& t1,
-                TwoParticleGFPart::NonResonantTerm const& t2) {
+bool operator!=(TwoParticleGFPart::NonResonantTerm const& t1, TwoParticleGFPart::NonResonantTerm const& t2) {
     return !operator==(t1, t2);
 }
 
-bool operator==(TwoParticleGFPart::ResonantTerm const& t1,
-                TwoParticleGFPart::ResonantTerm const& t2) {
-    return t1.ResCoeff == t2.ResCoeff &&
-           t1.NonResCoeff == t2.NonResCoeff &&
-           std::equal(t1.Poles.begin(), t1.Poles.end(), t2.Poles.begin()) &&
-           t1.isz1z2 == t2.isz1z2 &&
+bool operator==(TwoParticleGFPart::ResonantTerm const& t1, TwoParticleGFPart::ResonantTerm const& t2) {
+    return t1.ResCoeff == t2.ResCoeff && t1.NonResCoeff == t2.NonResCoeff &&
+           std::equal(t1.Poles.begin(), t1.Poles.end(), t2.Poles.begin()) && t1.isz1z2 == t2.isz1z2 &&
            t1.Weight == t2.Weight;
 }
-bool operator!=(TwoParticleGFPart::ResonantTerm const& t1,
-                TwoParticleGFPart::ResonantTerm const& t2) {
+bool operator!=(TwoParticleGFPart::ResonantTerm const& t1, TwoParticleGFPart::ResonantTerm const& t2) {
     return !operator==(t1, t2);
 }
 
-}
+} // namespace Pomerol
 
 using namespace Pomerol;
 
@@ -42,14 +34,9 @@ TEST_CASE("broadcast() methods of various objects", "[broadcast]") {
     int rank = pMPI::rank(MPI_COMM_WORLD);
 
     // Reference objects
-    TwoParticleGFPart::NonResonantTerm tnr_ref(ComplexType(4.0, 3.0),
-                                               -0.1, 0.2, 0.3, true
-    );
+    TwoParticleGFPart::NonResonantTerm tnr_ref(ComplexType(4.0, 3.0), -0.1, 0.2, 0.3, true);
     tnr_ref.Weight = 100;
-    TwoParticleGFPart::ResonantTerm tr_ref(ComplexType(4.0, 3.0),
-                                            ComplexType(5.0, 6.0),
-                                          -0.1, 0.2, 0.3, true
-    );
+    TwoParticleGFPart::ResonantTerm tr_ref(ComplexType(4.0, 3.0), ComplexType(5.0, 6.0), -0.1, 0.2, 0.3, true);
     tr_ref.Weight = 100;
 
     SECTION("TwoParticleGFPart::NonResonantTerm::mpi_datatype()") {
@@ -59,9 +46,11 @@ TEST_CASE("broadcast() methods of various objects", "[broadcast]") {
 
         std::vector<TwoParticleGFPart::NonResonantTerm> tnr_v(10, tnr);
 
-        MPI_Bcast(tnr_v.data(), static_cast<int>(tnr_v.size()),
+        MPI_Bcast(tnr_v.data(),
+                  static_cast<int>(tnr_v.size()),
                   TwoParticleGFPart::NonResonantTerm::mpi_datatype(),
-                  0, MPI_COMM_WORLD);
+                  0,
+                  MPI_COMM_WORLD);
 
         for(auto const& t : tnr_v)
             REQUIRE(t == tnr_ref);
@@ -74,31 +63,27 @@ TEST_CASE("broadcast() methods of various objects", "[broadcast]") {
             tr = tr_ref;
 
         std::vector<TwoParticleGFPart::ResonantTerm> tr_v(10, tr);
-        MPI_Bcast(tr_v.data(), static_cast<int>(tr_v.size()),
+        MPI_Bcast(tr_v.data(),
+                  static_cast<int>(tr_v.size()),
                   TwoParticleGFPart::ResonantTerm::mpi_datatype(),
-                  0, MPI_COMM_WORLD);
+                  0,
+                  MPI_COMM_WORLD);
 
         for(auto const& t : tr_v)
             REQUIRE(t == tr_ref);
     }
 
     SECTION("TermList::broadcast()") {
-        TermList<TwoParticleGFPart::NonResonantTerm> tl(
-            TwoParticleGFPart::NonResonantTerm::Compare(1.0/1024),
-            TwoParticleGFPart::NonResonantTerm::IsNegligible(1.0/1024)
-        );
+        TermList<TwoParticleGFPart::NonResonantTerm> tl(TwoParticleGFPart::NonResonantTerm::Compare(1.0 / 1024),
+                                                        TwoParticleGFPart::NonResonantTerm::IsNegligible(1.0 / 1024));
         tl.add_term(tnr_ref);
 
         TermList<TwoParticleGFPart::NonResonantTerm> tl_ref(
-            TwoParticleGFPart::NonResonantTerm::Compare(1.0/2048),
-            TwoParticleGFPart::NonResonantTerm::IsNegligible(1.0/2048)
-        );
-        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(1.0, 2.0),
-                                                       -0.1, 0.2, 0.4, true));
-        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(1.0, 8.0),
-                                                       -0.4, 0.2, 0.4, false));
-        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(7.0, 2.0),
-                                                       -0.6, 0.2, 0.4, true));
+            TwoParticleGFPart::NonResonantTerm::Compare(1.0 / 2048),
+            TwoParticleGFPart::NonResonantTerm::IsNegligible(1.0 / 2048));
+        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(1.0, 2.0), -0.1, 0.2, 0.4, true));
+        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(1.0, 8.0), -0.4, 0.2, 0.4, false));
+        tl_ref.add_term(TwoParticleGFPart::NonResonantTerm(ComplexType(7.0, 2.0), -0.6, 0.2, 0.4, true));
 
         if(rank == 0)
             tl = tl_ref;

--- a/test/GF1siteTest.cpp
+++ b/test/GF1siteTest.cpp
@@ -26,8 +26,8 @@
 
 #include <pomerol/DensityMatrix.hpp>
 #include <pomerol/FieldOperatorContainer.hpp>
-#include <pomerol/GreensFunction.hpp>
 #include <pomerol/GFContainer.hpp>
+#include <pomerol/GreensFunction.hpp>
 #include <pomerol/Hamiltonian.hpp>
 #include <pomerol/HilbertSpace.hpp>
 #include <pomerol/IndexClassification.hpp>
@@ -47,17 +47,18 @@ TEST_CASE("Green's function of a Hubbard atom", "[GF1site]") {
     RealType beta = 10.0;
 
     // Reference Green's function
-    auto G_ref = [U,mu,beta](int n)
-    {
-        RealType omega = M_PI*(2*n+1)/beta;
+    auto G_ref = [U, mu, beta](int n) {
+        RealType omega = M_PI * (2 * n + 1) / beta;
 
         RealType w0 = 1.0;
-        RealType w1 = exp(beta*mu);
-        RealType w2 = exp(-beta*(-2*mu+U));
-        RealType Z = w0 + 2*w1 +w2;
-        w0 /= Z; w1 /= Z; w2 /= Z;
+        RealType w1 = exp(beta * mu);
+        RealType w2 = exp(-beta * (-2 * mu + U));
+        RealType Z = w0 + 2 * w1 + w2;
+        w0 /= Z;
+        w1 /= Z;
+        w2 /= Z;
 
-        return (w0+w1)/(I*omega+mu) + (w1+w2)/(I*omega+mu-U);
+        return (w0 + w1) / (I * omega + mu) + (w1 + w2) / (I * omega + mu - U);
     };
 
     using namespace LatticePresets;
@@ -79,7 +80,7 @@ TEST_CASE("Green's function of a Hubbard atom", "[GF1site]") {
     INFO("Energy levels " << H.getEigenValues());
     INFO("The value of ground energy is " << H.getGroundEnergy());
 
-    DensityMatrix rho(S,H,beta);
+    DensityMatrix rho(S, H, beta);
     rho.prepare();
     rho.compute();
     for(QuantumState i = 0; i < S.getNumberOfStates(); ++i)
@@ -89,11 +90,10 @@ TEST_CASE("Green's function of a Hubbard atom", "[GF1site]") {
     Operators.prepareAll(HS);
     Operators.computeAll();
 
-    ParticleIndex down_index = IndexInfo.getIndex("A",0,down);
+    ParticleIndex down_index = IndexInfo.getIndex("A", 0, down);
 
     auto const& c_map = Operators.getCreationOperator(down_index).getBlockMapping();
-    for (auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++)
-    {
+    for(auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++) {
         INFO(c_map_it->first << "->" << c_map_it->second);
     }
 
@@ -113,23 +113,23 @@ TEST_CASE("Green's function of a Hubbard atom", "[GF1site]") {
     }
 
     SECTION("GFContainer") {
-        GFContainer G(IndexInfo,S,H,rho,Operators);
+        GFContainer G(IndexInfo, S, H, rho, Operators);
 
         std::set<IndexCombination2> indices;
-        indices.insert(IndexCombination2(0,0));
-        indices.insert(IndexCombination2(0,1));
-        indices.insert(IndexCombination2(1,0));
-        indices.insert(IndexCombination2(1,1));
+        indices.insert(IndexCombination2(0, 0));
+        indices.insert(IndexCombination2(0, 1));
+        indices.insert(IndexCombination2(1, 0));
+        indices.insert(IndexCombination2(1, 1));
 
         G.prepareAll(indices);
         G.computeAll();
 
         for(int n = -100; n < 100; ++n) {
             auto ref = G_ref(n);
-            REQUIRE_THAT(G(0,0)(n), IsCloseTo(ref, 1e-14));
-            REQUIRE_THAT(G(0,1)(n), IsCloseTo(0, 1e-14));
-            REQUIRE_THAT(G(1,0)(n), IsCloseTo(0, 1e-14));
-            REQUIRE_THAT(G(1,1)(n), IsCloseTo(ref, 1e-14));
+            REQUIRE_THAT(G(0, 0)(n), IsCloseTo(ref, 1e-14));
+            REQUIRE_THAT(G(0, 1)(n), IsCloseTo(0, 1e-14));
+            REQUIRE_THAT(G(1, 0)(n), IsCloseTo(0, 1e-14));
+            REQUIRE_THAT(G(1, 1)(n), IsCloseTo(ref, 1e-14));
         }
     }
 }

--- a/test/GF2siteTest.cpp
+++ b/test/GF2siteTest.cpp
@@ -48,21 +48,23 @@ TEST_CASE("Green's function of a Hubbard dimer", "[GF2site]") {
 
     // Reference Green's function
     ComplexVectorType G_ref(10);
-    G_ref << -2.53021005e-01*I,
-             -4.62090702e-01*I,
-             -4.32482782e-01*I,
-             -3.65598615e-01*I,
-             -3.07785174e-01*I,
-             -2.62894141e-01*I,
-             -2.28274316e-01*I,
-             -2.01170772e-01*I,
-             -1.79539602e-01*I, // cppcheck-suppress constStatement
-             -1.61950993e-01*I;
+    // clang-format off
+    G_ref << -2.53021005e-01 * I,
+             -4.62090702e-01 * I,
+             -4.32482782e-01 * I,
+             -3.65598615e-01 * I,
+             -3.07785174e-01 * I,
+             -2.62894141e-01 * I,
+             -2.28274316e-01 * I,
+             -2.01170772e-01 * I,
+             -1.79539602e-01 * I, // cppcheck-suppress constStatement
+             -1.61950993e-01 * I;
+    // clang-format on
 
     using namespace LatticePresets;
 
     auto HExpr = CoulombS("A", U, -mu) + CoulombS("B", U, -mu);
-    HExpr += Hopping("A","B", -1.0);
+    HExpr += Hopping("A", "B", -1.0);
     INFO("Hamiltonian\n" << HExpr);
 
     auto IndexInfo = MakeIndexClassification(HExpr);
@@ -95,7 +97,7 @@ TEST_CASE("Green's function of a Hubbard dimer", "[GF2site]") {
     INFO("Energy levels " << H.getEigenValues());
     INFO("The value of ground energy is " << H.getGroundEnergy());
 
-    DensityMatrix rho(S,H,beta);
+    DensityMatrix rho(S, H, beta);
     rho.prepare();
     rho.compute();
     for(QuantumState i = 0; i < S.getNumberOfStates(); ++i)
@@ -105,11 +107,10 @@ TEST_CASE("Green's function of a Hubbard dimer", "[GF2site]") {
     Operators.prepareAll(HS);
     Operators.computeAll();
 
-    ParticleIndex A_down_index = IndexInfo.getIndex("A",0,down);
+    ParticleIndex A_down_index = IndexInfo.getIndex("A", 0, down);
 
     auto const& c_map = Operators.getCreationOperator(A_down_index).getBlockMapping();
-    for(auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++)
-    {
+    for(auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++) {
         INFO(c_map_it->first << "->" << c_map_it->second);
     }
 

--- a/test/GF4siteTest.cpp
+++ b/test/GF4siteTest.cpp
@@ -42,17 +42,19 @@ TEST_CASE("Green's function of a Hubbard plaquette", "[GF4site]") {
     RealType beta = 10.0;
 
     // Reference Green's function
+    // clang-format off
     ComplexVectorType G_ref(10);
-    G_ref <<  0.00515461461  -0.191132319*I,
-             -0.0129218293   -0.35749415*I,
-             -0.0063208255   -0.364571553*I,
-             -0.00244599255  -0.326995909*I,
-             -0.000938220077 -0.285235829*I,
-             -0.000360621591 -0.248974505*I,
-             -0.000129046261 -0.219206946*I,
-             -3.20102701e-05 -0.194983212*I,
-              9.51503858e-06 -0.175149329*I, // cppcheck-suppress constStatement
-              2.68929175e-05 -0.158732731*I;
+    G_ref << 0.00515461461 - 0.191132319 * I,
+            -0.0129218293 - 0.35749415 * I,
+            -0.0063208255 - 0.364571553 * I,
+            -0.00244599255 - 0.326995909 * I,
+            -0.000938220077 - 0.285235829 * I,
+            -0.000360621591 - 0.248974505 * I,
+            -0.000129046261 - 0.219206946 * I,
+            -3.20102701e-05 - 0.194983212 * I,
+             9.51503858e-06 - 0.175149329 * I, // cppcheck-suppress constStatement
+             2.68929175e-05 - 0.158732731 * I;
+    // clang-format on
 
     using namespace LatticePresets;
 
@@ -81,7 +83,7 @@ TEST_CASE("Green's function of a Hubbard plaquette", "[GF4site]") {
     INFO("Energy levels " << H.getEigenValues());
     INFO("The value of ground energy is " << H.getGroundEnergy());
 
-    DensityMatrix rho(S,H,beta);
+    DensityMatrix rho(S, H, beta);
     rho.prepare();
     rho.compute();
     for(QuantumState i = 0; i < S.getNumberOfStates(); ++i)
@@ -94,8 +96,7 @@ TEST_CASE("Green's function of a Hubbard plaquette", "[GF4site]") {
     ParticleIndex A_down_index = IndexInfo.getIndex("A", 0, down);
 
     auto const& c_map = Operators.getCreationOperator(A_down_index).getBlockMapping();
-    for(auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++)
-    {
+    for(auto c_map_it = c_map.right.begin(); c_map_it != c_map.right.end(); c_map_it++) {
         INFO(c_map_it->first << "->" << c_map_it->second);
     }
 

--- a/test/HamiltonianBosonsTest.cpp
+++ b/test/HamiltonianBosonsTest.cpp
@@ -41,8 +41,7 @@
 
 using namespace Pomerol;
 
-TEST_CASE("Hamiltonian of an isolated Hubbard-Holstein atom",
-          "[HubbardHolstein]") {
+TEST_CASE("Hamiltonian of an isolated Hubbard-Holstein atom", "[HubbardHolstein]") {
     using namespace LatticePresets;
     using namespace Operators;
 
@@ -76,8 +75,7 @@ TEST_CASE("Hamiltonian of an isolated Hubbard-Holstein atom",
     std::sort(ev_ref.begin(), ev_ref.end());
 
     auto HExpr = CoulombS("A", U, -mu);
-    HExpr += BosonLevel("A", Omega, 0) +
-             HolsteinInteraction("A", lambda, 0, 0);
+    HExpr += BosonLevel("A", Omega, 0) + HolsteinInteraction("A", lambda, 0, 0);
     INFO("Hamiltonian\n" << HExpr);
 
     auto IndexInfo = MakeIndexClassification(HExpr);

--- a/test/HamiltonianTest.cpp
+++ b/test/HamiltonianTest.cpp
@@ -24,8 +24,8 @@
 ** \author Andrey Antipov (Andrey.E.Antipov@gmail.com)
 */
 
-#include <pomerol/HamiltonianPart.hpp>
 #include <pomerol/Hamiltonian.hpp>
+#include <pomerol/HamiltonianPart.hpp>
 #include <pomerol/HilbertSpace.hpp>
 #include <pomerol/Index.hpp>
 #include <pomerol/IndexClassification.hpp>
@@ -81,7 +81,8 @@ TEST_CASE("Simple Hamiltonian test", "[hamiltonian]") {
         op.compute();
         BlockNumber result_block = op.getLeftIndex(test_block);
 
-        INFO("Acting with rotated cdag_" << op_index << " on block " << test_block << " and receiving " << result_block);
+        INFO("Acting with rotated cdag_" << op_index << " on block " << test_block << " and receiving "
+                                         << result_block);
 
         using LOperatorT = LOperatorType<RealType>;
 

--- a/test/MPIDispatcherTest.cpp
+++ b/test/MPIDispatcherTest.cpp
@@ -34,22 +34,22 @@ TEST_CASE("Test mpi_dispatcher", "[mpi_dispatcher]") {
 
         std::unique_ptr<MPIMaster> disp(comm_rank == root ? new MPIMaster(MPI_COMM_WORLD, ntasks, true) : nullptr);
 
-        if (comm_rank == root) {
+        if(comm_rank == root) {
             disp->order();
         }
         MPI_Barrier(MPI_COMM_WORLD);
 
         while(!worker.is_finished()) {
-            if (comm_rank == root) disp->order();
+            if(comm_rank == root)
+                disp->order();
             worker.receive_order();
-            if (worker.is_working()) {
+            if(worker.is_working()) {
                 dumb_task(dist(gen), worker.current_job(), comm_rank);
                 worker.report_job_done();
             };
-            if (comm_rank == root) {
-                INFO("--> stack size = " << disp->JobStack.size() <<
-                     " --> worker stack size =" << disp->WorkerStack.size() <<
-                     "\n");
+            if(comm_rank == root) {
+                INFO("--> stack size = " << disp->JobStack.size()
+                                         << " --> worker stack size =" << disp->WorkerStack.size() << "\n");
                 disp->check_workers();
             }
         }
@@ -65,18 +65,17 @@ TEST_CASE("Test mpi_dispatcher", "[mpi_dispatcher]") {
         dumb_task_type dumb_task;
         int ntasks = 45;
 
-        if (comm_rank == root) {
+        if(comm_rank == root) {
             MPIMaster master(MPI_COMM_WORLD, ntasks, false);
-            for (; !master.is_finished();) {
+            for(; !master.is_finished();) {
                 master.order();
                 master.check_workers();
             }
-        }
-        else {
+        } else {
             MPIWorker worker(MPI_COMM_WORLD, root);
-            for (; !worker.is_finished();) {
+            for(; !worker.is_finished();) {
                 worker.receive_order();
-                if (worker.is_working()) {
+                if(worker.is_working()) {
                     dumb_task(dist(gen), worker.current_job(), comm_rank);
                     worker.report_job_done();
                 }

--- a/test/SusceptibilityTest.cpp
+++ b/test/SusceptibilityTest.cpp
@@ -18,8 +18,8 @@
 // You should have received a copy of the GNU General Public License
 // along with pomerol.  If not, see <http://www.gnu.org/licenses/>.
 
-#include <pomerol/EnsembleAverage.hpp>
 #include <pomerol/DensityMatrix.hpp>
+#include <pomerol/EnsembleAverage.hpp>
 #include <pomerol/Hamiltonian.hpp>
 #include <pomerol/HilbertSpace.hpp>
 #include <pomerol/IndexClassification.hpp>
@@ -41,7 +41,7 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
     RealType beta = 10.0;
     int n_iw = 20;
 
-    auto omega = [beta](int n) { return M_PI * (2*n) / beta; };
+    auto omega = [beta](int n) { return M_PI * (2 * n) / beta; };
 
     using namespace LatticePresets;
 
@@ -62,12 +62,12 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
     INFO("Energy levels " << H.getEigenValues());
     INFO("The value of ground energy is " << H.getGroundEnergy());
 
-    DensityMatrix rho(S,H,beta);
+    DensityMatrix rho(S, H, beta);
     rho.prepare();
     rho.compute();
 
-    ParticleIndex up_index = IndexInfo.getIndex("A",0,up);
-    ParticleIndex dn_index = IndexInfo.getIndex("A",0,down);
+    ParticleIndex up_index = IndexInfo.getIndex("A", 0, up);
+    ParticleIndex dn_index = IndexInfo.getIndex("A", 0, down);
 
     // Quadratic operators of form c^+ c
     QuadraticOperator s_plus(IndexInfo, HS, S, H, up_index, dn_index);
@@ -75,17 +75,14 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
     QuadraticOperator n_up(IndexInfo, HS, S, H, up_index, up_index);
     QuadraticOperator n_dn(IndexInfo, HS, S, H, dn_index, dn_index);
 
-    for(auto * op : {&s_plus, &s_minus, &n_up, &n_dn}) {
+    for(auto* op : {&s_plus, &s_minus, &n_up, &n_dn}) {
         op->prepare(HS);
         op->compute();
     }
 
     // Reference statistical weights of states
     RealVectorType weights_ref(4); // {0, up, down, 2}
-    weights_ref << 1.0,
-                   exp(-beta*(-mu-h_field)),
-                   exp(-beta*(-mu+h_field)),
-                   exp(-beta*(-2*mu+U));
+    weights_ref << 1.0, exp(-beta * (-mu - h_field)), exp(-beta * (-mu + h_field)), exp(-beta * (-2 * mu + U));
     weights_ref /= weights_ref.sum();
     RealType wu = weights_ref[1];
     RealType wd = weights_ref[2];
@@ -122,7 +119,7 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
             if(std::abs(wu - wd) < 1e-8 && n == 0) // E_up == E_down
                 g += wu * beta;
             else
-                g += -(wu - wd) / (I*omega(n) - 2*h_field);
+                g += -(wu - wd) / (I * omega(n) - 2 * h_field);
             return g;
         };
         for(int n = 0; n < n_iw; ++n)
@@ -135,9 +132,7 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
         Chi.compute();
         Chi.subtractDisconnected();
 
-        auto ref = [&](int n) {
-            return n == 0 ? (wu + w2) * (1 - wu - w2) * beta : 0;
-        };
+        auto ref = [&](int n) { return n == 0 ? (wu + w2) * (1 - wu - w2) * beta : 0; };
         for(int n = 0; n < n_iw; ++n)
             REQUIRE_THAT(Chi(n), IsCloseTo(ref(n), 1e-14));
     }
@@ -148,9 +143,7 @@ TEST_CASE("Susceptibilities of a single Hubbard atom", "[Susceptibility]") {
         Chi.compute();
         Chi.subtractDisconnected();
 
-        auto ref = [&](int n) {
-            return n == 0 ? (w2 - (wu + w2) * (wd + w2)) * beta : 0;
-        };
+        auto ref = [&](int n) { return n == 0 ? (w2 - (wu + w2) * (wd + w2)) * beta : 0; };
         for(int n = 0; n < n_iw; ++n)
             REQUIRE_THAT(Chi(n), IsCloseTo(ref(n), 1e-14));
     }

--- a/test/Vertex4Test.cpp
+++ b/test/Vertex4Test.cpp
@@ -41,7 +41,9 @@
 #include <cmath>
 
 // Generalized 'square' function.
-template<typename T> inline T sqr(T x) { return x*x; }
+template <typename T> inline T sqr(T x) {
+    return x * x;
+}
 
 using namespace Pomerol;
 
@@ -54,41 +56,41 @@ TEST_CASE("Two-particle vertex of a single Hubbard atom", "[Vertex4]") {
     // Auxiliary functions
     auto w = [beta](int n) { return M_PI * (2 * n + 1) / beta; };
     auto delta = [](int n1, int n2) { return n1 == n2 ? 1.0 : 0.0; };
-    auto deltam = [](int n1, int n2) { return n1 + n2==-1 ? 1.0 : 0.0; };
+    auto deltam = [](int n1, int n2) { return n1 + n2 == -1 ? 1.0 : 0.0; };
 
     // Reference gamma4(up,up,up,up)
-    auto Gamma4uuuu_ref = [&](int n1, int n2, int n3)
-    {
+    auto Gamma4uuuu_ref = [&](int n1, int n2, int n3) {
         RealType omega1 = w(n1);
         RealType omega2 = w(n2);
 
-        return -beta*(delta(n1,n3)-delta(n2,n3))*sqr(0.5*U)*
-                (1. + sqr(0.5*U/omega1))*
-                (1. + sqr(0.5*U/omega2));
+        return -beta * (delta(n1, n3) - delta(n2, n3)) * sqr(0.5 * U) * (1. + sqr(0.5 * U / omega1)) *
+               (1. + sqr(0.5 * U / omega2));
     };
 
     // Reference gamma4(up,down,up,down)
-    auto Gamma4udud_ref = [&](int n1, int n2, int n3)
-    {
+    auto Gamma4udud_ref = [&](int n1, int n2, int n3) {
         RealType omega1 = w(n1);
         RealType omega2 = w(n2);
         RealType omega3 = w(n3);
-        RealType omega4 = omega1+omega2-omega3;
+        RealType omega4 = omega1 + omega2 - omega3;
 
-        RealType w = 1.0/(1.0+std::exp(beta*0.5*U));
+        RealType w = 1.0 / (1.0 + std::exp(beta * 0.5 * U));
 
         ComplexType Value = U;
-        Value += -0.125*U*U*U*(sqr(omega1)+sqr(omega2)+sqr(omega3)+sqr(omega4))/(omega1*omega2*omega3*omega4);
-        Value += -0.1875*U*U*U*U*U/(omega1*omega2*omega3*omega4);
-        Value += -beta*(2*deltam(n1,n2)+delta(n1,n3))*w*sqr(0.5*U)*(1.0+sqr(0.5*U/omega2))*(1.0+sqr(0.5*U/omega3));
-        Value += beta*(2*delta(n2,n3)+delta(n1,n3))*(1-w)*sqr(0.5*U)*(1.0+sqr(0.5*U/omega1))*(1.0+sqr(0.5*U/omega2));
+        Value += -0.125 * U * U * U * (sqr(omega1) + sqr(omega2) + sqr(omega3) + sqr(omega4)) /
+                 (omega1 * omega2 * omega3 * omega4);
+        Value += -0.1875 * U * U * U * U * U / (omega1 * omega2 * omega3 * omega4);
+        Value += -beta * (2 * deltam(n1, n2) + delta(n1, n3)) * w * sqr(0.5 * U) * (1.0 + sqr(0.5 * U / omega2)) *
+                 (1.0 + sqr(0.5 * U / omega3));
+        Value += beta * (2 * delta(n2, n3) + delta(n1, n3)) * (1 - w) * sqr(0.5 * U) * (1.0 + sqr(0.5 * U / omega1)) *
+                 (1.0 + sqr(0.5 * U / omega2));
 
         return Value;
     };
 
     using namespace LatticePresets;
 
-    auto HExpr = CoulombS("A", U, -U/2);
+    auto HExpr = CoulombS("A", U, -U / 2);
     INFO("Hamiltonian\n" << HExpr);
 
     auto IndexInfo = MakeIndexClassification(HExpr);
@@ -105,7 +107,7 @@ TEST_CASE("Two-particle vertex of a single Hubbard atom", "[Vertex4]") {
     INFO("Energy levels " << H.getEigenValues());
     INFO("The value of ground energy is " << H.getGroundEnergy());
 
-    DensityMatrix rho(S,H,beta);
+    DensityMatrix rho(S, H, beta);
     rho.prepare();
     rho.compute();
 
@@ -113,11 +115,11 @@ TEST_CASE("Two-particle vertex of a single Hubbard atom", "[Vertex4]") {
     Operators.prepareAll(HS);
     Operators.computeAll();
 
-    GFContainer G(IndexInfo,S,H,rho,Operators);
+    GFContainer G(IndexInfo, S, H, rho, Operators);
     G.prepareAll();
     G.computeAll();
 
-    TwoParticleGFContainer Chi(IndexInfo,S,H,rho,Operators);
+    TwoParticleGFContainer Chi(IndexInfo, S, H, rho, Operators);
     Chi.ReduceResonanceTolerance = 1e-4;
     Chi.CoefficientTolerance = 1e-12;
     Chi.prepareAll();
@@ -129,22 +131,22 @@ TEST_CASE("Two-particle vertex of a single Hubbard atom", "[Vertex4]") {
 
     SECTION("\\chi_{\\up\\up\\up\\up} and \\Gamma_{\\up\\up\\up\\up}") {
         GreensFunction const& GF = G(up_index, up_index);
-        TwoParticleGF const& Chi_uuuu = Chi(IndexCombination4(up_index,up_index,up_index,up_index));
-        Vertex4 Gamma4_uuuu(Chi_uuuu,GF,GF,GF,GF);
+        TwoParticleGF const& Chi_uuuu = Chi(IndexCombination4(up_index, up_index, up_index, up_index));
+        Vertex4 Gamma4_uuuu(Chi_uuuu, GF, GF, GF, GF);
         for(int n1 = -n_iw; n1 < n_iw; ++n1) {
             for(int n2 = -n_iw; n2 < n_iw; ++n2) {
                 for(int n3 = -n_iw; n3 < n_iw; ++n3) {
-                    int n4 = n1+n2-n3;
-                    INFO(n1 << " " << n2 << " " << n3 << " " << n1+n2-n3);
+                    int n4 = n1 + n2 - n3;
+                    INFO(n1 << " " << n2 << " " << n3 << " " << n1 + n2 - n3);
 
-                    ComplexType chi_value = Chi_uuuu(n1,n2,n3);
-                    ComplexType chi_ref = Gamma4uuuu_ref(n1,n2,n3)*GF(n1)*GF(n2)*GF(n3)*GF(n4)
-                                        + beta*GF(n1)*GF(n2)*delta(n1,n4)
-                                        - beta*GF(n1)*GF(n2)*delta(n1,n3);
+                    ComplexType chi_value = Chi_uuuu(n1, n2, n3);
+                    ComplexType chi_ref = Gamma4uuuu_ref(n1, n2, n3) * GF(n1) * GF(n2) * GF(n3) * GF(n4) +
+                                          beta * GF(n1) * GF(n2) * delta(n1, n4) -
+                                          beta * GF(n1) * GF(n2) * delta(n1, n3);
                     REQUIRE_THAT(chi_value, IsCloseTo(chi_ref, 1e-6));
 
-                    ComplexType Gamma_value = Gamma4_uuuu.value(n1,n2,n3);
-                    ComplexType Gamma_ref = Gamma4uuuu_ref(n1,n2,n3)*GF(n1)*GF(n2)*GF(n3)*GF(n4);
+                    ComplexType Gamma_value = Gamma4_uuuu.value(n1, n2, n3);
+                    ComplexType Gamma_ref = Gamma4uuuu_ref(n1, n2, n3) * GF(n1) * GF(n2) * GF(n3) * GF(n4);
                     REQUIRE_THAT(Gamma_value, IsCloseTo(Gamma_ref, 1e-6));
                 }
             }
@@ -154,16 +156,17 @@ TEST_CASE("Two-particle vertex of a single Hubbard atom", "[Vertex4]") {
     SECTION("\\chi_{\\up\\down\\up\\down}") {
         GreensFunction const& GF_up = G(up_index, up_index);
         GreensFunction const& GF_down = G(down_index, down_index);
-        TwoParticleGF const& Chi_udud = Chi(IndexCombination4(up_index,down_index,up_index,down_index));
+        TwoParticleGF const& Chi_udud = Chi(IndexCombination4(up_index, down_index, up_index, down_index));
         for(int n1 = -n_iw; n1 < n_iw; ++n1) {
             for(int n2 = -n_iw; n2 < n_iw; ++n2) {
                 for(int n3 = -n_iw; n3 < n_iw; ++n3) {
-                    int n4 = n1+n2-n3;
-                    INFO(n1 << " " << n2 << " " << n3 << " " << n1+n2-n3);
+                    int n4 = n1 + n2 - n3;
+                    INFO(n1 << " " << n2 << " " << n3 << " " << n4);
 
-                    ComplexType chi_value = Chi_udud(n1,n2,n3);
-                    ComplexType chi_ref = Gamma4udud_ref(n1,n2,n3)*GF_up(n1)*GF_down(n2)*GF_up(n3)*GF_down(n4)
-                                        - beta*GF_up(n1)*GF_down(n2)*delta(n1,n3);
+                    ComplexType chi_value = Chi_udud(n1, n2, n3);
+                    ComplexType chi_ref =
+                        Gamma4udud_ref(n1, n2, n3) * GF_up(n1) * GF_down(n2) * GF_up(n3) * GF_down(n4) -
+                        beta * GF_up(n1) * GF_down(n2) * delta(n1, n3);
                     REQUIRE_THAT(chi_value, IsCloseTo(chi_ref, 1e-6));
                 }
             }


### PR DESCRIPTION
I suggest we use the LLVM formatting style with a few adjustments (see [`.clang-format`](https://github.com/aeantipov/pomerol/blob/5d185ebc87a0215b9ae9d427ad366a0d1aaf2cdf/.clang-format)). I decided to set `ColumnLimit` to 120 because sticking to the limiting 80 characters per line is nowadays debatable, especially when combined with 4 characters per indentation level.

Format of the comments is ignored for now and will be corrected as needed during an upcoming documentation revision.

A bash script `scripts/clang-format.sh` has been added to make it easier to reformat the sources in the future.