### PR TITLE
[mpi] replace nullptr with MPI_COMM_NULL

### DIFF
--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -82,7 +82,7 @@ TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec const& freqs, 
     MPI_Barrier(comm);
     int comp = 0;
 
-    MPI_Comm comm_split = nullptr;
+    MPI_Comm comm_split = MPI_COMM_NULL;
     MPI_Comm_split(comm, proc_colors[comm_rank], comm_rank, &comm_split);
 
     for(auto iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {


### PR DESCRIPTION
Dear Pomerol developers,

This is a small fix that enables building Pomerol on systems where `std::nullptr_t` and `MPI_Comm` is not the same type (e.g. HP/Cray systems). 

For an null MPI communicator `MPI_COMM_NULL` seems to be the right thing to use, see https://linux.die.net/man/3/mpi_comm_null

Best, Hugo