### PR TITLE
HP/Cray MPI Support (Demote MPI_CXX types to MPI_C)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,8 @@ message(STATUS "MPI flags: ${MPI_CXX_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS}")
 # MPI_CXX_* datatypes
 #
 option(Use_MPI_C_datatypes
-       "Use MPI_C_* datatypes instead of similar MPI_CXX_* datatypes" OFF)
+    "Workaround: Use MPI_C_* datatypes instead of similar MPI_CXX_* datatypes"
+    OFF)
 mark_as_advanced(Use_MPI_C_datatypes)
 if(Use_MPI_C_datatypes)
     add_definitions(-DPOMEROL_MPI_BOOL=MPI_C_BOOL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,21 @@ message(STATUS "MPI includes: ${MPI_CXX_INCLUDE_PATH}")
 message(STATUS "MPI C++ libs: ${MPI_CXX_LIBRARIES}")
 message(STATUS "MPI flags: ${MPI_CXX_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS}")
 
+#
+# Workaround for MPI implementations that do not properly support
+# MPI_CXX_* datatypes
+#
+option(Use_MPI_C_datatypes
+       "Use MPI_C_* datatypes instead of similar MPI_CXX_* datatypes" OFF)
+mark_as_advanced(Use_MPI_C_datatypes)
+if(Use_MPI_C_datatypes)
+    add_definitions(-DPOMEROL_MPI_BOOL=MPI_C_BOOL
+                    -DPOMEROL_MPI_DOUBLE_COMPLEX=MPI_C_DOUBLE_COMPLEX)
+else(Use_MPI_C_datatypes)
+    add_definitions(-DPOMEROL_MPI_BOOL=MPI_CXX_BOOL
+                    -DPOMEROL_MPI_DOUBLE_COMPLEX=MPI_CXX_DOUBLE_COMPLEX)
+endif(Use_MPI_C_datatypes)
+
 # Boost
 find_package(Boost 1.54.0 REQUIRED)
 message(STATUS "Boost includes: ${Boost_INCLUDE_DIRS}" )

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ two-particle Green's functions as well as susceptibilities.
 The library, _libpomerol_ is built. It can be used for linking with executables.
 Some working executables are given in `prog` subdirectory.
 
+> :warning: It has been [reported](https://github.com/aeantipov/pomerol/pull/60)
+that some [MPICH](https://www.mpich.org/)-based MPI implementations, such as HPE
+Cray MPI may not properly support `MPI_CXX_*` datatypes, which pomerol's code
+depends on. In case you see failing MPI unit tests when linking to said MPI
+libraries, try using CMake option `-DUse_MPI_C_datatypes=ON`.
+
 ## Interfacing with your own code and other libraries
 
 Check the `tutorial` directory for an example of a pomerol-based code that is

--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -42,7 +42,7 @@ template <bool C> void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, M
     std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, false);
     MPI_Barrier(comm);
 
-    MPI_Datatype H_dt = C ? MPI_C_DOUBLE_COMPLEX : MPI_DOUBLE;
+    MPI_Datatype H_dt = C ? POMEROL_MPI_DOUBLE_COMPLEX : MPI_DOUBLE;
 
     for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
         auto& part = parts[p];
@@ -77,7 +77,7 @@ template <bool C> void Hamiltonian::computeImpl(MPI_Comm const& comm) {
 
     // Start distributing data
     MPI_Barrier(comm);
-    MPI_Datatype H_dt = C ? MPI_C_DOUBLE_COMPLEX : MPI_DOUBLE;
+    MPI_Datatype H_dt = C ? POMEROL_MPI_DOUBLE_COMPLEX : MPI_DOUBLE;
     for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
         auto& part = parts[p];
         auto& H = part.getMatrix<C>();

--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -42,7 +42,7 @@ template <bool C> void Hamiltonian::prepareImpl(LOperatorTypeRC<C> const& HOp, M
     std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, false);
     MPI_Barrier(comm);
 
-    MPI_Datatype H_dt = C ? MPI_CXX_DOUBLE_COMPLEX : MPI_DOUBLE;
+    MPI_Datatype H_dt = C ? MPI_C_DOUBLE_COMPLEX : MPI_DOUBLE;
 
     for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
         auto& part = parts[p];
@@ -77,7 +77,7 @@ template <bool C> void Hamiltonian::computeImpl(MPI_Comm const& comm) {
 
     // Start distributing data
     MPI_Barrier(comm);
-    MPI_Datatype H_dt = C ? MPI_CXX_DOUBLE_COMPLEX : MPI_DOUBLE;
+    MPI_Datatype H_dt = C ? MPI_C_DOUBLE_COMPLEX : MPI_DOUBLE;
     for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
         auto& part = parts[p];
         auto& H = part.getMatrix<C>();

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -185,7 +185,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs
         MPI_Allreduce(MPI_IN_PLACE,
                       m_data.data(),
                       static_cast<int>(m_data.size()),
-                      MPI_C_DOUBLE_COMPLEX,
+                      POMEROL_MPI_DOUBLE_COMPLEX,
                       MPI_SUM,
                       comm);
 

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -185,7 +185,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs
         MPI_Allreduce(MPI_IN_PLACE,
                       m_data.data(),
                       static_cast<int>(m_data.size()),
-                      MPI_CXX_DOUBLE_COMPLEX,
+                      MPI_C_DOUBLE_COMPLEX,
                       MPI_SUM,
                       comm);
 

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -82,7 +82,7 @@ TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec const& freqs, 
     MPI_Barrier(comm);
     int comp = 0;
 
-    MPI_Comm comm_split = nullptr;
+    MPI_Comm comm_split = MPI_COMM_NULL;
     MPI_Comm_split(comm, proc_colors[comm_rank], comm_rank, &comm_split);
 
     for(auto iter = NonTrivialElements.begin(); iter != NonTrivialElements.end(); iter++, comp++) {

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -108,11 +108,11 @@ TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec const& freqs, 
                 freq_data = storage[iter->first];
                 freq_data_size = static_cast<int>(freq_data.size());
                 MPI_Bcast(&freq_data_size, 1, MPI_LONG, sender, comm);
-                MPI_Bcast(freq_data.data(), freq_data_size, MPI_C_DOUBLE_COMPLEX, sender, comm);
+                MPI_Bcast(freq_data.data(), freq_data_size, POMEROL_MPI_DOUBLE_COMPLEX, sender, comm);
             } else {
                 MPI_Bcast(&freq_data_size, 1, MPI_LONG, sender, comm);
                 freq_data.resize(freq_data_size);
-                MPI_Bcast(freq_data.data(), freq_data_size, MPI_C_DOUBLE_COMPLEX, sender, comm);
+                MPI_Bcast(freq_data.data(), freq_data_size, POMEROL_MPI_DOUBLE_COMPLEX, sender, comm);
             }
             out[iter->first] = freq_data;
 

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -108,11 +108,11 @@ TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec const& freqs, 
                 freq_data = storage[iter->first];
                 freq_data_size = static_cast<int>(freq_data.size());
                 MPI_Bcast(&freq_data_size, 1, MPI_LONG, sender, comm);
-                MPI_Bcast(freq_data.data(), freq_data_size, MPI_CXX_DOUBLE_COMPLEX, sender, comm);
+                MPI_Bcast(freq_data.data(), freq_data_size, MPI_C_DOUBLE_COMPLEX, sender, comm);
             } else {
                 MPI_Bcast(&freq_data_size, 1, MPI_LONG, sender, comm);
                 freq_data.resize(freq_data_size);
-                MPI_Bcast(freq_data.data(), freq_data_size, MPI_CXX_DOUBLE_COMPLEX, sender, comm);
+                MPI_Bcast(freq_data.data(), freq_data_size, MPI_C_DOUBLE_COMPLEX, sender, comm);
             }
             out[iter->first] = freq_data;
 

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -87,10 +87,10 @@ MPI_Datatype TwoParticleGFPart::NonResonantTerm::mpi_datatype() {
                                     offsetof(NonResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Datatype types[] = {
-            MPI_C_DOUBLE_COMPLEX, // ComplexType Coeff
-            MPI_DOUBLE,             // RealType Poles[3]
-            MPI_C_BOOL,           // bool isz4
-            MPI_LONG                // long Weight
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_DOUBLE,                 // RealType Poles[3]
+            POMEROL_MPI_BOOL,           // bool isz4
+            MPI_LONG                    // long Weight
         };
         MPI_Type_create_struct(4, blocklengths, displacements, types, &dt);
         MPI_Type_commit(&dt);
@@ -140,11 +140,11 @@ MPI_Datatype TwoParticleGFPart::ResonantTerm::mpi_datatype() {
                                     offsetof(ResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Datatype types[] = {
-            MPI_C_DOUBLE_COMPLEX, // ComplexType ResCoeff
-            MPI_C_DOUBLE_COMPLEX, // ComplexType NonResCoeff
-            MPI_DOUBLE,             // RealType Poles[3]
-            MPI_C_BOOL,           // bool isz1z2
-            MPI_LONG                // long Weight
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType ResCoeff
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType NonResCoeff
+            MPI_DOUBLE,                 // RealType Poles[3]
+            POMEROL_MPI_BOOL,           // bool isz1z2
+            MPI_LONG                    // long Weight
         };
         MPI_Type_create_struct(5, blocklengths, displacements, types, &dt);
         MPI_Type_commit(&dt);

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -87,7 +87,7 @@ MPI_Datatype TwoParticleGFPart::NonResonantTerm::mpi_datatype() {
                                     offsetof(NonResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Datatype types[] = {
-            MPI_CXX_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_C_DOUBLE_COMPLEX, // ComplexType Coeff
             MPI_DOUBLE,             // RealType Poles[3]
             MPI_CXX_BOOL,           // bool isz4
             MPI_LONG                // long Weight
@@ -140,8 +140,8 @@ MPI_Datatype TwoParticleGFPart::ResonantTerm::mpi_datatype() {
                                     offsetof(ResonantTerm, Weight)};
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
         MPI_Datatype types[] = {
-            MPI_CXX_DOUBLE_COMPLEX, // ComplexType ResCoeff
-            MPI_CXX_DOUBLE_COMPLEX, // ComplexType NonResCoeff
+            MPI_C_DOUBLE_COMPLEX, // ComplexType ResCoeff
+            MPI_C_DOUBLE_COMPLEX, // ComplexType NonResCoeff
             MPI_DOUBLE,             // RealType Poles[3]
             MPI_CXX_BOOL,           // bool isz1z2
             MPI_LONG                // long Weight

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -89,7 +89,7 @@ MPI_Datatype TwoParticleGFPart::NonResonantTerm::mpi_datatype() {
         MPI_Datatype types[] = {
             MPI_C_DOUBLE_COMPLEX, // ComplexType Coeff
             MPI_DOUBLE,             // RealType Poles[3]
-            MPI_CXX_BOOL,           // bool isz4
+            MPI_C_BOOL,           // bool isz4
             MPI_LONG                // long Weight
         };
         MPI_Type_create_struct(4, blocklengths, displacements, types, &dt);
@@ -143,7 +143,7 @@ MPI_Datatype TwoParticleGFPart::ResonantTerm::mpi_datatype() {
             MPI_C_DOUBLE_COMPLEX, // ComplexType ResCoeff
             MPI_C_DOUBLE_COMPLEX, // ComplexType NonResCoeff
             MPI_DOUBLE,             // RealType Poles[3]
-            MPI_CXX_BOOL,           // bool isz1z2
+            MPI_C_BOOL,           // bool isz1z2
             MPI_LONG                // long Weight
         };
         MPI_Type_create_struct(5, blocklengths, displacements, types, &dt);


### PR DESCRIPTION
Dear Pomerol developers,

In order to compile Pomerol on (modern) HP/Cray systems (e.g. https://lumi-supercomputer.eu/) I had to demote the MPI_CXX_DOUBLE_COMPLEX and MPI_CXX_BOOL types to their C equivalents MPI_C_DOUBLE_COMPLEX and MPI_C_BOOL.

With this change (and the null pointer fix) Pomerol compiles and passes tests on LUMI.

Would you please consider merging this to support this class of systems?

Best, Hugo