### PR TITLE
Explicit types fix

### DIFF
--- a/include/pomerol/Hamiltonian.hpp
+++ b/include/pomerol/Hamiltonian.hpp
@@ -97,7 +97,7 @@ public:
     /// Return a single eigenvalue of the Hamiltonian.
     /// \param[in] state Index of the eigenvalue within the full diagonalized matrix of the Hamiltonian.
     /// \pre \ref compute() has been called.
-    RealType getEigenValue(unsigned long state) const;
+    RealType getEigenValue(QuantumState state) const;
 
     /// Return a list of eigenvalues of the Hamiltonian within a block.
     /// \param[in] Block Index of the diagonal block.

--- a/src/pomerol/StatesClassification.cpp
+++ b/src/pomerol/StatesClassification.cpp
@@ -49,7 +49,7 @@ void StatesClassification::checkComputed() const {
     }
 }
 
-unsigned long StatesClassification::getBlockSize(BlockNumber in) const {
+Pomerol::InnerQuantumState StatesClassification::getBlockSize(BlockNumber in) const {
     checkComputed();
     return static_cast<InnerQuantumState>(getFockStates(in).size());
 }


### PR DESCRIPTION
Dear Pomerol developers,

This is a small fix that silences `gcc12`'s complains on two implicit type casts.

Best, Hugo