### PR TITLE
Fix building of progs

### DIFF
--- a/prog/CMakeLists.txt
+++ b/prog/CMakeLists.txt
@@ -11,7 +11,6 @@
 set(DEFAULT_PROGS
     anderson
     hubbard2d
-    quantum_model
 )
 
 # Find or fetch gftools


### PR DESCRIPTION
The progs `anderson` and `hubbard2d` are based on `quantum_model` but `quantum_model` itself is not a valid model.