### PR TITLE
3-point fermion-boson susceptibility

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,6 +17,7 @@ BinPackParameters: false
 BinPackArguments: false
 SortUsingDeclarations: false
 BreakBeforeTernaryOperators: false
+QualifierAlignment: Right
 
 # Stop clang-format from messing with Doxygen comments
 ReflowComments: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
-Main changes in Pomerol 2.0
-===========================
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.1] - Unreleased
+
+- New classes to compute the 3-point fermion-boson susceptibilities,
+  `ThreePointSusceptibility`, `ThreePointSusceptibilityPart` and
+  `ThreePointSusceptibilityContainer`.
+- `QuadraticOperator` can now be a product of two creators or two annihilators.
+- Renamed type aliases `FreqTuple` -> `FreqTuple3` and `FreqVec` -> `FreqVec3`.
+  The old names are still usable but marked as deprecated.
+
+## [2.0] - 2021-11-30
 
 - The Mozilla Public License Version 2.0 has been adopted.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 cmake_minimum_required(VERSION 3.1.0)
 
 project(pomerol CXX)
-set(POMEROL_VERSION 2.0)
+set(POMEROL_VERSION 2.1)
 set(POMEROL_DESCRIPTION "An exact diagonalization library aimed at \
 solving condensed matter models of interacting fermions")
 set(POMEROL_URL "https://aeantipov.github.io/pomerol/")

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,1 +1,1 @@
-Copyright (C) 2009-2021 Andrey Antipov, Igor Krivenko and contributors
+Copyright (C) 2009-2022 Andrey Antipov, Igor Krivenko and contributors

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Please, attribute this work by a citation to
   * Hiroshi Shinaoka
   * Nils Wentzell
   * Hugo U.R. Strand
+  * Dominik Kiese
 
 # Development/Help
 Please, feel free to contact us and to contribute!

--- a/cmake/StaticAnalysis.cmake
+++ b/cmake/StaticAnalysis.cmake
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/cmake/pomerolConfig.cmake.in
+++ b/cmake/pomerolConfig.cmake.in
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/doc/chi3cluster.py
+++ b/doc/chi3cluster.py
@@ -1,0 +1,119 @@
+#
+# \chi^{(3)} of a Hubbard cluster calculated using pycommute
+#
+
+from itertools import product
+import numpy as np
+
+from pycommute.expression import c, c_dag, n
+from pycommute.models import tight_binding, dispersion, hubbard_int
+from pycommute.loperator import HilbertSpace, LOperatorR, make_matrix
+
+from networkx.generators.lattice import grid_2d_graph
+from networkx.linalg.graphmatrix import adjacency_matrix
+
+# 3x1 Hubbard plaquette
+Nx, Ny = 3, 1
+
+# Parameters
+beta = 5.0
+t = 1.0
+U = 4.0
+mu = 0.6 * U
+
+# Lattice and hopping matrix
+lat = grid_2d_graph(Nx, Ny, periodic=True)
+hopping_matrix = -t * adjacency_matrix(lat).todense()
+
+# Lists of indices for electronic spin-up and spin-down operators.
+indices_up = [(x, y, "up") for x, y in lat.nodes()]
+indices_dn = [(x, y, "dn") for x, y in lat.nodes()]
+indices = indices_up + indices_dn
+
+# Hamiltonian of the model
+
+H = tight_binding(hopping_matrix, indices=indices_up) \
+  + tight_binding(hopping_matrix, indices=indices_dn)
+H += dispersion(-mu * np.ones(Nx*Ny), indices=indices_up) \
+  + dispersion(-mu * np.ones(Nx*Ny), indices=indices_dn)
+H += hubbard_int(U * np.ones(Nx*Ny),
+                 indices_up=indices_up, indices_dn=indices_dn)
+
+# Hilbert space
+hs = HilbertSpace(H)
+
+# Operator form of the Hamiltonian
+H_op = LOperatorR(H, hs)
+
+# Matrix form of the Hamiltonian
+H_mat = np.matrix(make_matrix(H_op, hs))
+np.testing.assert_allclose(H_mat.H, H_mat)
+
+def to_eigenbasis(O):
+    return U_mat.H @ O @ U_mat
+
+# Diagonalization
+E, U_mat = np.linalg.eigh(H_mat)
+print("E =", E)
+np.testing.assert_allclose(U_mat.H @ U_mat, np.eye(hs.dim), atol=1e-14)
+np.testing.assert_allclose(to_eigenbasis(H_mat), np.diag(E), atol=1e-13)
+
+w = np.exp(-beta * E) # Statistical weights of levels
+Z = np.sum(w) # Partition function
+w /= Z
+
+# Construct matrix representation of creation and annihilation operators
+C_mats = {ind: to_eigenbasis(make_matrix(LOperatorR(c(*ind), hs), hs)) for ind in indices}
+Cdag_mats = {ind: to_eigenbasis(make_matrix(LOperatorR(c_dag(*ind), hs), hs)) for ind in indices}
+for ind in indices:
+    np.testing.assert_allclose(C_mats[ind].H, Cdag_mats[ind], atol=1e-13)
+
+# Function f_{234} from Dominik Kiese's notes
+def f(i, j, k, w1, w2):
+    res = (w[j] + w[i]) / (E[i] - E[j] - 1j*w1)
+    if np.isclose(E[i], E[k], atol=1e-13):
+        res += beta * w[i] * np.isclose(w1, -w2, atol=1e-13)
+    else:
+        res += (w[k] - w[i]) / (E[i] - E[k] - 1j*w1 - 1j*w2)
+    res /= -(E[j] - E[k] - 1j*w2)
+    return res
+
+# \chi^{(3)}_{pp}
+def chi3_pp(x1p, x1, x2p, x2, w1, w2):
+    Delta = C_mats[x1] @ C_mats[x2]
+    res = 0
+    for i, j, k in product(range(hs.dim), repeat=3):
+        res += f(i, j, k, w1, w2) * Cdag_mats[x1p][i, j] * Cdag_mats[x2p][j, k] * Delta[k, i]
+        res += -f(i, j, k, w2, w1) * Cdag_mats[x2p][i, j] * Cdag_mats[x1p][j, k] * Delta[k, i]
+    return res
+
+# \chi^{(3)}_{ph}
+def chi3_ph(x1p, x1, x2p, x2, w1, w2):
+    N = Cdag_mats[x2p] @ C_mats[x2]
+    res = 0
+    for i, j, k in product(range(hs.dim), repeat=3):
+        res += -f(i, j, k, w1, -w2) * Cdag_mats[x1p][i, j] * C_mats[x1][j, k] * N[k, i]
+        res += f(i, j, k, -w2, w1) * C_mats[x1][i, j] * Cdag_mats[x1p][j, k] * N[k, i]
+    return res
+
+# Matsubara frequency
+def nu(n):
+    return np.pi*(2*n+1)/beta
+
+print("Particle-particle")
+x1p = (0, 0, "up")
+x1 = (2, 0, "up")
+x2p = (0, 0, "dn")
+x2 = (2, 0, "dn")
+
+for n1, n2 in product(range(-1, 2), repeat=2):
+    print(n1, n2, chi3_pp(x1p, x1, x2p, x2, nu(n1), nu(n2)))
+
+print("Particle-hole")
+x1p = (0, 0, "up")
+x1 = (0, 0, "up")
+x2p = (2, 0, "dn")
+x2 = (2, 0, "dn")
+
+for n1, n2 in product(range(-1, 2), repeat=2):
+    print(n1, n2, chi3_ph(x1p, x1, x2p, x2, nu(n1), nu(n2)))

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/mpi_dispatcher/misc.hpp
+++ b/include/mpi_dispatcher/misc.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/mpi_dispatcher/mpi_dispatcher.hpp
+++ b/include/mpi_dispatcher/mpi_dispatcher.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/mpi_dispatcher/mpi_skel.hpp
+++ b/include/mpi_dispatcher/mpi_skel.hpp
@@ -42,7 +42,6 @@ template <typename PartType> struct ComputeWrap {
     /// Complexity of a call to x.compute().
     int complexity;
 
-    ComputeWrap() = default;
     /// Constructor.
     /// \param[in] x Reference to the wrapped object.
     /// \param[in] complexity Complexity of a call to x.compute().
@@ -60,7 +59,6 @@ template <typename PartType> struct PrepareWrap {
     /// Complexity of a call to x.prepare().
     int complexity;
 
-    PrepareWrap() = default;
     /// Constructor.
     /// \param[in] x Reference to the wrapped object.
     /// \param[in] complexity Complexity of a call to x.prepare().

--- a/include/mpi_dispatcher/mpi_skel.hpp
+++ b/include/mpi_dispatcher/mpi_skel.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol.hpp
+++ b/include/pomerol.hpp
@@ -32,6 +32,8 @@
 #include "pomerol/Operators.hpp"
 #include "pomerol/StatesClassification.hpp"
 #include "pomerol/Susceptibility.hpp"
+#include "pomerol/ThreePointSusceptibility.hpp"
+#include "pomerol/ThreePointSusceptibilityContainer.hpp"
 #include "pomerol/TwoParticleGF.hpp"
 #include "pomerol/TwoParticleGFContainer.hpp"
 

--- a/include/pomerol.hpp
+++ b/include/pomerol.hpp
@@ -67,6 +67,8 @@ namespace Pomerol {
 ///     - Gibbs ensemble averages of \ref MonomialOperator "operators" of physical observables (\ref EnsembleAverage).
 ///     - Single-particle fermionic Green's functions (\ref GreensFunction, \ref GFContainer).
 ///     - Dynamical susceptibilities -- correlators of two \ref MonomialOperator's (\ref Susceptibility).
+///     - 3-point susceptibilities -- correlators of two fermionic and one bosonic quadratic operator
+///       (\ref ThreePointSusceptibility).
 ///     - Two-particle fermionic Green's functions and irreducible vertices (\ref TwoParticleGF,
 ///       \ref TwoParticleGFContainer, \ref Vertex4).
 ///

--- a/include/pomerol.hpp
+++ b/include/pomerol.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/ChaseIndices.hpp
+++ b/include/pomerol/ChaseIndices.hpp
@@ -1,0 +1,50 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file include/pomerol/ChaseIndices.hpp
+/// \brief `Chase indices` algorithm used in multipoint correlator calculations.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#ifndef POMEROL_INCLUDE_POMEROL_CHASEINDICES_HPP
+#define POMEROL_INCLUDE_POMEROL_CHASEINDICES_HPP
+
+#include "pomerol/StatesClassification.hpp"
+
+#ifndef DOXYGEN_SKIP
+#define EIGEN_YES_I_KNOW_SPARSE_MODULE_IS_NOT_STABLE_YET
+#endif
+#include <Eigen/Core>
+#include <Eigen/Sparse>
+
+namespace Pomerol {
+
+/// Make the lagging index catch up or outrun the leading index.
+template <bool Complex>
+inline bool chaseIndices(typename RowMajorMatrixType<Complex>::InnerIterator& index1_iter,
+                         typename ColMajorMatrixType<Complex>::InnerIterator& index2_iter) {
+    InnerQuantumState index1 = index1_iter.index();
+    InnerQuantumState index2 = index2_iter.index();
+
+    if(index1 == index2)
+        return true;
+
+    if(index1 < index2)
+        for(; InnerQuantumState(index1_iter.index()) < index2 && index1_iter; ++index1_iter)
+            ;
+    else
+        for(; InnerQuantumState(index2_iter.index()) < index1 && index2_iter; ++index2_iter)
+            ;
+
+    return false;
+}
+
+} // namespace Pomerol
+
+#endif // #ifndef POMEROL_INCLUDE_POMEROL_CHASEINDICES_HPP

--- a/include/pomerol/ComputableObject.hpp
+++ b/include/pomerol/ComputableObject.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/DensityMatrix.hpp
+++ b/include/pomerol/DensityMatrix.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/DensityMatrixPart.hpp
+++ b/include/pomerol/DensityMatrixPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/EnsembleAverage.hpp
+++ b/include/pomerol/EnsembleAverage.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/FieldOperatorContainer.hpp
+++ b/include/pomerol/FieldOperatorContainer.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/GFContainer.hpp
+++ b/include/pomerol/GFContainer.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/GreensFunction.hpp
+++ b/include/pomerol/GreensFunction.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/GreensFunctionPart.hpp
+++ b/include/pomerol/GreensFunctionPart.hpp
@@ -77,7 +77,7 @@ class GreensFunctionPart : public Thermal {
         public:
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the pole.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Are terms similar?
             /// \param[in] t1 First term.
             /// \param[in] t2 Second term.
@@ -93,7 +93,7 @@ class GreensFunctionPart : public Thermal {
         public:
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.

--- a/include/pomerol/GreensFunctionPart.hpp
+++ b/include/pomerol/GreensFunctionPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Hamiltonian.hpp
+++ b/include/pomerol/Hamiltonian.hpp
@@ -116,7 +116,7 @@ private:
     // Implementation details
     void computeGroundEnergy();
 
-    template <bool C> void prepareImpl(LOperatorTypeRC<C> const& HOp, const MPI_Comm& comm);
+    template <bool C> void prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& comm);
     template <bool C> void computeImpl(MPI_Comm const& comm);
 };
 

--- a/include/pomerol/Hamiltonian.hpp
+++ b/include/pomerol/Hamiltonian.hpp
@@ -116,6 +116,7 @@ private:
     // Implementation details
     void computeGroundEnergy();
 
+    // cppcheck-suppress unusedPrivateFunction
     template <bool C> void prepareImpl(LOperatorTypeRC<C> const& HOp, MPI_Comm const& comm);
     template <bool C> void computeImpl(MPI_Comm const& comm);
 };

--- a/include/pomerol/Hamiltonian.hpp
+++ b/include/pomerol/Hamiltonian.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/HamiltonianPart.hpp
+++ b/include/pomerol/HamiltonianPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/HilbertSpace.hpp
+++ b/include/pomerol/HilbertSpace.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Index.hpp
+++ b/include/pomerol/Index.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/IndexClassification.hpp
+++ b/include/pomerol/IndexClassification.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/IndexContainer2.hpp
+++ b/include/pomerol/IndexContainer2.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/IndexContainer4.hpp
+++ b/include/pomerol/IndexContainer4.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/LatticePresets.hpp
+++ b/include/pomerol/LatticePresets.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/MatsubaraContainers.hpp
+++ b/include/pomerol/MatsubaraContainers.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Misc.hpp
+++ b/include/pomerol/Misc.hpp
@@ -32,6 +32,12 @@
 #include <omp.h>
 #endif
 
+#if __cplusplus >= 201402L
+#define POMEROL_DEPRECATED [[deprecated]]
+#else
+#define POMEROL_DEPRECATED
+#endif
+
 #include <array>
 #include <complex>
 #include <cstddef>

--- a/include/pomerol/Misc.hpp
+++ b/include/pomerol/Misc.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/MonomialOperator.hpp
+++ b/include/pomerol/MonomialOperator.hpp
@@ -292,14 +292,12 @@ public:
                       ParticleIndex Index2,
                       std::tuple<bool, bool> const& Dagger = {true, false})
         : MonomialOperator(
-            (std::get<0>(Dagger) ?
-                Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index1)) :
-                Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index1))
-            ) * (
-             std::get<1>(Dagger) ?
-                Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index2)) :
-                Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index2))
-              ),
+              (std::get<0>(Dagger) ?
+                   Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index1)) :
+                   Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index1))) *
+                  (std::get<1>(Dagger) ?
+                       Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index2)) :
+                       Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index2))),
               HS,
               S,
               H),

--- a/include/pomerol/MonomialOperator.hpp
+++ b/include/pomerol/MonomialOperator.hpp
@@ -29,9 +29,11 @@
 
 #include <boost/bimap.hpp>
 
+#include <cassert>
 #include <cstddef>
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -261,12 +263,15 @@ public:
     ParticleIndex getIndex() const { return Index; }
 };
 
-/// A special case of a monomial operator: A single quadratic fermionic operator \f$c^\dagger_i c_j\f$.
+/// A special case of a monomial operator: A product of two fermionic operators \f$X_i Y_j\f$.
+/// Each of \f$X_i\f$ and \f$Y_j\f$ can be either a creation or annihilation operator.
 class QuadraticOperator : public MonomialOperator {
-    /// The single-particle index corresponding to the creation operator.
+    /// The single-particle index corresponding to the first operator.
     ParticleIndex Index1;
-    /// The single-particle index corresponding to the annihilation operator.
+    /// The single-particle index corresponding to the second operator.
     ParticleIndex Index2;
+    /// Indicates whether each of the two operators is a creator.
+    std::tuple<bool, bool> Dagger;
 
 public:
     /// Constructor.
@@ -275,28 +280,51 @@ public:
     /// \param[in] HS Hilbert space.
     /// \param[in] S Information about invariant subspaces of the Hamiltonian.
     /// \param[in] H The Hamiltonian.
-    /// \param[in] Index1 The single-particle index \f$i\f$ of the creation operator.
-    /// \param[in] Index2 The single-particle index \f$j\f$ of the annihilation operator.
+    /// \param[in] Index1 The single-particle index \f$i\f$ of the first operator.
+    /// \param[in] Index2 The single-particle index \f$j\f$ of the second operator.
+    /// \param[in] Dagger Indicates whether each of the two operators is a creator.
     template <typename... IndexTypes>
     QuadraticOperator(IndexClassification<IndexTypes...> const& IndexInfo,
                       HilbertSpace<IndexTypes...> const& HS,
                       StatesClassification const& S,
                       Hamiltonian const& H,
                       ParticleIndex Index1,
-                      ParticleIndex Index2)
+                      ParticleIndex Index2,
+                      std::tuple<bool, bool> const& Dagger = {true, false})
         : MonomialOperator(
-              Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index1)) *
-                  Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index2)),
+            (std::get<0>(Dagger) ?
+                Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index1)) :
+                Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index1))
+            ) * (
+             std::get<1>(Dagger) ?
+                Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index2)) :
+                Operators::Detail::apply(Operators::c<double, IndexTypes...>, IndexInfo.getInfo(Index2))
+              ),
               HS,
               S,
               H),
           Index1(Index1),
-          Index2(Index2) {}
+          Index2(Index2),
+          Dagger(Dagger) {}
 
-    /// Return the single-particle index \f$i\f$.
-    ParticleIndex getCXXIndex() const { return Index1; }
-    /// Return the single-particle index \f$j\f$.
-    ParticleIndex getCIndex() const { return Index2; }
+    /// Return the single-particle index \f$i\f$
+    ParticleIndex getIndex1() const { return Index1; }
+    /// Return the single-particle index \f$j\f$
+    ParticleIndex getIndex2() const { return Index2; }
+
+    /// Return the single-particle index \f$i\f$ under the assumption that X_i is a creation operator.
+    ParticleIndex getCXXIndex() const {
+        assert(std::get<0>(Dagger));
+        return Index1;
+    }
+    /// Return the single-particle index \f$j\f$ under the assumption that Y_j is an annihilation operator.
+    ParticleIndex getCIndex() const {
+        assert(!std::get<1>(Dagger));
+        return Index2;
+    }
+
+    /// Return the creation/annihilation type of each of the two operators.
+    std::tuple<bool, bool> const& getDagger() const { return Dagger; }
 };
 
 ///@}

--- a/include/pomerol/MonomialOperator.hpp
+++ b/include/pomerol/MonomialOperator.hpp
@@ -290,7 +290,7 @@ public:
                       Hamiltonian const& H,
                       ParticleIndex Index1,
                       ParticleIndex Index2,
-                      std::tuple<bool, bool> const& Dagger = {true, false})
+                      std::tuple<bool, bool> const& Dagger = std::tuple<bool, bool>(true, false))
         : MonomialOperator(
               (std::get<0>(Dagger) ?
                    Operators::Detail::apply(Operators::c_dag<double, IndexTypes...>, IndexInfo.getInfo(Index1)) :

--- a/include/pomerol/MonomialOperator.hpp
+++ b/include/pomerol/MonomialOperator.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/MonomialOperatorPart.hpp
+++ b/include/pomerol/MonomialOperatorPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Operators.hpp
+++ b/include/pomerol/Operators.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/StatesClassification.hpp
+++ b/include/pomerol/StatesClassification.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Susceptibility.hpp
+++ b/include/pomerol/Susceptibility.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/SusceptibilityPart.hpp
+++ b/include/pomerol/SusceptibilityPart.hpp
@@ -63,9 +63,9 @@ class SusceptibilityPart : public Thermal {
     /// a fraction of the form \f$\frac{R}{z - P}\f$.
     struct Term {
         /// Residue at the pole (\f$ R \f$).
-        ComplexType Residue;
+        ComplexType Residue = 0;
         /// Position of the pole (\f$ P \f$).
-        RealType Pole;
+        RealType Pole = 0;
 
         /// Comparator object for terms.
         struct Compare {
@@ -76,7 +76,7 @@ class SusceptibilityPart : public Thermal {
         public:
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the pole.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Are terms similar?
             /// \param[in] t1 First term.
             /// \param[in] t2 Second term.
@@ -92,7 +92,7 @@ class SusceptibilityPart : public Thermal {
         public:
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.

--- a/include/pomerol/SusceptibilityPart.hpp
+++ b/include/pomerol/SusceptibilityPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/TermList.hpp
+++ b/include/pomerol/TermList.hpp
@@ -21,7 +21,6 @@
 
 #include <cstddef>
 #include <set>
-#include <utility>
 #include <vector>
 
 namespace Pomerol {
@@ -90,8 +89,10 @@ public:
     /// \param[in] args Arguments to be passes to the terms.
     template <typename... Args> ComplexType operator()(Args&&... args) const {
         ComplexType res = 0;
-        for(auto const& t : data)
-            res += t(std::forward<Args>(args)...);
+        for(auto const& t : data) {
+            // cppcheck-suppress useStlAlgorithm
+            res += t(args...);
+        }
         return res;
     }
 

--- a/include/pomerol/TermList.hpp
+++ b/include/pomerol/TermList.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Thermal.hpp
+++ b/include/pomerol/Thermal.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/ThreePointSusceptibility.hpp
+++ b/include/pomerol/ThreePointSusceptibility.hpp
@@ -1,0 +1,191 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file include/pomerol/ThreePointSusceptibility.hpp
+/// \brief 3-point susceptibility in the Matsubara representation.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITY_HPP
+#define POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITY_HPP
+
+#include "ComputableObject.hpp"
+#include "DensityMatrix.hpp"
+#include "Hamiltonian.hpp"
+#include "Misc.hpp"
+#include "MonomialOperator.hpp"
+#include "StatesClassification.hpp"
+#include "Thermal.hpp"
+#include "ThreePointSusceptibilityPart.hpp"
+
+#include "mpi_dispatcher/misc.hpp"
+
+#include <cstddef>
+#include <numeric>
+#include <tuple>
+#include <vector>
+
+namespace Pomerol {
+
+/// \defgroup 3PSusc Three-point fermion-boson susceptibility
+///@{
+
+/// Duplet of complex frequencies.
+using FreqTuple2 = std::tuple<ComplexType, ComplexType>;
+/// List of complex frequency duplets.
+using FreqVec2 = std::vector<FreqTuple2>;
+
+/// \brief 3-point fermion-boson susceptibility in the Matsubara representation.
+///
+/// \f[ \chi^{(3)}(\omega_{n_1},\omega_{n_2}) = \int_0^\beta
+/// e^{-i\omega_{n_1}\tau_1} e^{-i\omega_{n_2}\tau_2} \chi^{(3)}(\tau_1, \tau_2) d\tau_1 d\tau_2.
+/// \f]
+/// The imaginary time susceptibility can be defined in one of the following three channels.
+/// \li Particle-particle channel: \f$\chi^{(3)}_{pp}(\tau_1, \tau_2) = Tr[\mathcal{T}_\tau \hat\rho
+/// c^\dagger_1(\tau_1) c_2(0) c^\dagger_3(\tau_2) c_4(0)]\f$;
+/// \li Particle-hole channel: \f$\chi^{(3)}_{ph}(\tau_1, \tau_2) = Tr[\mathcal{T}_\tau \hat\rho
+/// c^\dagger_1(\tau_1) c_2(\tau_2) c^\dagger_3(0) c_4(0)]\f$;
+/// \li Crossed particle-hole channel: \f$\chi^{(3)}_{\overline{ph}}(\tau_1, \tau_2) =
+/// Tr[\mathcal{T}_\tau \hat\rho c^\dagger_1(\tau_1) c_2(0) c^\dagger_3(0) c_4(\tau_2)]\f$;
+///
+/// These susceptibilities can be interpreted as time-ordered 3-point correlators of two fermionic
+/// operators \f$\hat F_1(\tau_1), \hat F_2(\tau_2)\f$ and one bosonic operator \f$\hat B(0)\f$.
+/// \li PP channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c^\dagger_3, \hat B = \Delta_{24} = c_2 c_4 \f$;
+/// \li PH channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c_2, \hat B = n_{34} = c^\dagger_3 c_4 \f$;
+/// \li Crossed PH channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c_4, \hat B = \bar n_{23} = c_2 c^\dagger_3\f$.
+///
+/// It is actually a container class for a collection of \ref ThreePointSusceptibilityPart's
+/// (most of the real calculations take place in the parts).
+class ThreePointSusceptibility : public Thermal, public ComputableObject {
+
+public:
+    /// Channel of the 3-point susceptibility.
+    enum Channel {
+        PP,       ///< Particle-particle channel.
+        PH,       ///< Particle-hole channel.
+        CrossedPH ///< Crossed particle-hole channel.
+    };
+
+private:
+    // FIXME
+    //friend class ThreePointSusceptibilityContainer;
+
+    /// Channel
+    Channel channel;
+
+    /// Information about invariant subspaces of the Hamiltonian.
+    StatesClassification const& S;
+    /// The Hamiltonian.
+    Hamiltonian const& H;
+    /// The first fermionic operator \f$\hat F_1\f$.
+    CreationOperator const& F1;
+    /// The first fermionic operator \f$\hat F_2\f$.
+    MonomialOperator const& F2;
+    /// The quadratic bosonic operator \f$\hat B\f$.
+    QuadraticOperator const& B;
+    /// Many-body density matrix \f$\hat\rho\f$.
+    DensityMatrix const& DM;
+
+    /// The list of all \ref ThreePointSusceptibilityPart's contributing to this susceptibility.
+    std::vector<ThreePointSusceptibilityPart> parts;
+
+protected:
+    /// A flag that marks an identically vanishing susceptibility.
+    bool Vanishing = true;
+
+public:
+    /// A difference in energies with magnitude below this value is treated as zero.
+    RealType ReduceResonanceTolerance = 1e-8;
+    /// Minimal magnitude of the coefficient of a term for it to be taken into account.
+    RealType CoefficientTolerance = 1e-16;
+
+    /// Constructor for the particle-particle channel.
+    /// \param[in] S Information about invariant subspaces of the Hamiltonian.
+    /// \param[in] H The Hamiltonian.
+    /// \param[in] CX1 The creation operator \f$c^\dagger_1\f$.
+    /// \param[in] CX2 The creation operator \f$c^\dagger_3\f$.
+    /// \param[in] Delta The pairing operator \f$\Delta_{24} = c_2 c_4\f$.
+    /// \param[in] DM Many-body density matrix \f$\hat\rho\f$.
+    ThreePointSusceptibility(StatesClassification const& S,
+                             Hamiltonian const& H,
+                             CreationOperator const& CX1,
+                             CreationOperator const& CX3,
+                             QuadraticOperator const& Delta,
+                             DensityMatrix const& DM);
+
+    /// Constructor for the particle-hole an crossed particle-hole channels.
+    /// \param[in] S Information about invariant subspaces of the Hamiltonian.
+    /// \param[in] H The Hamiltonian.
+    /// \param[in] CX The creation operator \f$c^\dagger_1\f$.
+    /// \param[in] C Either the annihilation operator \f$c_2\f$ (PH) of \f$c_4\f$ (crossed PH).
+    /// \param[in] N Either the density operator \f$n_{34} = c^\dagger_3 c_4\f$ (PH) or
+    ///              the hole density operator \f$\bar n_{23} = c_2 c^\dagger_3\f$.
+    /// \param[in] DM Many-body density matrix \f$\hat\rho\f$.
+    ThreePointSusceptibility(StatesClassification const& S,
+                             Hamiltonian const& H,
+                             CreationOperator const& CX,
+                             AnnihilationOperator const& C,
+                             QuadraticOperator const& N,
+                             DensityMatrix const& DM);
+
+    /// Choose relevant parts of \f$\hat F_1, \hat F_2, \hat B\f$ and allocate resources for the parts.
+    void prepare();
+
+    /// Compute the parts in parallel and fill the internal cache of precomputed values.
+    /// \param[in] clear If true, computed \ref ThreePointSusceptibilityPart's will be destroyed immediately after
+    ///                  filling the precomputed value cache.
+    /// \param[in] freqs List of frequency duplets \f$(\omega_{n_1},\omega_{n_2})\f$.
+    /// \param[in] comm MPI communicator used to parallelize the computation.
+    /// \return A list of precomputed values.
+    /// \pre \ref prepare() has been called.
+    std::vector<ComplexType>
+    compute(bool clear = false, FreqVec2 const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+
+    /// Returns the single particle index of one of the operators \f$c^\dagger_1, c_2, c^\dagger_3, c_4\f$.
+    /// \param[in] Position Position of the requested operator, 0--3.
+    ParticleIndex getIndex(std::size_t Position) const;
+
+    /// Return the value of the 3-point susceptibility calculated at a given complex frequency duplet.
+    /// This method ignores the precomputed value cache.
+    /// \param[in] z1 First frequency \f$z_1\f$.
+    /// \param[in] z2 Second frequency \f$z_2\f$.
+    ComplexType operator()(ComplexType z1, ComplexType z2) const;
+    /// Return the value of the 3-point susceptibility calculated a given Matsubara frequency duplet.
+    /// \param[in] MatsubaraNumber1 Index of the first Matsubara frequency
+    ///                             \f$n_1\f$ (\f$\omega_{n_1}=\pi(2n_1+1)/\beta\f$).
+    /// \param[in] MatsubaraNumber2 Index of the second Matsubara frequency
+    ///                             \f$n_2\f$ (\f$\omega_{n_2}=\pi(2n_2+1)/\beta\f$).
+    ComplexType operator()(long MatsubaraNumber1, long MatsubaraNumber2) const;
+
+    /// Is this susceptibility identically zero?
+    bool isVanishing() const { return Vanishing; }
+};
+
+///@}
+
+inline ComplexType ThreePointSusceptibility::operator()(ComplexType z1, ComplexType z2) const {
+    if(Vanishing)
+        return 0;
+    else {
+        return std::accumulate(
+            parts.begin(),
+            parts.end(),
+            ComplexType(0),
+            [z1, z2](ComplexType s, ThreePointSusceptibilityPart const& p) { return s + p(z1, z2); });
+    }
+}
+
+inline ComplexType ThreePointSusceptibility::operator()(long MatsubaraNumber1, long MatsubaraNumber2) const {
+    return (*this)(MatsubaraSpacing * RealType(2 * MatsubaraNumber1 + 1),
+                   MatsubaraSpacing * RealType(2 * MatsubaraNumber2 + 1));
+}
+
+} // namespace Pomerol
+
+#endif // #ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITY_HPP

--- a/include/pomerol/ThreePointSusceptibility.hpp
+++ b/include/pomerol/ThreePointSusceptibility.hpp
@@ -73,8 +73,7 @@ public:
     };
 
 private:
-    // FIXME
-    //friend class ThreePointSusceptibilityContainer;
+    friend class ThreePointSusceptibilityContainer;
 
     /// Channel
     Channel channel;
@@ -165,6 +164,10 @@ public:
 
     /// Is this susceptibility identically zero?
     bool isVanishing() const { return Vanishing; }
+
+    /// Select channel based on the form of the quadratic operator \f$\hat B\f$ used in the definition.
+    /// \param[in] B Quadratic operator \f$\hat B\f$.
+    static Channel selectChannel(QuadraticOperator const& B);
 };
 
 ///@}

--- a/include/pomerol/ThreePointSusceptibility.hpp
+++ b/include/pomerol/ThreePointSusceptibility.hpp
@@ -104,7 +104,7 @@ public:
     /// \param[in] S Information about invariant subspaces of the Hamiltonian.
     /// \param[in] H The Hamiltonian.
     /// \param[in] CX1 The creation operator \f$c^\dagger_1\f$.
-    /// \param[in] CX2 The creation operator \f$c^\dagger_3\f$.
+    /// \param[in] CX3 The creation operator \f$c^\dagger_3\f$.
     /// \param[in] Delta The pairing operator \f$\Delta_{24} = c_2 c_4\f$.
     /// \param[in] DM Many-body density matrix \f$\hat\rho\f$.
     ThreePointSusceptibility(StatesClassification const& S,

--- a/include/pomerol/ThreePointSusceptibility.hpp
+++ b/include/pomerol/ThreePointSusceptibility.hpp
@@ -46,19 +46,16 @@ using FreqVec2 = std::vector<FreqTuple2>;
 /// \f[ \chi^{(3)}(\omega_{n_1},\omega_{n_2}) = \int_0^\beta
 /// e^{-i\omega_{n_1}\tau_1} e^{-i\omega_{n_2}\tau_2} \chi^{(3)}(\tau_1, \tau_2) d\tau_1 d\tau_2.
 /// \f]
-/// The imaginary time susceptibility can be defined in one of the following three channels.
+/// The imaginary time susceptibility can be defined in one of the following two channels.
 /// \li Particle-particle channel: \f$\chi^{(3)}_{pp}(\tau_1, \tau_2) = Tr[\mathcal{T}_\tau \hat\rho
 /// c^\dagger_1(\tau_1) c_2(0) c^\dagger_3(\tau_2) c_4(0)]\f$;
 /// \li Particle-hole channel: \f$\chi^{(3)}_{ph}(\tau_1, \tau_2) = Tr[\mathcal{T}_\tau \hat\rho
 /// c^\dagger_1(\tau_1) c_2(\tau_2) c^\dagger_3(0) c_4(0)]\f$;
-/// \li Crossed particle-hole channel: \f$\chi^{(3)}_{\overline{ph}}(\tau_1, \tau_2) =
-/// Tr[\mathcal{T}_\tau \hat\rho c^\dagger_1(\tau_1) c_2(0) c^\dagger_3(0) c_4(\tau_2)]\f$;
 ///
 /// These susceptibilities can be interpreted as time-ordered 3-point correlators of two fermionic
 /// operators \f$\hat F_1(\tau_1), \hat F_2(\tau_2)\f$ and one bosonic operator \f$\hat B(0)\f$.
 /// \li PP channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c^\dagger_3, \hat B = \Delta_{24} = c_2 c_4 \f$;
 /// \li PH channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c_2, \hat B = n_{34} = c^\dagger_3 c_4 \f$;
-/// \li Crossed PH channel: \f$\hat F_1 = c^\dagger_1, \hat F_2 = c_4, \hat B = \bar n_{23} = c_2 c^\dagger_3\f$.
 ///
 /// It is actually a container class for a collection of \ref ThreePointSusceptibilityPart's
 /// (most of the real calculations take place in the parts).
@@ -67,9 +64,8 @@ class ThreePointSusceptibility : public Thermal, public ComputableObject {
 public:
     /// Channel of the 3-point susceptibility.
     enum Channel {
-        PP,       ///< Particle-particle channel.
-        PH,       ///< Particle-hole channel.
-        CrossedPH ///< Crossed particle-hole channel.
+        PP, ///< Particle-particle channel.
+        PH  ///< Particle-hole channel.
     };
 
 private:
@@ -118,18 +114,17 @@ public:
                              QuadraticOperator const& Delta,
                              DensityMatrix const& DM);
 
-    /// Constructor for the particle-hole an crossed particle-hole channels.
+    /// Constructor for the particle-hole channel.
     /// \param[in] S Information about invariant subspaces of the Hamiltonian.
     /// \param[in] H The Hamiltonian.
-    /// \param[in] CX The creation operator \f$c^\dagger_1\f$.
-    /// \param[in] C Either the annihilation operator \f$c_2\f$ (PH) of \f$c_4\f$ (crossed PH).
-    /// \param[in] N Either the density operator \f$n_{34} = c^\dagger_3 c_4\f$ (PH) or
-    ///              the hole density operator \f$\bar n_{23} = c_2 c^\dagger_3\f$.
+    /// \param[in] CX1 The creation operator \f$c^\dagger_1\f$.
+    /// \param[in] C2 The annihilation operator \f$c_2\f$.
+    /// \param[in] N The density operator \f$n_{34} = c^\dagger_3 c_4\f$.
     /// \param[in] DM Many-body density matrix \f$\hat\rho\f$.
     ThreePointSusceptibility(StatesClassification const& S,
                              Hamiltonian const& H,
-                             CreationOperator const& CX,
-                             AnnihilationOperator const& C,
+                             CreationOperator const& CX1,
+                             AnnihilationOperator const& C2,
                              QuadraticOperator const& N,
                              DensityMatrix const& DM);
 

--- a/include/pomerol/ThreePointSusceptibilityContainer.hpp
+++ b/include/pomerol/ThreePointSusceptibilityContainer.hpp
@@ -1,0 +1,117 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file include/pomerol/ThreePointSusceptibilityContainer.hpp
+/// \brief Storage for multiple 3-point susceptibilities in the Matsubara representation.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYCONTAINER_HPP
+#define POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYCONTAINER_HPP
+
+#include "DensityMatrix.hpp"
+#include "FieldOperatorContainer.hpp"
+#include "Hamiltonian.hpp"
+#include "Index.hpp"
+#include "IndexClassification.hpp"
+#include "IndexContainer2.hpp"
+#include "Misc.hpp"
+#include "StatesClassification.hpp"
+#include "Thermal.hpp"
+#include "ThreePointSusceptibility.hpp"
+
+#include "mpi_dispatcher/misc.hpp"
+
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+namespace Pomerol {
+
+/// \addtogroup 3PSusc
+///@{
+
+/// \brief Container for instances of \ref ThreePointSusceptibility.
+///
+/// This class stores multiple \f$(i, j, \hat B)\f$-elements of a 3-point susceptibility.
+/// A quadratic operator \f$\hat B\f$ determines the channel the susceptibility is defined in,
+/// and is shared by all stored elements.
+class ThreePointSusceptibilityContainer
+    : public IndexContainer2<ThreePointSusceptibility, ThreePointSusceptibilityContainer>,
+      public Thermal {
+public:
+    /// A difference in energies with magnitude below this value is treated as zero.
+    RealType ReduceResonanceTolerance = 1e-8;
+    /// Minimal magnitude of the coefficient of a term for it to be taken into account.
+    RealType CoefficientTolerance = 1e-16;
+
+    /// Constructor.
+    /// \tparam IndexTypes Types of indices carried by the creation and annihilation operators.
+    /// \param[in] IndexInfo Map for fermionic operator index tuples.
+    /// \param[in] S Information about invariant subspaces of the Hamiltonian.
+    /// \param[in] H The Hamiltonian.
+    /// \param[in] DM Many-body density matrix \f$\hat\rho\f$.
+    /// \param[in] Ops A set of creation/annihilation operators \f$c^\dagger\f$/\f$c\f$.
+    /// \param[in] B A quadratic operator \f$\hat B\f$. See \ref ThreePointSusceptibility for more details.
+    template <typename... IndexTypes>
+    ThreePointSusceptibilityContainer(IndexClassification<IndexTypes...> const& IndexInfo,
+                                      StatesClassification const& S,
+                                      Hamiltonian const& H,
+                                      DensityMatrix const& DM,
+                                      FieldOperatorContainer const& Ops,
+                                      QuadraticOperator const& B)
+        : IndexContainer2<ThreePointSusceptibility, ThreePointSusceptibilityContainer>(*this, IndexInfo),
+          Thermal(DM),
+          S(S),
+          H(H),
+          DM(DM),
+          Operators(Ops),
+          B(B),
+          Channel(ThreePointSusceptibility::selectChannel(B)) {}
+
+    /// Prepare a set of elements \f$\chi^{(3)}_{ij,\hat B}\f$.
+    /// \param[in] Indices Set of index combinations of the elements \f$\chi^{(3)}_{ij,\hat B}\f$ to be prepared.
+    ///            An empty set results in creation of elements for all possible index combinations \f$(i,j)\f$.
+    void prepareAll(std::set<IndexCombination2> const& Indices = {});
+    /// Compute all prepared elements \f$\chi^{(3)}_{ij,\hat B}\f$.
+    /// \param[in] clear If true, computed \ref ThreePointSusceptibilityPart's of all elements will be destroyed
+    ///                  immediately after filling the precomputed value cache.
+    /// \param[in] freqs List of frequency duplets \f$(\omega_{n_1},\omega_{n_2})\f$ for value pre-computation.
+    /// \pre \ref prepareAll() has been called.
+    std::map<IndexCombination2, std::vector<ComplexType>>
+    computeAll(bool clearTerms = false, FreqVec2 const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+
+protected:
+    friend class IndexContainer2<ThreePointSusceptibility, ThreePointSusceptibilityContainer>;
+
+    /// Create a single element \f$\chi^{(3)}_{ij,\hat B}\f$.
+    /// \param[in] Indices Index combination \f$(i,j)\f$.
+    std::shared_ptr<ThreePointSusceptibility> createElement(IndexCombination2 const& Indices) const;
+
+    /// Information about invariant subspaces of the Hamiltonian.
+    StatesClassification const& S;
+
+    /// The Hamiltonian.
+    Hamiltonian const& H;
+    /// Many-body density matrix \f$\hat\rho\f$.
+    DensityMatrix const& DM;
+    /// A set of creation/annihilation operators \f$c^\dagger\f$/\f$c\f$.
+    FieldOperatorContainer const& Operators;
+    /// Quadratic operator B.
+    QuadraticOperator const& B;
+    /// Channel of \f$\chi^{(3)}\f$.
+    ThreePointSusceptibility::Channel Channel;
+};
+
+///@}
+
+} // namespace Pomerol
+
+#endif // #ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYCONTAINER_HPP

--- a/include/pomerol/ThreePointSusceptibilityPart.hpp
+++ b/include/pomerol/ThreePointSusceptibilityPart.hpp
@@ -1,0 +1,479 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file include/pomerol/ThreePointSusceptibilityPart.hpp
+/// \brief Part of a 3-point susceptibility in the Matsubara representation.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYPART_HPP
+#define POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYPART_HPP
+
+#include "ComputableObject.hpp"
+#include "DensityMatrixPart.hpp"
+#include "HamiltonianPart.hpp"
+#include "Misc.hpp"
+#include "MonomialOperatorPart.hpp"
+#include "StatesClassification.hpp"
+#include "TermList.hpp"
+#include "Thermal.hpp"
+
+#include "mpi_dispatcher/misc.hpp"
+
+#include <array>
+#include <complex>
+#include <cstddef>
+
+namespace Pomerol {
+
+/// \addtogroup 3PSusc
+///@{
+
+/// \brief Part of a 3-point susceptibility.
+///
+/// It includes contributions from all matrix elements of the following form,
+/// \f[
+///  \langle {\rm S_1}| \hat F_1 |{\rm S_2}\rangle
+///  \langle {\rm S_2}| \hat F_2 |{\rm S_3} \rangle
+///  \langle {\rm S_3}| \hat B |{\rm S_1} \rangle,
+/// \f]
+/// where \f$\hat F_1, \hat F_2\f$ are fermionic field operators, and \f$\hat B\f$ is a bosonic
+/// (quadratic) operator.
+/// \f${\rm S_1}, {\rm S_2}, {\rm S_3}\f$ are invariant subspaces of the Hamiltonian.
+/// The contributions are stored as terms of the Lehmann representation. There are three kinds of terms contributing
+/// to the expansion, so called resonant (\ref ResonantTerm), non-resonant fermion-fermion (\ref NonResonantFFTerm)
+/// and non-resonant fermion-boson (\ref NonResonantFBTerm) terms.
+class ThreePointSusceptibilityPart : public Thermal, ComputableObject {
+
+    friend class ThreePointSusceptibility;
+    // FIXME
+    //friend class ThreePointSusceptibilityContainer;
+
+public:
+    /// \brief A non-resonant fermion-fermion term in the Lehmann representation of \ref ThreePointSusceptibility.
+    ///
+    /// It is parametrized by a complex coefficient \f$C\f$ and positions of real poles \f$P_1, P_2\f$.
+    /// An explicit expression for the term reads \f$\frac{C}{(z_1-P_1)(z_2-P_2)}\f$.
+    struct NonResonantFFTerm {
+        /// Coefficient \f$C\f$.
+        ComplexType Coeff;
+
+        /// Poles \f$P_1\f$, \f$P_2\f$.
+        std::array<RealType, 2> Poles;
+
+        /// Weight \f$W\f$ used in addition of terms with different poles.
+        /// \see \ref operator+=()
+        long Weight;
+
+        /// Comparator object for non-resonant fermion-fermion terms.
+        struct Compare {
+            /// Tolerance level used to compare positions of the poles.
+            double Tolerance;
+            bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
+            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+
+            /// Are terms similar?
+            /// \param[in] t1 First term.
+            /// \param[in] t2 Second term.
+            bool operator()(NonResonantFFTerm const& t1, NonResonantFFTerm const& t2) const {
+                return !real_eq(t1.Poles[0], t2.Poles[0]) ? (t1.Poles[0] < t2.Poles[0]) :
+                                                            (t2.Poles[1] - t1.Poles[1] >= Tolerance);
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        /// Predicate: Does a term have a negligible residue?
+        struct IsNegligible {
+            /// Tolerance level used to detect negligible residues.
+            double Tolerance;
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to detect negligible residues.
+            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            /// Is term negligible?
+            /// \param[in] t Term.
+            /// \param[in] ToleranceDivisor Divide tolerance by this value.
+            bool operator()(NonResonantFFTerm const& t, std::size_t ToleranceDivisor) const {
+                return std::abs(t.Coeff) < Tolerance / ToleranceDivisor;
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        NonResonantFFTerm() = default;
+
+        /// Constructor.
+        /// \param[in] Coeff Coefficient of the term \f$C\f$.
+        /// \param[in] P1 Pole \f$P_1\f$.
+        /// \param[in] P2 Pole \f$P_2\f$.
+        inline NonResonantFFTerm(ComplexType Coeff, RealType P1, RealType P2)
+            : Coeff(Coeff), Poles{P1, P2}, Weight(1) {}
+
+        /// Substitute complex frequencies \f$z_1, z_2\f$ into this term.
+        /// \param[in] z1 Complex frequency \f$z_1\f$.
+        /// \param[in] z2 Complex frequency \f$z_2\f$.
+        ComplexType operator()(ComplexType z1, ComplexType z2) const;
+
+        /// Add a non-resonant fermion-fermion term to this term.
+        ///
+        /// This operator does not check similarity of the terms!
+        /// Parameters of this term are updated as follows.
+        /// \li Coeff += AnotherTerm.Coeff
+        /// \li Poles[i] = (Poles[i] * Weight + AnotherTerm.Poles[i] * AnotherTerm.Weight) /
+        ///                (Weight + AnotherTerm.Weight)
+        /// \li Weight += AnotherTerm.Weight
+        /// \param[in] AnotherTerm Term to add.
+        NonResonantFFTerm& operator+=(NonResonantFFTerm const& AnotherTerm);
+
+        /// Create and commit an MPI datatype for \ref NonResonantFFTerm.
+        static MPI_Datatype mpi_datatype();
+    };
+
+    /// \brief A non-resonant fermion-boson term in the Lehmann representation of \ref ThreePointSusceptibility.
+    ///
+    /// It is parametrized by a complex coefficient \f$C\f$, positions of real poles \f$P_1, P_{12}\f$
+    /// and a coefficient \f$\xi\f$ that controls how the bosonic frequency is computed.
+    /// An explicit expression for the term reads \f$\frac{C}{(z_1-P_1)(z_1 - \xi z_2 - P_{12})}\f$.
+    struct NonResonantFBTerm {
+        /// Coefficient \f$C\f$.
+        ComplexType Coeff;
+
+        /// Pole \f$P_1\f$.
+        RealType P1;
+
+        /// Pole \f$P_{12}\f$.
+        RealType P12;
+
+        /// Coefficient \f$\xi\f$.
+        int xi;
+
+        /// Weight \f$W\f$ used in addition of terms with different poles.
+        /// \see \ref operator+=()
+        long Weight;
+
+        /// Comparator object for non-resonant fermion-boson terms.
+        struct Compare {
+            /// Tolerance level used to compare positions of the poles.
+            double Tolerance;
+            bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
+            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+
+            /// Are terms similar?
+            /// \param[in] t1 First term.
+            /// \param[in] t2 Second term.
+            bool operator()(NonResonantFBTerm const& t1, NonResonantFBTerm const& t2) const {
+                if(t1.xi == t2.xi)
+                    return !real_eq(t1.P1, t2.P1) ? (t1.P1 < t2.P1) : (t2.P12 - t1.P12 >= Tolerance);
+                else
+                    return t1.xi < t2.xi;
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        /// Predicate: Does a term have a negligible residue?
+        struct IsNegligible {
+            /// Tolerance level used to detect negligible residues.
+            double Tolerance;
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to detect negligible residues.
+            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            /// Is term negligible?
+            /// \param[in] t Term.
+            /// \param[in] ToleranceDivisor Divide tolerance by this value.
+            bool operator()(NonResonantFBTerm const& t, std::size_t ToleranceDivisor) const {
+                return std::abs(t.Coeff) < Tolerance / ToleranceDivisor;
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        NonResonantFBTerm() = default;
+
+        /// Constructor.
+        /// \param[in] Coeff Coefficient of the term \f$C\f$.
+        /// \param[in] P1 Pole \f$P_1\f$.
+        /// \param[in] P12 Pole \f$P_{12}\f$.
+        /// \param[in] xi Coefficient \f$\xi\f$.
+        inline NonResonantFBTerm(ComplexType Coeff, RealType P1, RealType P12, int xi)
+            : Coeff(Coeff), P1(P1), P12(P12), xi(xi), Weight(1) {}
+
+        /// Substitute complex frequencies \f$z_1, z_2\f$ into this term.
+        /// \param[in] z1 Complex frequency \f$z_1\f$.
+        /// \param[in] z2 Complex frequency \f$z_2\f$.
+        ComplexType operator()(ComplexType z1, ComplexType z2) const;
+
+        /// Add a non-resonant fermion-boson term to this term.
+        ///
+        /// This operator does not check similarity of the terms!
+        /// Parameters of this term are updated as follows.
+        /// \li Coeff += AnotherTerm.Coeff
+        /// \li P = (P1 * Weight + AnotherTerm.P1 * AnotherTerm.Weight) / (Weight + AnotherTerm.Weight)
+        /// \li P12 = (P12 * Weight + AnotherTerm.P12 * AnotherTerm.Weight) / (Weight + AnotherTerm.Weight)
+        /// \li Weight += AnotherTerm.Weight
+        /// \param[in] AnotherTerm Term to add.
+        NonResonantFBTerm& operator+=(NonResonantFBTerm const& AnotherTerm);
+
+        /// Create and commit an MPI datatype for \ref NonResonantFBTerm.
+        static MPI_Datatype mpi_datatype();
+    };
+
+    /// \brief A resonant term in the Lehmann representation of \ref ThreePointSusceptibility.
+    ///
+    /// It is parametrized by a complex coefficient \f$C\f$, position of a real pole \f$P\f$
+    /// and a coefficient \f$\xi\f$ that controls how the bosonic frequency is computed.
+    /// An explicit expression for the term reads \f$\frac{C}{z_1-P}\delta_{z_1, \xi z_2}\f$.
+    struct ResonantTerm {
+        /// Coefficient \f$C\f$.
+        ComplexType Coeff;
+
+        /// Pole \f$P\f$.
+        RealType P;
+
+        /// Coefficient \f$\xi\f$.
+        int xi;
+
+        /// Weight \f$W\f$ used in addition of terms with different poles.
+        /// \see \ref operator+=()
+        long Weight;
+
+        /// Comparator object for resonant terms.
+        struct Compare {
+            /// Tolerance level used to compare positions of the poles.
+            double Tolerance;
+            bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
+            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            /// Are terms similar?
+            /// \param[in] t1 First term.
+            /// \param[in] t2 Second term.
+            bool operator()(ResonantTerm const& t1, ResonantTerm const& t2) const {
+                if(t1.xi == t2.xi)
+                    return t2.P - t1.P >= Tolerance;
+                else
+                    return t1.xi < t2.xi;
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        /// Predicate: Does a term have a negligible residue?
+        struct IsNegligible {
+            /// Tolerance level used to detect negligible residues.
+            double Tolerance;
+            /// Constructor.
+            /// \param[in] Tolerance Tolerance level used to detect negligible residues.
+            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            /// Is term negligible?
+            /// \param[in] t Term.
+            /// \param[in] ToleranceDivisor Divide tolerance by this value.
+            bool operator()(ResonantTerm const& t, std::size_t ToleranceDivisor) const {
+                return std::abs(t.Coeff) < Tolerance / ToleranceDivisor;
+            }
+            /// Broadcast this object from a root MPI rank to all other ranks in a communicator.
+            /// \param[in] comm The MPI communicator for the broadcast operation.
+            /// \param[in] root Rank of the root MPI process.
+            void broadcast(MPI_Comm const& comm, int root) { MPI_Bcast(&Tolerance, 1, MPI_DOUBLE, root, comm); }
+        };
+
+        ResonantTerm() = default;
+
+        /// Constructor.
+        /// \param[in] Coeff Coefficient of the term \f$C\f$.
+        /// \param[in] P Pole \f$P\f$.
+        /// \param[in] xi Coefficient \f$\xi\f$.
+        inline ResonantTerm(ComplexType Coeff, RealType P, int xi) : Coeff(Coeff), P(P), xi(xi), Weight(1) {}
+
+        /// Substitute complex frequencies \f$z_1, z_2\f$ into this term.
+        /// \param[in] z1 Complex frequency \f$z_1\f$.
+        /// \param[in] z2 Complex frequency \f$z_2\f$.
+        /// \param[in] DeltaTolerance Tolerance for the resonance detection.
+        ComplexType operator()(ComplexType z1, ComplexType z2, RealType DeltaTolerance = 1e-16) const;
+
+        /// Add a resonant term to this term.
+        ///
+        /// This operator does not check similarity of the terms!
+        /// Parameters of this term are updated as follows.
+        /// \li Coeff += AnotherTerm.Coeff
+        /// \li P = (P * Weight + AnotherTerm.P * AnotherTerm.Weight) / (Weight + AnotherTerm.Weight)
+        /// \li Weight += AnotherTerm.Weight
+        /// \param[in] AnotherTerm Term to add.
+        ResonantTerm& operator+=(ResonantTerm const& AnotherTerm);
+
+        /// Create and commit an MPI datatype for \ref ResonantTerm.
+        static MPI_Datatype mpi_datatype();
+    };
+
+private:
+    /// Part of the first fermionic operator.
+    MonomialOperatorPart const& F1;
+    /// Part of the second fermionic operator.
+    MonomialOperatorPart const& F2;
+    /// Part of the quadratic bosonic operator.
+    MonomialOperatorPart const& B;
+
+    /// Diagonal block of the Hamiltonian corresponding to the subspace \f${\rm S_1}\f$.
+    HamiltonianPart const& Hpart1;
+    /// Diagonal block of the Hamiltonian corresponding to the subspace \f${\rm S_2}\f$.
+    HamiltonianPart const& Hpart2;
+    /// Diagonal block of the Hamiltonian corresponding to the subspace \f${\rm S_3}\f$.
+    HamiltonianPart const& Hpart3;
+
+    /// Diagonal block of the many-body density matrix corresponding to the subspace \f${\rm S_1}\f$.
+    DensityMatrixPart const& DMpart1;
+    /// Diagonal block of the many-body density matrix corresponding to the subspace \f${\rm S_2}\f$.
+    DensityMatrixPart const& DMpart2;
+    /// Diagonal block of the many-body density matrix corresponding to the subspace \f${\rm S_3}\f$.
+    DensityMatrixPart const& DMpart3;
+
+    /// Is this a part of the 3-point susceptibility in the PP-channel?
+    bool PP;
+
+    /// Are fermionic operators in this part swapped with respect to their order in the definition?
+    bool SwappedFermionOps;
+
+    /// List of all non-resonant fermion-fermion terms contributing to this part.
+    TermList<NonResonantFFTerm> NonResonantFFTerms;
+    /// List of all non-resonant fermion-boson terms contributing to this part.
+    TermList<NonResonantFBTerm> NonResonantFBTerms;
+    /// List of all resonant terms contributing to this part.
+    TermList<ResonantTerm> ResonantTerms;
+
+    /// Adds a multi-term that has one of the following forms:
+    /// \li PP channel, non-swapped fermionic operators: \f$C f(z_1, z_2)\f$;
+    /// \li PP channel, swapped fermionic operators: \f$C f(z_2, z_1)\f$;
+    /// \li PH/crossed PH channels, non-swapped fermionic operators: \f$C f(z_1, -z_2)\f$;
+    /// \li PP/crossed PH channels, swapped fermionic operators: \f$C f(-z_2, z_1)\f$.
+    ///
+    /// Here, function \f$f(z_1, z_2)\f$ is defined as
+    /// \f[
+    /// f(z_1, z_2) = \frac{1}{z_2-(E_j-E_k)}
+    ///     \left(-\frac{w_i+w_j}{z_1-(E_i-E_j)} +
+    ///     \frac{(w_i-w_k)}{(z_1+z_2)-(E_i-E_k)}(1-\delta_{E_i,E _k}) +
+    ///     \beta w_i \delta_{z_1+z_2,0} \delta_{E_i,E_k}\right).
+    /// \f]
+    ///
+    /// \param[in] Coeff Common prefactor \f$C\f$.
+    /// \param[in] beta Inverse temperature.
+    /// \param[in] Ei The first energy level \f$E_i\f$.
+    /// \param[in] Ej The second energy level \f$E_j\f$.
+    /// \param[in] Ek The third energy level \f$E_k\f$.
+    /// \param[in] Wi The first weight \f$w_i\f$.
+    /// \param[in] Wj The second weight \f$w_j\f$.
+    /// \param[in] Wk The third weight \f$w_k\f$.
+    void addMultiterm(ComplexType Coeff,
+                      RealType beta,
+                      RealType Ei,
+                      RealType Ej,
+                      RealType Ek,
+                      RealType Wi,
+                      RealType Wj,
+                      RealType Wk);
+
+    /// A difference in energies with magnitude below this value is treated as zero.
+    RealType ReduceResonanceTolerance = 1e-8;
+    /// Minimal magnitude of the coefficient of a term for it to be taken into account.
+    RealType CoefficientTolerance = 1e-16;
+
+    // compute() implementation details.
+    template <bool Complex> void computeImpl();
+
+public:
+    /// Constructor.
+    /// \param[in] F1 Part of the first fermionic field operator \f$\hat F_1\f$.
+    /// \param[in] F2 Part of the second fermionic field operator \f$\hat F_2\f$.
+    /// \param[in] B Part of the quadratic bosonic operator \f$\hat B\f$.
+    /// \param[in] Hpart1 Part of the Hamiltonian corresponding to the subspace \f${\rm S_1}\f$.
+    /// \param[in] Hpart2 Part of the Hamiltonian corresponding to the subspace \f${\rm S_2}\f$.
+    /// \param[in] Hpart3 Part of the Hamiltonian corresponding to the subspace \f${\rm S_3}\f$.
+    /// \param[in] DMpart1 Part of the many-body density matrix corresponding to the subspace \f${\rm S_1}\f$.
+    /// \param[in] DMpart2 Part of the many-body density matrix corresponding to the subspace \f${\rm S_2}\f$.
+    /// \param[in] DMpart3 Part of the many-body density matrix corresponding to the subspace \f${\rm S_3}\f$.
+    /// \param[in] PP Is this a part of the 3-point susceptibility in the PP-channel?
+    /// \param[in] SwappedFermionOps Are fermionic operators swapped with respect to their order in the definition?
+    ThreePointSusceptibilityPart(MonomialOperatorPart const& F1,
+                                 MonomialOperatorPart const& F2,
+                                 MonomialOperatorPart const& B,
+                                 HamiltonianPart const& Hpart1,
+                                 HamiltonianPart const& Hpart2,
+                                 HamiltonianPart const& Hpart3,
+                                 DensityMatrixPart const& DMpart1,
+                                 DensityMatrixPart const& DMpart2,
+                                 DensityMatrixPart const& DMpart3,
+                                 bool PP,
+                                 bool SwappedFermionOps);
+
+    /// Compute the terms contributing to this part.
+    void compute();
+
+    /// Purge all terms.
+    void clear();
+
+    /// Substitute complex frequencies \f$z_1, z_2\f$ into this part.
+    /// \param[in] z1 First frequency \f$z_1\f$.
+    /// \param[in] z2 Second frequency \f$z_2\f$.
+    ComplexType operator()(ComplexType z1, ComplexType z2) const;
+    /// Substitute Matsubara frequencies \f$i\omega_{n_1}, i\omega_{n_2}\f$ into this part.
+    /// \param[in] MatsubaraNumber1 Index of the first Matsubara frequency
+    ///                             \f$n_1\f$ (\f$\omega_{n_1}=\pi(2n_1+1)/\beta\f$).
+    /// \param[in] MatsubaraNumber2 Index of the second Matsubara frequency
+    ///                             \f$n_2\f$ (\f$\omega_{n_2}=\pi(2n_2+1)/\beta\f$).
+    ComplexType operator()(long MatsubaraNumber1, long MatsubaraNumber2) const;
+
+    /// Return the number of resonant terms.
+    std::size_t getNumResonantTerms() const { return ResonantTerms.size(); }
+    /// Return the number of non-resonant fermion-fermion terms.
+    std::size_t getNumNonResonantFFTerms() const { return NonResonantFFTerms.size(); }
+    /// Return the number of non-resonant fermion-boson terms.
+    std::size_t getNumNonResonantFBTerms() const { return NonResonantFBTerms.size(); }
+
+    /// Are fermionic operators in this part swapped with respect to their order in the definition?
+    bool getSwappedFermionOps() const { return SwappedFermionOps; }
+
+    /// Access the list of the resonant terms.
+    TermList<ResonantTerm> const& getResonantTerms() const { return ResonantTerms; }
+    /// Access the list of the non-resonant fermion-fermion terms.
+    TermList<NonResonantFFTerm> const& getNonResonantFFTerms() const { return NonResonantFFTerms; }
+    /// Access the list of the non-resonant fermion-boson terms.
+    TermList<NonResonantFBTerm> const& getNonResonantFBTerms() const { return NonResonantFBTerms; }
+};
+
+///@}
+
+inline ComplexType ThreePointSusceptibilityPart::NonResonantFFTerm::operator()(ComplexType z1, ComplexType z2) const {
+    return Coeff / ((z1 - Poles[0]) * (z2 - Poles[1]));
+}
+
+inline ComplexType ThreePointSusceptibilityPart::NonResonantFBTerm::operator()(ComplexType z1, ComplexType z2) const {
+    return Coeff / ((z1 - P1) * (z1 - double(xi) * z2 - P12));
+}
+
+inline ComplexType
+ThreePointSusceptibilityPart::ResonantTerm::operator()(ComplexType z1, ComplexType z2, RealType DeltaTolerance) const {
+    return (std::abs(z1 - double(xi) * z2) < DeltaTolerance) ? (Coeff / (z1 - P)) : 0;
+}
+
+} // namespace Pomerol
+
+#endif // #ifndef POMEROL_INCLUDE_THREEPOINTSUSCEPTIBILITYPART_HPP

--- a/include/pomerol/ThreePointSusceptibilityPart.hpp
+++ b/include/pomerol/ThreePointSusceptibilityPart.hpp
@@ -61,14 +61,14 @@ public:
     /// An explicit expression for the term reads \f$\frac{C}{(z_1-P_1)(z_2-P_2)}\f$.
     struct NonResonantFFTerm {
         /// Coefficient \f$C\f$.
-        ComplexType Coeff;
+        ComplexType Coeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$.
-        std::array<RealType, 2> Poles;
+        std::array<RealType, 2> Poles = {0, 0};
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()
-        long Weight;
+        long Weight = 0;
 
         /// Comparator object for non-resonant fermion-fermion terms.
         struct Compare {
@@ -77,7 +77,7 @@ public:
             bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
 
             /// Are terms similar?
             /// \param[in] t1 First term.
@@ -98,7 +98,7 @@ public:
             double Tolerance;
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.
@@ -150,17 +150,17 @@ public:
         ComplexType Coeff;
 
         /// Pole \f$P_1\f$.
-        RealType P1;
+        RealType P1 = 0;
 
         /// Pole \f$P_{12}\f$.
-        RealType P12;
+        RealType P12 = 0;
 
         /// Coefficient \f$\xi\f$.
-        int xi;
+        int xi = 1;
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()
-        long Weight;
+        long Weight = 0;
 
         /// Comparator object for non-resonant fermion-boson terms.
         struct Compare {
@@ -169,7 +169,7 @@ public:
             bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
 
             /// Are terms similar?
             /// \param[in] t1 First term.
@@ -192,7 +192,7 @@ public:
             double Tolerance;
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.
@@ -242,17 +242,17 @@ public:
     /// An explicit expression for the term reads \f$\frac{C}{z_1-P}\delta_{z_1, \xi z_2}\f$.
     struct ResonantTerm {
         /// Coefficient \f$C\f$.
-        ComplexType Coeff;
+        ComplexType Coeff = 0;
 
         /// Pole \f$P\f$.
-        RealType P;
+        RealType P = 0;
 
         /// Coefficient \f$\xi\f$.
-        int xi;
+        int xi = 1;
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()
-        long Weight;
+        long Weight = 0;
 
         /// Comparator object for resonant terms.
         struct Compare {
@@ -261,7 +261,7 @@ public:
             bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Are terms similar?
             /// \param[in] t1 First term.
             /// \param[in] t2 Second term.
@@ -283,7 +283,7 @@ public:
             double Tolerance;
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.

--- a/include/pomerol/ThreePointSusceptibilityPart.hpp
+++ b/include/pomerol/ThreePointSusceptibilityPart.hpp
@@ -52,8 +52,7 @@ namespace Pomerol {
 class ThreePointSusceptibilityPart : public Thermal, ComputableObject {
 
     friend class ThreePointSusceptibility;
-    // FIXME
-    //friend class ThreePointSusceptibilityContainer;
+    friend class ThreePointSusceptibilityContainer;
 
 public:
     /// \brief A non-resonant fermion-fermion term in the Lehmann representation of \ref ThreePointSusceptibility.

--- a/include/pomerol/ThreePointSusceptibilityPart.hpp
+++ b/include/pomerol/ThreePointSusceptibilityPart.hpp
@@ -362,8 +362,8 @@ private:
     /// Adds a multi-term that has one of the following forms:
     /// \li PP channel, non-swapped fermionic operators: \f$C f(z_1, z_2)\f$;
     /// \li PP channel, swapped fermionic operators: \f$C f(z_2, z_1)\f$;
-    /// \li PH/crossed PH channels, non-swapped fermionic operators: \f$C f(z_1, -z_2)\f$;
-    /// \li PP/crossed PH channels, swapped fermionic operators: \f$C f(-z_2, z_1)\f$.
+    /// \li PH channel, non-swapped fermionic operators: \f$C f(z_1, -z_2)\f$;
+    /// \li PP channel, swapped fermionic operators: \f$C f(-z_2, z_1)\f$.
     ///
     /// Here, function \f$f(z_1, z_2)\f$ is defined as
     /// \f[

--- a/include/pomerol/ThreePointSusceptibilityPart.hpp
+++ b/include/pomerol/ThreePointSusceptibilityPart.hpp
@@ -64,7 +64,7 @@ public:
         ComplexType Coeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$.
-        std::array<RealType, 2> Poles = {0, 0};
+        std::array<RealType, 2> Poles = {{0, 0}};
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()

--- a/include/pomerol/TwoParticleGF.hpp
+++ b/include/pomerol/TwoParticleGF.hpp
@@ -38,9 +38,14 @@ namespace Pomerol {
 ///@{
 
 /// Triplet of complex frequencies.
-using FreqTuple = std::tuple<ComplexType, ComplexType, ComplexType>;
+using FreqTuple3 = std::tuple<ComplexType, ComplexType, ComplexType>;
 /// List of complex frequency triplets.
-using FreqVec = std::vector<FreqTuple>;
+using FreqVec3 = std::vector<FreqTuple3>;
+
+#ifndef DOXYGEN_SKIP
+using FreqTuple POMEROL_DEPRECATED = FreqTuple3;
+using FreqVec POMEROL_DEPRECATED = FreqVec3;
+#endif
 
 /// \brief Fermionic two-particle Matsubara Green's function.
 ///
@@ -139,7 +144,7 @@ public:
     /// \return A list of precomputed values.
     /// \pre \ref prepare() has been called.
     std::vector<ComplexType>
-    compute(bool clear = false, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+    compute(bool clear = false, FreqVec3 const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
 
     /// Returns the single particle index of one of the operators \f$c_i,c_j,c^\dagger_k,c^\dagger_l\f$.
     /// \param[in] Position Position of the requested operator, 0--3.

--- a/include/pomerol/TwoParticleGF.hpp
+++ b/include/pomerol/TwoParticleGF.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/TwoParticleGFContainer.hpp
+++ b/include/pomerol/TwoParticleGFContainer.hpp
@@ -91,7 +91,7 @@ public:
     /// \param[in] split Enable MPI parallelization.
     /// \pre \ref prepareAll() has been called.
     std::map<IndexCombination4, std::vector<ComplexType>> computeAll(bool clearTerms = false,
-                                                                     FreqVec const& freqs = {},
+                                                                     FreqVec3 const& freqs = {},
                                                                      MPI_Comm const& comm = MPI_COMM_WORLD,
                                                                      bool split = true);
 
@@ -115,9 +115,9 @@ protected:
 private:
     // Implementation details.
     std::map<IndexCombination4, std::vector<ComplexType>>
-    computeAll_nosplit(bool clearTerms, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+    computeAll_nosplit(bool clearTerms, FreqVec3 const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
     std::map<IndexCombination4, std::vector<ComplexType>>
-    computeAll_split(bool clearTerms, FreqVec const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
+    computeAll_split(bool clearTerms, FreqVec3 const& freqs = {}, MPI_Comm const& comm = MPI_COMM_WORLD);
 };
 
 ///@}

--- a/include/pomerol/TwoParticleGFContainer.hpp
+++ b/include/pomerol/TwoParticleGFContainer.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/TwoParticleGFPart.hpp
+++ b/include/pomerol/TwoParticleGFPart.hpp
@@ -68,7 +68,7 @@ public:
         ComplexType Coeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$, \f$P_3\f$.
-        std::array<RealType, 3> Poles = {0, 0, 0};
+        std::array<RealType, 3> Poles = {{0, 0, 0}};
 
         /// Are we using \f$z_4=z_1+z_2+z_3\f$ instead of \f$z_2\f$ in this term?
         bool isz4 = false;
@@ -176,7 +176,7 @@ public:
         ComplexType NonResCoeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$, \f$P_3\f$.
-        std::array<RealType, 3> Poles = {0, 0, 0};
+        std::array<RealType, 3> Poles = {{0, 0, 0}};
 
         /// Are we using \f$ \delta(z_1+z_2-P_1-P_2) \f$ resonance condition?
         /// If not, we are using \f$ \delta(z_2+z_3-P_2-P_3) \f$.

--- a/include/pomerol/TwoParticleGFPart.hpp
+++ b/include/pomerol/TwoParticleGFPart.hpp
@@ -65,17 +65,17 @@ public:
     /// \li \f$\frac{C}{(z_1-P_1)(z_1+z_2+z_3-P_1-P_2-P_3)(z_3-P_3)}\f$ for \ref isz4 == true.
     struct NonResonantTerm {
         /// Coefficient \f$C\f$.
-        ComplexType Coeff;
+        ComplexType Coeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$, \f$P_3\f$.
-        std::array<RealType, 3> Poles;
+        std::array<RealType, 3> Poles = {0, 0, 0};
 
         /// Are we using \f$z_4=z_1+z_2+z_3\f$ instead of \f$z_2\f$ in this term?
-        bool isz4;
+        bool isz4 = false;
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()
-        long Weight;
+        long Weight = 0;
 
         /// Comparator object for non-resonant terms.
         struct Compare {
@@ -84,7 +84,7 @@ public:
             bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
 
             /// Are terms similar?
             /// \param[in] t1 First term.
@@ -110,7 +110,7 @@ public:
             double Tolerance;
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.
@@ -171,20 +171,20 @@ public:
     struct ResonantTerm {
 
         /// Coefficient \f$R\f$.
-        ComplexType ResCoeff;
+        ComplexType ResCoeff = 0;
         /// Coefficient \f$N\f$.
-        ComplexType NonResCoeff;
+        ComplexType NonResCoeff = 0;
 
         /// Poles \f$P_1\f$, \f$P_2\f$, \f$P_3\f$.
-        std::array<RealType, 3> Poles;
+        std::array<RealType, 3> Poles = {0, 0, 0};
 
         /// Are we using \f$ \delta(z_1+z_2-P_1-P_2) \f$ resonance condition?
         /// If not, we are using \f$ \delta(z_2+z_3-P_2-P_3) \f$.
-        bool isz1z2;
+        bool isz1z2 = false;
 
         /// Weight \f$W\f$ used in addition of terms with different poles.
         /// \see \ref operator+=()
-        long Weight;
+        long Weight = 0;
 
         /// Comparator object for resonant terms.
         struct Compare {
@@ -193,7 +193,7 @@ public:
             bool real_eq(RealType x1, RealType x2) const { return std::abs(x1 - x2) < Tolerance; }
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to compare positions of the poles.
-            Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
+            explicit Compare(double Tolerance = 1e-8) : Tolerance(Tolerance) {}
             /// Are terms similar?
             /// \param[in] t1 First term.
             /// \param[in] t2 Second term.
@@ -218,7 +218,7 @@ public:
             double Tolerance;
             /// Constructor.
             /// \param[in] Tolerance Tolerance level used to detect negligible residues.
-            IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
+            explicit IsNegligible(double Tolerance = 1e-16) : Tolerance(Tolerance) {}
             /// Is term negligible?
             /// \param[in] t Term.
             /// \param[in] ToleranceDivisor Divide tolerance by this value.

--- a/include/pomerol/TwoParticleGFPart.hpp
+++ b/include/pomerol/TwoParticleGFPart.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Version.hpp.in
+++ b/include/pomerol/Version.hpp.in
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/include/pomerol/Vertex4.hpp
+++ b/include/pomerol/Vertex4.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/pomerol.lmod.in
+++ b/pomerol.lmod.in
@@ -3,7 +3,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/CMakeLists.txt
+++ b/prog/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/anderson_model.hpp
+++ b/prog/anderson_model.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/hubbard2d_model.hpp
+++ b/prog/hubbard2d_model.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/main.cpp
+++ b/prog/main.cpp
@@ -21,9 +21,11 @@
 
 int main(int argc, char* argv[]) {
 #ifdef POMEROL_ANDERSON
+    // cppcheck-suppress unreadVariable
     anderson_model m(argc, argv);
 #endif
 #ifdef POMEROL_HUBBARD2D
+    // cppcheck-suppress unreadVariable
     hubbard2d_model m(argc, argv);
 #endif
 

--- a/prog/main.cpp
+++ b/prog/main.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/quantum_model.cpp
+++ b/prog/quantum_model.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/prog/quantum_model.hpp
+++ b/prog/quantum_model.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/scripts/VLALatticeGenerator.py
+++ b/scripts/VLALatticeGenerator.py
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -3,7 +3,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SOURCES
     pomerol/Vertex4.cpp
     pomerol/SusceptibilityPart.cpp
     pomerol/Susceptibility.cpp
+    pomerol/ThreePointSusceptibility.cpp
+    pomerol/ThreePointSusceptibilityPart.cpp
     pomerol/EnsembleAverage.cpp
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     pomerol/Susceptibility.cpp
     pomerol/ThreePointSusceptibility.cpp
     pomerol/ThreePointSusceptibilityPart.cpp
+    pomerol/ThreePointSusceptibilityContainer.cpp
     pomerol/EnsembleAverage.cpp
 )
 

--- a/src/mpi_dispatcher/mpi_dispatcher.cpp
+++ b/src/mpi_dispatcher/mpi_dispatcher.cpp
@@ -128,8 +128,8 @@ void MPIMaster::order_worker(WorkerId worker, JobId job) {
 
 void MPIMaster::order() {
     while(!WorkerStack.empty() && !JobStack.empty()) {
-        WorkerId& worker = WorkerStack.top();
-        JobId& job = JobStack.top();
+        WorkerId const& worker = WorkerStack.top();
+        JobId const& job = JobStack.top();
         order_worker(worker, job);
         WorkerStack.pop();
         JobStack.pop();

--- a/src/mpi_dispatcher/mpi_dispatcher.cpp
+++ b/src/mpi_dispatcher/mpi_dispatcher.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/DensityMatrix.cpp
+++ b/src/pomerol/DensityMatrix.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/DensityMatrixPart.cpp
+++ b/src/pomerol/DensityMatrixPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/EnsembleAverage.cpp
+++ b/src/pomerol/EnsembleAverage.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/FieldOperatorContainer.cpp
+++ b/src/pomerol/FieldOperatorContainer.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/GFContainer.cpp
+++ b/src/pomerol/GFContainer.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/GreensFunction.cpp
+++ b/src/pomerol/GreensFunction.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/GreensFunctionPart.cpp
+++ b/src/pomerol/GreensFunctionPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/Hamiltonian.cpp
+++ b/src/pomerol/Hamiltonian.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/HamiltonianPart.cpp
+++ b/src/pomerol/HamiltonianPart.cpp
@@ -102,7 +102,7 @@ template <bool C> void HamiltonianPart::computeImpl() {
 template <bool C> MatrixType<C> const& HamiltonianPart::getMatrix() const {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
-    return *std::static_pointer_cast<const MatrixType<C>>(HMatrix);
+    return *std::static_pointer_cast<MatrixType<C> const>(HMatrix);
 }
 template MatrixType<true> const& HamiltonianPart::getMatrix<true>() const;
 template MatrixType<false> const& HamiltonianPart::getMatrix<false>() const;

--- a/src/pomerol/HamiltonianPart.cpp
+++ b/src/pomerol/HamiltonianPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/LatticePresets.cpp
+++ b/src/pomerol/LatticePresets.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/Misc.cpp
+++ b/src/pomerol/Misc.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/MonomialOperator.cpp
+++ b/src/pomerol/MonomialOperator.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/MonomialOperatorPart.cpp
+++ b/src/pomerol/MonomialOperatorPart.cpp
@@ -137,7 +137,7 @@ template RowMajorMatrixType<false>& MonomialOperatorPart::getRowMajorValue<false
 template <bool C> RowMajorMatrixType<C> const& MonomialOperatorPart::getRowMajorValue() const {
     if(C != isComplex())
         throw std::runtime_error("Stored matrix type mismatch (real/complex)");
-    return *std::static_pointer_cast<const RowMajorMatrixType<C>>(elementsRowMajor);
+    return *std::static_pointer_cast<RowMajorMatrixType<C> const>(elementsRowMajor);
 }
 template RowMajorMatrixType<true> const& MonomialOperatorPart::getRowMajorValue<true>() const;
 template RowMajorMatrixType<false> const& MonomialOperatorPart::getRowMajorValue<false>() const;

--- a/src/pomerol/MonomialOperatorPart.cpp
+++ b/src/pomerol/MonomialOperatorPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/StatesClassification.cpp
+++ b/src/pomerol/StatesClassification.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/Susceptibility.cpp
+++ b/src/pomerol/Susceptibility.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/SusceptibilityPart.cpp
+++ b/src/pomerol/SusceptibilityPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/ThreePointSusceptibility.cpp
+++ b/src/pomerol/ThreePointSusceptibility.cpp
@@ -136,13 +136,13 @@ void ThreePointSusceptibility::prepare() {
 // 1) compute ThreePointSusceptibility terms;
 // 2) convert them to a Matsubara Container;
 // 3) purge terms
-struct ComputeAndClearWrap {
-    ComputeAndClearWrap(FreqVec2 const& freqs,
-                        std::vector<ComplexType>& data,
-                        ThreePointSusceptibilityPart& p,
-                        bool clear,
-                        bool fill,
-                        int complexity = 1)
+struct ComputeAndClearWrap3PSusc {
+    ComputeAndClearWrap3PSusc(FreqVec2 const& freqs,
+                              std::vector<ComplexType>& data,
+                              ThreePointSusceptibilityPart& p,
+                              bool clear,
+                              bool fill,
+                              int complexity = 1)
         : complexity(complexity), freqs_(freqs), data_(data), p(p), clear_(clear), fill_(fill) {}
 
     void run() {
@@ -184,7 +184,7 @@ std::vector<ComplexType> ThreePointSusceptibility::compute(bool clear, FreqVec2 
 
     if(!Vanishing) {
         // Create a "skeleton" class with pointers to part that can call a compute method
-        pMPI::mpi_skel<ComputeAndClearWrap> skel;
+        pMPI::mpi_skel<ComputeAndClearWrap3PSusc> skel;
         bool fill_container = !freqs.empty();
         skel.parts.reserve(parts.size());
         m_data.resize(freqs.size(), 0.0);

--- a/src/pomerol/ThreePointSusceptibility.cpp
+++ b/src/pomerol/ThreePointSusceptibility.cpp
@@ -1,0 +1,248 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file src/pomerol/ThreePointSusceptibility.cpp
+/// \brief 3-point susceptibility in the Matsubara representation (implementation).
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#include "pomerol/ThreePointSusceptibility.hpp"
+
+#include "mpi_dispatcher/mpi_skel.hpp"
+
+#include <array>
+#include <cassert>
+#include <ostream>
+#include <stdexcept>
+#include <tuple>
+
+namespace Pomerol {
+
+std::ostream& operator<<(std::ostream& os, ThreePointSusceptibility::Channel channel) {
+    switch(channel) {
+    case ThreePointSusceptibility::PP: return os << "PP";
+    case ThreePointSusceptibility::PH: return os << "PH";
+    case ThreePointSusceptibility::CrossedPH: return os << "Crossed PH";
+    default: return os;
+    }
+}
+
+ThreePointSusceptibility::ThreePointSusceptibility(StatesClassification const& S,
+                                                   Hamiltonian const& H,
+                                                   CreationOperator const& CX1,
+                                                   CreationOperator const& CX2,
+                                                   QuadraticOperator const& Delta,
+                                                   DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), channel(PP), S(S), H(H), F1(CX1), F2(CX2), B(Delta), DM(DM) {
+    if(Delta.getDagger() != std::make_tuple(false, false))
+        throw std::runtime_error("Pairing operator for ThreePointSusceptibility must be a product of two annihilators");
+}
+
+ThreePointSusceptibility::Channel SelectPHCrossedPH(QuadraticOperator const& N) {
+    auto daggers = N.getDagger();
+    if(daggers == std::make_tuple(true, false))
+        return ThreePointSusceptibility::PH;
+    else if(daggers == std::make_tuple(false, true))
+        return ThreePointSusceptibility::CrossedPH;
+    else
+        throw std::runtime_error("Density/hole density operator for ThreePointSusceptibility must be a product of one "
+                                 "creator and one annihilator");
+}
+
+ThreePointSusceptibility::ThreePointSusceptibility(StatesClassification const& S,
+                                                   Hamiltonian const& H,
+                                                   CreationOperator const& CX,
+                                                   AnnihilationOperator const& C,
+                                                   QuadraticOperator const& N,
+                                                   DensityMatrix const& DM)
+    : Thermal(DM.beta), ComputableObject(), channel(SelectPHCrossedPH(N)), S(S), H(H), F1(CX), F2(C), B(N), DM(DM) {}
+
+void ThreePointSusceptibility::prepare() {
+    if(getStatus() >= Prepared)
+        return;
+
+    // Find out non-trivial blocks of B.
+    MonomialOperator::BlocksBimap const& BNontrivialBlocks = B.getBlockMapping();
+    // Iterate over the outermost index.
+    for(auto Biter = BNontrivialBlocks.right.begin(); Biter != BNontrivialBlocks.right.end(); Biter++) {
+        BlockNumber Bright = Biter->first;
+        BlockNumber Bleft = Biter->second;
+
+        // F_1, F_2, B term
+        // <Bright|F_1|F1right><F2left|F_2|Bleft><Bleft|B|Bright>
+        BlockNumber F1right = F1.getRightIndex(Bright);
+        BlockNumber F2left = F2.getLeftIndex(Bleft);
+        if(F1right == F2left && F1right != INVALID_BLOCK_NUMBER) {
+            if(DM.isRetained(Bright) && DM.isRetained(F1right) && DM.isRetained(Bleft)) {
+                parts.emplace_back(F1.getPartFromLeftIndex(Bright),
+                                   F2.getPartFromLeftIndex(F2left),
+                                   B.getPartFromLeftIndex(Bleft),
+                                   H.getPart(Bright),
+                                   H.getPart(F1right),
+                                   H.getPart(Bleft),
+                                   DM.getPart(Bright),
+                                   DM.getPart(F1right),
+                                   DM.getPart(Bleft),
+                                   channel == PP,
+                                   false);
+                parts.back().ReduceResonanceTolerance = ReduceResonanceTolerance;
+            }
+        }
+
+        // F_2, F_1, B term
+        // <Bright|F_2|F2right><F1left|F_1|Bleft><Bleft|B|Bright>
+        BlockNumber F2right = F2.getRightIndex(Bright);
+        BlockNumber F1left = F1.getLeftIndex(Bleft);
+        if(F2right == F1left && F2right != INVALID_BLOCK_NUMBER) {
+            if(DM.isRetained(Bright) && DM.isRetained(F2right) && DM.isRetained(Bleft)) {
+                parts.emplace_back(F2.getPartFromLeftIndex(Bright),
+                                   F1.getPartFromLeftIndex(F1left),
+                                   B.getPartFromLeftIndex(Bleft),
+                                   H.getPart(Bright),
+                                   H.getPart(F2right),
+                                   H.getPart(Bleft),
+                                   DM.getPart(Bright),
+                                   DM.getPart(F2right),
+                                   DM.getPart(Bleft),
+                                   channel == PP,
+                                   true);
+                parts.back().ReduceResonanceTolerance = ReduceResonanceTolerance;
+                parts.back().CoefficientTolerance = CoefficientTolerance;
+            }
+        }
+    }
+
+    if(!parts.empty()) {
+        Vanishing = false;
+        INFO("ThreePointSusceptibility(" << channel << "," << getIndex(0) << "," << getIndex(1) << "," << getIndex(2)
+                                         << "," << getIndex(3) << "): " << parts.size() << " parts will be calculated");
+    }
+    setStatus(Prepared);
+}
+
+// An MPI adapter to
+// 1) compute ThreePointSusceptibility terms;
+// 2) convert them to a Matsubara Container;
+// 3) purge terms
+struct ComputeAndClearWrap {
+    ComputeAndClearWrap(FreqVec2 const& freqs,
+                        std::vector<ComplexType>& data,
+                        ThreePointSusceptibilityPart& p,
+                        bool clear,
+                        bool fill,
+                        int complexity = 1)
+        : complexity(complexity), freqs_(freqs), data_(data), p(p), clear_(clear), fill_(fill) {}
+
+    void run() {
+        p.compute();
+        if(fill_) {
+            std::size_t wsize = freqs_.size();
+#ifdef POMEROL_USE_OPENMP
+#pragma omp parallel for
+#endif
+            for(int w = 0; w < wsize; ++w) {
+                data_[w] += p(std::get<0>(freqs_[w]), std::get<1>(freqs_[w]));
+            }
+#ifdef POMEROL_USE_OPENMP
+#pragma omp barrier
+#endif
+        }
+        if(clear_)
+            p.clear();
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-non-private-member-variables-in-classes)
+    int const complexity;
+
+private:
+    FreqVec2 const& freqs_;
+    std::vector<ComplexType>& data_;
+    ThreePointSusceptibilityPart& p;
+    bool clear_;
+    bool fill_;
+};
+
+std::vector<ComplexType> ThreePointSusceptibility::compute(bool clear, FreqVec2 const& freqs, MPI_Comm const& comm) {
+    if(getStatus() < Prepared)
+        throw StatusMismatch("ThreePointSusceptibility is not prepared yet.");
+
+    std::vector<ComplexType> m_data;
+    if(getStatus() >= Computed)
+        return m_data;
+
+    if(!Vanishing) {
+        // Create a "skeleton" class with pointers to part that can call a compute method
+        pMPI::mpi_skel<ComputeAndClearWrap> skel;
+        bool fill_container = !freqs.empty();
+        skel.parts.reserve(parts.size());
+        m_data.resize(freqs.size(), 0.0);
+        for(auto& part : parts) {
+            skel.parts.emplace_back(freqs, m_data, part, clear, fill_container, 1);
+        }
+        std::map<pMPI::JobId, pMPI::WorkerId> job_map = skel.run(comm, true); // actual running - very costly
+
+        // Start distributing data
+        MPI_Barrier(comm);
+
+        MPI_Allreduce(MPI_IN_PLACE,
+                      m_data.data(),
+                      static_cast<int>(m_data.size()),
+                      POMEROL_MPI_DOUBLE_COMPLEX,
+                      MPI_SUM,
+                      comm);
+
+        // Optionally distribute terms to other processes
+        if(!clear) {
+            for(int p = 0; p < static_cast<int>(parts.size()); ++p) {
+                parts[p].NonResonantFFTerms.broadcast(comm, job_map[p]);
+                parts[p].NonResonantFBTerms.broadcast(comm, job_map[p]);
+                parts[p].ResonantTerms.broadcast(comm, job_map[p]);
+                parts[p].setStatus(ThreePointSusceptibilityPart::Computed);
+            }
+            MPI_Barrier(comm);
+        }
+    }
+
+    setStatus(Computed);
+
+    return m_data;
+}
+
+ParticleIndex ThreePointSusceptibility::getIndex(std::size_t Position) const {
+    switch(channel) {
+    case PP: {
+        switch(Position) {
+        case 0: return F1.getIndex();
+        case 1: return B.getIndex1();
+        case 2: return static_cast<CreationOperator const&>(F2).getIndex();
+        case 3: return B.getIndex2();
+        }
+    }
+    case PH: {
+        switch(Position) {
+        case 0: return F1.getIndex();
+        case 1: return static_cast<AnnihilationOperator const&>(F2).getIndex();
+        case 2: return B.getIndex1();
+        case 3: return B.getIndex2();
+        }
+    }
+    case CrossedPH: {
+        switch(Position) {
+        case 0: return F1.getIndex();
+        case 1: return B.getIndex1();
+        case 2: return B.getIndex2();
+        case 3: return static_cast<AnnihilationOperator const&>(F2).getIndex();
+        }
+    }
+    default: assert(0);
+    }
+    throw std::runtime_error("ThreePointSusceptibility: Could not get operator index");
+}
+
+} // namespace Pomerol

--- a/src/pomerol/ThreePointSusceptibility.cpp
+++ b/src/pomerol/ThreePointSusceptibility.cpp
@@ -231,6 +231,7 @@ ParticleIndex ThreePointSusceptibility::getIndex(std::size_t Position) const {
         switch(Position) {
         case 0: return F1.getIndex();
         case 1: return B.getIndex1();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         case 2: return static_cast<CreationOperator const&>(F2).getIndex();
         case 3: return B.getIndex2();
         }
@@ -238,6 +239,7 @@ ParticleIndex ThreePointSusceptibility::getIndex(std::size_t Position) const {
     case PH: {
         switch(Position) {
         case 0: return F1.getIndex();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
         case 1: return static_cast<AnnihilationOperator const&>(F2).getIndex();
         case 2: return B.getIndex1();
         case 3: return B.getIndex2();

--- a/src/pomerol/ThreePointSusceptibilityContainer.cpp
+++ b/src/pomerol/ThreePointSusceptibilityContainer.cpp
@@ -53,6 +53,7 @@ ThreePointSusceptibilityContainer::createElement(IndexCombination2 const& Indice
                                                           Operators.getAnnihilationOperator(Indices.Index2),
                                                           B,
                                                           DM);
+    default: assert(0);
     }
 }
 

--- a/src/pomerol/ThreePointSusceptibilityContainer.cpp
+++ b/src/pomerol/ThreePointSusceptibilityContainer.cpp
@@ -1,0 +1,60 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file src/pomerol/ThreePointSusceptibilityContainer.cpp
+/// \brief Storage for multiple 3-point susceptibilities in the Matsubara representation (implementation).
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#include "pomerol/ThreePointSusceptibilityContainer.hpp"
+
+namespace Pomerol {
+
+void ThreePointSusceptibilityContainer::prepareAll(std::set<IndexCombination2> const& InitialIndices) {
+    fill(InitialIndices);
+    for(auto& el : ElementsMap) {
+        el.second->ReduceResonanceTolerance = ReduceResonanceTolerance;
+        el.second->CoefficientTolerance = CoefficientTolerance;
+        el.second->prepare();
+    }
+}
+
+std::map<IndexCombination2, std::vector<ComplexType>>
+ThreePointSusceptibilityContainer::computeAll(bool clear, FreqVec2 const& freqs, MPI_Comm const& comm) {
+    std::map<IndexCombination2, std::vector<ComplexType>> out;
+    for(auto& el : ElementsMap) {
+        INFO("Computing 3PSusceptibility for " << el.first);
+        out.emplace(el.first, el.second->compute(clear, freqs, comm));
+    }
+    return out;
+}
+
+std::shared_ptr<ThreePointSusceptibility>
+ThreePointSusceptibilityContainer::createElement(IndexCombination2 const& Indices) const {
+    CreationOperator const& CX1 = Operators.getCreationOperator(Indices.Index1);
+    switch(Channel) {
+    case ThreePointSusceptibility::PP:
+        return std::make_shared<ThreePointSusceptibility>(S,
+                                                          H,
+                                                          CX1,
+                                                          Operators.getCreationOperator(Indices.Index2),
+                                                          B,
+                                                          DM);
+    case ThreePointSusceptibility::PH:
+    case ThreePointSusceptibility::CrossedPH:
+        return std::make_shared<ThreePointSusceptibility>(S,
+                                                          H,
+                                                          CX1,
+                                                          Operators.getAnnihilationOperator(Indices.Index2),
+                                                          B,
+                                                          DM);
+    }
+}
+
+} // namespace Pomerol

--- a/src/pomerol/ThreePointSusceptibilityContainer.cpp
+++ b/src/pomerol/ThreePointSusceptibilityContainer.cpp
@@ -47,7 +47,6 @@ ThreePointSusceptibilityContainer::createElement(IndexCombination2 const& Indice
                                                           B,
                                                           DM);
     case ThreePointSusceptibility::PH:
-    case ThreePointSusceptibility::CrossedPH:
         return std::make_shared<ThreePointSusceptibility>(S,
                                                           H,
                                                           CX1,

--- a/src/pomerol/ThreePointSusceptibilityPart.cpp
+++ b/src/pomerol/ThreePointSusceptibilityPart.cpp
@@ -246,12 +246,12 @@ template <bool Complex> void ThreePointSusceptibilityPart::computeImpl() {
         RealType E1 = Hpart1.getEigenValue(index1);
         RealType weight1 = DMpart1.getWeight(index1);
 
-        typename ColMajorMatrixType<Complex>::InnerIterator index3bra_iter(Bmatrix, index1);
         typename RowMajorMatrixType<Complex>::InnerIterator index2ket_iter(F1matrix, index1);
         for(; index2ket_iter; ++index2ket_iter) {
             RealType E2 = Hpart2.getEigenValue(index2ket_iter.index());
             RealType weight2 = DMpart2.getWeight(index2ket_iter.index());
 
+            typename ColMajorMatrixType<Complex>::InnerIterator index3bra_iter(Bmatrix, index1);
             typename RowMajorMatrixType<Complex>::InnerIterator index3ket_iter(F2matrix, index2ket_iter.index());
             while(index3bra_iter && index3ket_iter) {
                 if(chaseIndices<Complex>(index3ket_iter, index3bra_iter)) {

--- a/src/pomerol/ThreePointSusceptibilityPart.cpp
+++ b/src/pomerol/ThreePointSusceptibilityPart.cpp
@@ -1,0 +1,350 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file src/pomerol/ThreePointSusceptibilityPart.cpp
+/// \brief Part of a 3-point susceptibility in the Matsubara representation (implementation).
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#include "pomerol/ThreePointSusceptibilityPart.hpp"
+#include "pomerol/ChaseIndices.hpp"
+
+#include <cassert>
+#include <mutex>
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::mutex NonResonantFFTerm_mpi_datatype_mutex;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::mutex NonResonantFBTerm_mpi_datatype_mutex;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static std::mutex ResonantTerm_mpi_datatype_mutex;
+
+namespace Pomerol {
+
+//
+// ThreePointSusceptibilityPart::NonResonantFFTerm
+//
+
+ThreePointSusceptibilityPart::NonResonantFFTerm&
+ThreePointSusceptibilityPart::NonResonantFFTerm::operator+=(NonResonantFFTerm const& AnotherTerm) {
+    long combinedWeight = Weight + AnotherTerm.Weight;
+    for(unsigned short p = 0; p < 2; ++p)
+        // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
+        Poles[p] = (Weight * Poles[p] + AnotherTerm.Weight * AnotherTerm.Poles[p]) / combinedWeight;
+    Weight = combinedWeight;
+    Coeff += AnotherTerm.Coeff;
+    return *this;
+}
+
+// When called for the first time, this function creates an MPI structure datatype
+// describing ThreePointSusceptibilityPart::NonResonantFFTerm and registers it using MPI_Type_commit().
+// The registered datatype is stored in a static variable and is immediately returned
+// upon successive calls to mpi_datatype().
+//
+// About MPI structure datatypes:
+// https://pages.tacc.utexas.edu/~eijkhout/pcse/html/mpi-data.html#Structtype
+MPI_Datatype ThreePointSusceptibilityPart::NonResonantFFTerm::mpi_datatype() {
+    static MPI_Datatype dt;
+
+    // Since we are using static variables here, we have to make sure the code
+    // is thread-safe.
+    std::lock_guard<std::mutex> const lock(NonResonantFFTerm_mpi_datatype_mutex);
+
+    // Create and commit datatype only once
+    static bool type_committed = false;
+    if(!type_committed) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        int blocklengths[] = {1, 2, 1};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Aint displacements[] = {offsetof(NonResonantFFTerm, Coeff),
+                                    offsetof(NonResonantFFTerm, Poles),
+                                    offsetof(NonResonantFFTerm, Weight)};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Datatype types[] = {
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_DOUBLE,                 // RealType Poles[2]
+            MPI_LONG                    // long Weight
+        };
+        MPI_Type_create_struct(3, blocklengths, displacements, types, &dt);
+        MPI_Type_commit(&dt);
+        type_committed = true;
+    }
+    return dt;
+}
+
+//
+// ThreePointSusceptibilityPart::NonResonantFBTerm
+//
+
+ThreePointSusceptibilityPart::NonResonantFBTerm&
+ThreePointSusceptibilityPart::NonResonantFBTerm::operator+=(NonResonantFBTerm const& AnotherTerm) {
+    long combinedWeight = Weight + AnotherTerm.Weight;
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
+    P1 = (Weight * P1 + AnotherTerm.Weight * AnotherTerm.P1) / combinedWeight;
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
+    P12 = (Weight * P12 + AnotherTerm.Weight * AnotherTerm.P12) / combinedWeight;
+    Weight = combinedWeight;
+    Coeff += AnotherTerm.Coeff;
+    return *this;
+}
+
+// When called for the first time, this function creates an MPI structure datatype
+// describing ThreePointSusceptibilityPart::NonResonantFBTerm and registers it using MPI_Type_commit().
+// The registered datatype is stored in a static variable and is immediately returned
+// upon successive calls to mpi_datatype().
+//
+// About MPI structure datatypes:
+// https://pages.tacc.utexas.edu/~eijkhout/pcse/html/mpi-data.html#Structtype
+MPI_Datatype ThreePointSusceptibilityPart::NonResonantFBTerm::mpi_datatype() {
+    static MPI_Datatype dt;
+
+    // Since we are using static variables here, we have to make sure the code
+    // is thread-safe.
+    std::lock_guard<std::mutex> const lock(NonResonantFBTerm_mpi_datatype_mutex);
+
+    // Create and commit datatype only once
+    static bool type_committed = false;
+    if(!type_committed) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        int blocklengths[] = {1, 1, 1, 1, 1};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Aint displacements[] = {offsetof(NonResonantFBTerm, Coeff),
+                                    offsetof(NonResonantFBTerm, P1),
+                                    offsetof(NonResonantFBTerm, P12),
+                                    offsetof(NonResonantFBTerm, xi),
+                                    offsetof(NonResonantFBTerm, Weight)};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Datatype types[] = {
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_DOUBLE,                 // RealType P1
+            MPI_DOUBLE,                 // RealType P12
+            MPI_INT,                    // int xi
+            MPI_LONG                    // long Weight
+        };
+        MPI_Type_create_struct(5, blocklengths, displacements, types, &dt);
+        MPI_Type_commit(&dt);
+        type_committed = true;
+    }
+    return dt;
+}
+
+//
+// ThreePointSusceptibilityPart::ResonantTerm
+//
+
+ThreePointSusceptibilityPart::ResonantTerm&
+ThreePointSusceptibilityPart::ResonantTerm::operator+=(ResonantTerm const& AnotherTerm) {
+    long combinedWeight = Weight + AnotherTerm.Weight;
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
+    P = (Weight * P + AnotherTerm.Weight * AnotherTerm.P) / combinedWeight;
+    Weight = combinedWeight;
+    Coeff += AnotherTerm.Coeff;
+    return *this;
+}
+
+// When called for the first time, this function creates an MPI structure datatype
+// describing ThreePointSusceptibilityPart::ResonantTerm and registers it using MPI_Type_commit().
+// The registered datatype is stored in a static variable and is immediately returned
+// upon successive calls to mpi_datatype().
+//
+// About MPI structure datatypes:
+// https://pages.tacc.utexas.edu/~eijkhout/pcse/html/mpi-data.html#Structtype
+MPI_Datatype ThreePointSusceptibilityPart::ResonantTerm::mpi_datatype() {
+    static MPI_Datatype dt;
+
+    // Since we are using static variables here, we have to make sure the code
+    // is thread-safe.
+    std::lock_guard<std::mutex> const lock(ResonantTerm_mpi_datatype_mutex);
+
+    // Create and commit datatype only once
+    static bool type_committed = false;
+    if(!type_committed) {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        int blocklengths[] = {1, 1, 1, 1};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Aint displacements[] = {offsetof(ResonantTerm, Coeff),
+                                    offsetof(ResonantTerm, P),
+                                    offsetof(ResonantTerm, xi),
+                                    offsetof(ResonantTerm, Weight)};
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,modernize-avoid-c-arrays)
+        MPI_Datatype types[] = {
+            POMEROL_MPI_DOUBLE_COMPLEX, // ComplexType Coeff
+            MPI_DOUBLE,                 // RealType P
+            MPI_INT,                    // int xi
+            MPI_LONG                    // long Weight
+        };
+        MPI_Type_create_struct(4, blocklengths, displacements, types, &dt);
+        MPI_Type_commit(&dt);
+        type_committed = true;
+    }
+    return dt;
+}
+
+//
+// ThreePointSusceptibilityPart
+//
+
+ThreePointSusceptibilityPart::ThreePointSusceptibilityPart(MonomialOperatorPart const& F1,
+                                                           MonomialOperatorPart const& F2,
+                                                           MonomialOperatorPart const& B,
+                                                           HamiltonianPart const& Hpart1,
+                                                           HamiltonianPart const& Hpart2,
+                                                           HamiltonianPart const& Hpart3,
+                                                           DensityMatrixPart const& DMpart1,
+                                                           DensityMatrixPart const& DMpart2,
+                                                           DensityMatrixPart const& DMpart3,
+                                                           bool PP,
+                                                           bool SwappedFermionOps)
+    : Thermal(DMpart1.beta),
+      ComputableObject(),
+      F1(F1),
+      F2(F2),
+      B(B),
+      Hpart1(Hpart1),
+      Hpart2(Hpart2),
+      Hpart3(Hpart3),
+      DMpart1(DMpart1),
+      DMpart2(DMpart2),
+      DMpart3(DMpart3),
+      PP(PP),
+      SwappedFermionOps(SwappedFermionOps),
+      NonResonantFFTerms(NonResonantFFTerm::Compare(), NonResonantFFTerm::IsNegligible()),
+      NonResonantFBTerms(NonResonantFBTerm::Compare(), NonResonantFBTerm::IsNegligible()),
+      ResonantTerms(ResonantTerm::Compare(), ResonantTerm::IsNegligible()) {}
+
+void ThreePointSusceptibilityPart::compute() {
+    if(getStatus() >= Computed)
+        return;
+
+    if(F1.isComplex() || F2.isComplex() || B.isComplex())
+        computeImpl<true>();
+    else
+        computeImpl<false>();
+}
+
+template <bool Complex> void ThreePointSusceptibilityPart::computeImpl() {
+    NonResonantFFTerms.clear();
+    NonResonantFBTerms.clear();
+    ResonantTerms.clear();
+
+    RealType beta = DMpart1.beta;
+    RealType prefactor = (PP == SwappedFermionOps) ? -1 : 1;
+
+    // <1| F1 |2> <2| F2 |3> <3| B |1>
+    RowMajorMatrixType<Complex> const& F1matrix = F1.getRowMajorValue<Complex>();
+    RowMajorMatrixType<Complex> const& F2matrix = F2.getRowMajorValue<Complex>();
+    ColMajorMatrixType<Complex> const& Bmatrix = B.getColMajorValue<Complex>();
+
+    InnerQuantumState index1Max = Bmatrix.outerSize();
+    for(InnerQuantumState index1 = 0; index1 < index1Max; ++index1) {
+        RealType E1 = Hpart1.getEigenValue(index1);
+        RealType weight1 = DMpart1.getWeight(index1);
+
+        typename ColMajorMatrixType<Complex>::InnerIterator index3bra_iter(Bmatrix, index1);
+        typename RowMajorMatrixType<Complex>::InnerIterator index2ket_iter(F1matrix, index1);
+        for(; index2ket_iter; ++index2ket_iter) {
+            RealType E2 = Hpart2.getEigenValue(index2ket_iter.index());
+            RealType weight2 = DMpart2.getWeight(index2ket_iter.index());
+
+            typename RowMajorMatrixType<Complex>::InnerIterator index3ket_iter(F2matrix, index2ket_iter.index());
+            while(index3bra_iter && index3ket_iter) {
+                if(chaseIndices<Complex>(index3ket_iter, index3bra_iter)) {
+                    RealType E3 = Hpart3.getEigenValue(index3ket_iter.index());
+                    RealType weight3 = DMpart3.getWeight(index3ket_iter.index());
+
+                    ComplexType MatrixElement =
+                        index2ket_iter.value() * index3ket_iter.value() * index3bra_iter.value();
+                    MatrixElement *= prefactor;
+
+                    addMultiterm(MatrixElement, beta, E1, E2, E3, weight1, weight2, weight3);
+
+                    ++index3bra_iter;
+                    ++index3ket_iter;
+                }
+            }
+        }
+    }
+
+    INFO("Total " << NonResonantFFTerms.size() << "+" << NonResonantFBTerms.size() << "+" << ResonantTerms.size() << "="
+                  << NonResonantFFTerms.size() + NonResonantFBTerms.size() + ResonantTerms.size() << " terms");
+
+    assert(NonResonantFFTerms.check_terms());
+    assert(NonResonantFBTerms.check_terms());
+    assert(ResonantTerms.check_terms());
+
+    setStatus(Computed);
+}
+
+inline void ThreePointSusceptibilityPart::addMultiterm(ComplexType Coeff,
+                                                       RealType beta,
+                                                       RealType Ei,
+                                                       RealType Ej,
+                                                       RealType Ek,
+                                                       RealType Wi,
+                                                       RealType Wj,
+                                                       RealType Wk) {
+    RealType Eij = Ei - Ej;
+    RealType Ejk = Ej - Ek;
+    RealType Eik = Ei - Ek;
+
+    // Non-resonant fermion-fermion term that is always present.
+    ComplexType CoeffNRFF = Coeff * (Wi + Wj);
+    if(std::abs(CoeffNRFF) > CoefficientTolerance) {
+        NonResonantFFTerms.add_term(NonResonantFFTerm(PP ? -CoeffNRFF : CoeffNRFF,
+                                                      SwappedFermionOps ? Ejk : Eij,
+                                                      (SwappedFermionOps ? Eij : Ejk) * (PP ? 1 : -1)));
+    }
+
+    // Resonant term
+    if(std::abs(Eik) < ReduceResonanceTolerance) {
+        ComplexType CoeffR = -Coeff * beta * Wi;
+        if(std::abs(CoeffR) > CoefficientTolerance) {
+            ResonantTerms.add_term(
+                ResonantTerm(SwappedFermionOps ? -CoeffR : CoeffR, SwappedFermionOps ? Ejk : -Ejk, PP ? -1 : 1));
+        }
+    } else {
+        // Non-resonant fermion-boson term
+        ComplexType CoeffNRFB = Coeff * (Wk - Wi);
+        if(std::abs(CoeffNRFB) > CoefficientTolerance) {
+            NonResonantFBTerms.add_term(NonResonantFBTerm(SwappedFermionOps ? -CoeffNRFB : CoeffNRFB,
+                                                          SwappedFermionOps ? Ejk : Eij,
+                                                          Eik,
+                                                          PP ? -1 : 1));
+
+            // Extra non-resonant fermion-fermion term
+            if(!SwappedFermionOps) {
+                NonResonantFFTerms.add_term(NonResonantFFTerm(PP ? -CoeffNRFB : CoeffNRFB, Eij, PP ? Ejk : -Ejk));
+            }
+        }
+    }
+}
+
+ComplexType ThreePointSusceptibilityPart::operator()(long MatsubaraNumber1, long MatsubaraNumber2) const {
+    long MatsubaraNumberOdd1 = 2 * MatsubaraNumber1 + 1;
+    long MatsubaraNumberOdd2 = 2 * MatsubaraNumber2 + 1;
+    return (*this)(MatsubaraSpacing * RealType(MatsubaraNumberOdd1), MatsubaraSpacing * RealType(MatsubaraNumberOdd2));
+}
+
+ComplexType ThreePointSusceptibilityPart::operator()(ComplexType z1, ComplexType z2) const {
+    if(getStatus() != Computed) {
+        throw StatusMismatch("3PSusceptibilityPart: Calling operator() on uncomputed container. Did you purge all the "
+                             "terms when called compute()?");
+    }
+
+    return NonResonantFFTerms(z1, z2) + NonResonantFBTerms(z1, z2) + ResonantTerms(z1, z2, ReduceResonanceTolerance);
+}
+
+void ThreePointSusceptibilityPart::clear() {
+    NonResonantFFTerms.clear();
+    NonResonantFBTerms.clear();
+    ResonantTerms.clear();
+    setStatus(Constructed);
+}
+
+} // namespace Pomerol

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -122,13 +122,13 @@ void TwoParticleGF::prepare() {
 }
 
 // An mpi adapter to 1) compute 2pgf terms; 2) convert them to a Matsubara Container; 3) purge terms
-struct ComputeAndClearWrap {
-    ComputeAndClearWrap(FreqVec3 const& freqs,
-                        std::vector<ComplexType>& data,
-                        TwoParticleGFPart& p,
-                        bool clear,
-                        bool fill,
-                        int complexity = 1)
+struct ComputeAndClearWrap2PGF {
+    ComputeAndClearWrap2PGF(FreqVec3 const& freqs,
+                            std::vector<ComplexType>& data,
+                            TwoParticleGFPart& p,
+                            bool clear,
+                            bool fill,
+                            int complexity = 1)
         : complexity(complexity), freqs_(freqs), data_(data), p(p), clear_(clear), fill_(fill) {}
 
     void run() {
@@ -170,7 +170,7 @@ std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec3 const& freq
 
     if(!Vanishing) {
         // Create a "skeleton" class with pointers to part that can call a compute method
-        pMPI::mpi_skel<ComputeAndClearWrap> skel;
+        pMPI::mpi_skel<ComputeAndClearWrap2PGF> skel;
         bool fill_container = !freqs.empty();
         skel.parts.reserve(parts.size());
         m_data.resize(freqs.size(), 0.0);

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -123,7 +123,7 @@ void TwoParticleGF::prepare() {
 
 // An mpi adapter to 1) compute 2pgf terms; 2) convert them to a Matsubara Container; 3) purge terms
 struct ComputeAndClearWrap {
-    ComputeAndClearWrap(FreqVec const& freqs,
+    ComputeAndClearWrap(FreqVec3 const& freqs,
                         std::vector<ComplexType>& data,
                         TwoParticleGFPart& p,
                         bool clear,
@@ -153,14 +153,14 @@ struct ComputeAndClearWrap {
     int const complexity;
 
 private:
-    FreqVec const& freqs_;
+    FreqVec3 const& freqs_;
     std::vector<ComplexType>& data_;
     TwoParticleGFPart& p;
     bool clear_;
     bool fill_;
 };
 
-std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec const& freqs, MPI_Comm const& comm) {
+std::vector<ComplexType> TwoParticleGF::compute(bool clear, FreqVec3 const& freqs, MPI_Comm const& comm) {
     if(getStatus() < Prepared)
         throw StatusMismatch("TwoParticleGF is not prepared yet.");
 

--- a/src/pomerol/TwoParticleGF.cpp
+++ b/src/pomerol/TwoParticleGF.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -32,7 +32,7 @@ void TwoParticleGFContainer::prepareAll(std::set<IndexCombination4> const& Initi
 }
 
 std::map<IndexCombination4, std::vector<ComplexType>>
-TwoParticleGFContainer::computeAll(bool clearTerms, FreqVec const& freqs, MPI_Comm const& comm, bool split) {
+TwoParticleGFContainer::computeAll(bool clearTerms, FreqVec3 const& freqs, MPI_Comm const& comm, bool split) {
     if(split)
         return computeAll_split(clearTerms, freqs, comm);
     else
@@ -40,7 +40,7 @@ TwoParticleGFContainer::computeAll(bool clearTerms, FreqVec const& freqs, MPI_Co
 }
 
 std::map<IndexCombination4, std::vector<ComplexType>>
-TwoParticleGFContainer::computeAll_nosplit(bool clearTerms, FreqVec const& freqs, MPI_Comm const& comm) {
+TwoParticleGFContainer::computeAll_nosplit(bool clearTerms, FreqVec3 const& freqs, MPI_Comm const& comm) {
     std::map<IndexCombination4, std::vector<ComplexType>> out;
     for(auto& el : ElementsMap) {
         INFO("Computing 2PGF for " << el.first);
@@ -50,7 +50,7 @@ TwoParticleGFContainer::computeAll_nosplit(bool clearTerms, FreqVec const& freqs
 }
 
 std::map<IndexCombination4, std::vector<ComplexType>>
-TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec const& freqs, MPI_Comm const& comm) {
+TwoParticleGFContainer::computeAll_split(bool clearTerms, FreqVec3 const& freqs, MPI_Comm const& comm) {
     std::map<IndexCombination4, std::vector<ComplexType>> out;
     std::map<IndexCombination4, std::vector<ComplexType>> storage;
 

--- a/src/pomerol/TwoParticleGFContainer.cpp
+++ b/src/pomerol/TwoParticleGFContainer.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -14,6 +14,7 @@
 /// \author Andrey Antipov (andrey.e.antipov@gmail.com)
 
 #include "pomerol/TwoParticleGFPart.hpp"
+#include "pomerol/ChaseIndices.hpp"
 
 #include <cassert>
 #include <mutex>
@@ -22,31 +23,11 @@
 #include <vector>
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::mutex NonResonantTerm_mpi_datatype_mutex;
+static std::mutex NonResonantTerm_mpi_datatype_mutex;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-std::mutex ResonantTerm_mpi_datatype_mutex;
+static std::mutex ResonantTerm_mpi_datatype_mutex;
 
 namespace Pomerol {
-
-// Make the lagging index catch up or outrun the leading index.
-template <bool Complex>
-inline bool chaseIndices(typename RowMajorMatrixType<Complex>::InnerIterator& index1_iter,
-                         typename ColMajorMatrixType<Complex>::InnerIterator& index2_iter) {
-    InnerQuantumState index1 = index1_iter.index();
-    InnerQuantumState index2 = index2_iter.index();
-
-    if(index1 == index2)
-        return true;
-
-    if(index1 < index2)
-        for(; InnerQuantumState(index1_iter.index()) < index2 && index1_iter; ++index1_iter)
-            ;
-    else
-        for(; InnerQuantumState(index2_iter.index()) < index1 && index2_iter; ++index2_iter)
-            ;
-
-    return false;
-}
 
 //
 // TwoParticleGFPart::NonResonantTerm

--- a/src/pomerol/TwoParticleGFPart.cpp
+++ b/src/pomerol/TwoParticleGFPart.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/pomerol/Vertex4.cpp
+++ b/src/pomerol/Vertex4.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/3PSusc1siteTest.cpp
+++ b/test/3PSusc1siteTest.cpp
@@ -1,0 +1,179 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file test/3PSusc1siteTest.cpp
+/// \brief 3-point susceptibilities of a single Hubbard atom.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#include <pomerol/DensityMatrix.hpp>
+#include <pomerol/FieldOperatorContainer.hpp>
+#include <pomerol/Hamiltonian.hpp>
+#include <pomerol/HilbertSpace.hpp>
+#include <pomerol/IndexClassification.hpp>
+#include <pomerol/LatticePresets.hpp>
+#include <pomerol/Misc.hpp>
+#include <pomerol/MonomialOperator.hpp>
+#include <pomerol/ThreePointSusceptibility.hpp>
+
+#include "catch2/catch-pomerol.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+using namespace Pomerol;
+
+// Auxiliary function g used in expressions for reference solutions
+struct g_aux {
+    RealType beta;
+    // Order of many-body states: |0>, |up>, |dn>, |2>
+    std::vector<RealType> E;
+    std::vector<RealType> rho;
+
+    g_aux(RealType beta, RealType U, RealType mu, RealType h_field)
+        : beta(beta), E{0, -mu - h_field, -mu + h_field, U - 2 * mu}, rho(4) {
+        std::transform(E.begin(), E.end(), rho.begin(), [beta](RealType e) { return std::exp(-beta * e); });
+        double Z = std::accumulate(rho.begin(), rho.end(), .0);
+        std::transform(rho.begin(), rho.end(), rho.begin(), [Z](RealType w) { return w / Z; });
+    }
+
+    static bool delta(RealType w1, RealType w2) { return std::abs(w1 - w2) < 1e-14 ? 1.0 : 0.0; };
+
+    ComplexType operator()(int i, int j, int k, RealType w1, RealType w2) const {
+        if(std::abs(rho[k] - rho[i]) < 1e-14) {
+            return 1. / (I * w2 + E[j] - E[k]) * (rho[i] + rho[j]) / (I * w1 + E[i] - E[j]) +
+                   beta * delta(w1, -w2) * rho[i] / (I * w2 + E[j] - E[i]);
+        } else {
+            return 1. / (I * w2 + E[j] - E[k]) *
+                   ((rho[k] - rho[i]) / (I * w1 + I * w2 + E[i] - E[k]) + (rho[i] + rho[j]) / (I * w1 + E[i] - E[j]));
+        }
+    }
+};
+
+TEST_CASE("3-point susceptibilities of a single Hubbard atom", "[ThreePointSusceptibility]") {
+    RealType U = 1.0;
+    RealType mu = 0.4;
+    auto h_field = GENERATE(values({.0, 0.01}));
+    RealType beta = 10.0;
+    int n_iw = 20;
+
+    using namespace LatticePresets;
+
+    auto HExpr = CoulombS("A", U, -mu) + Magnetization("A", -h_field);
+    INFO("Hamiltonian\n" << HExpr);
+
+    auto IndexInfo = MakeIndexClassification(HExpr);
+    INFO("Indices\n" << IndexInfo);
+
+    auto HS = MakeHilbertSpace(IndexInfo, HExpr);
+    HS.compute();
+    StatesClassification S;
+    S.compute(HS);
+
+    Hamiltonian H(S);
+    H.prepare(HExpr, HS, MPI_COMM_WORLD);
+    H.compute(MPI_COMM_WORLD);
+    INFO("Energy levels " << H.getEigenValues());
+    INFO("The value of ground energy is " << H.getGroundEnergy());
+
+    DensityMatrix rho(S, H, beta);
+    rho.prepare();
+    rho.compute();
+
+    FieldOperatorContainer Operators(IndexInfo, HS, S, H);
+    Operators.prepareAll(HS);
+    Operators.computeAll();
+
+    ParticleIndex up_index = IndexInfo.getIndex("A", 0, up);
+    ParticleIndex dn_index = IndexInfo.getIndex("A", 0, down);
+
+    auto omega = [beta](int n) { return M_PI * (2 * n + 1) / beta; };
+    g_aux g(beta, U, mu, h_field);
+
+    SECTION("Particle-particle channel") {
+        for(auto index1 : {up_index, dn_index}) {
+            for(auto index2 : {up_index, dn_index}) {
+
+                // Pairing operator
+                QuadraticOperator Delta(IndexInfo, HS, S, H, index1, index2, {false, false});
+                Delta.prepare(HS);
+                Delta.compute();
+
+                ThreePointSusceptibility chi3pp(S,
+                                                H,
+                                                Operators.getCreationOperator(index1),
+                                                Operators.getCreationOperator(index2),
+                                                Delta,
+                                                rho);
+                chi3pp.prepare();
+                chi3pp.compute();
+
+                if(index1 == index2) {
+                    REQUIRE(chi3pp.isVanishing());
+                } else {
+                    auto ref = [&](int n1, int n2) {
+                        return g(3, (index2 == up_index ? 1 : 2), 0, -omega(n1), -omega(n2)) +
+                               g(3, (index1 == up_index ? 1 : 2), 0, -omega(n2), -omega(n1));
+                    };
+                    for(int n1 = -n_iw; n1 < n_iw; ++n1) {
+                        for(int n2 = -n_iw; n2 < n_iw; ++n2) {
+                            REQUIRE_THAT(chi3pp(n1, n2), IsCloseTo(ref(n1, n2), 1e-14));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    SECTION("Particle-hole channel") {
+        for(auto index1 : {up_index, dn_index}) {
+            for(auto index2 : {up_index, dn_index}) {
+
+                // Density operator
+                QuadraticOperator N(IndexInfo, HS, S, H, index2, index2);
+                N.prepare(HS);
+                N.compute();
+
+                ThreePointSusceptibility chi3ph(S,
+                                                H,
+                                                Operators.getCreationOperator(index1),
+                                                Operators.getAnnihilationOperator(index1),
+                                                N,
+                                                rho);
+                chi3ph.prepare();
+                chi3ph.compute();
+
+                if(index1 == index2) {
+                    auto ref = [&](int n1, int n2) {
+                        int st1 = index1 == up_index ? 1 : 2;
+                        int st2 = index1 == up_index ? 2 : 1;
+                        return g(st1, 0, st1, -omega(n1), omega(n2)) + g(3, st2, 3, -omega(n1), omega(n2));
+                    };
+                    for(int n1 = -n_iw; n1 < n_iw; ++n1) {
+                        for(int n2 = -n_iw; n2 < n_iw; ++n2) {
+                            REQUIRE_THAT(chi3ph(n1, n2), IsCloseTo(ref(n1, n2), 1e-14));
+                        }
+                    }
+                } else {
+                    auto ref = [&](int n1, int n2) {
+                        int st = index2 == up_index ? 1 : 2;
+                        return g(3, st, 3, -omega(n1), omega(n2)) - g(st, 3, st, omega(n1), -omega(n2));
+                    };
+                    for(int n1 = -n_iw; n1 < n_iw; ++n1) {
+                        for(int n2 = -n_iw; n2 < n_iw; ++n2) {
+                            REQUIRE_THAT(chi3ph(n1, n2), IsCloseTo(ref(n1, n2), 1e-14));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/3PSusc1siteTest.cpp
+++ b/test/3PSusc1siteTest.cpp
@@ -103,7 +103,7 @@ TEST_CASE("3-point susceptibilities of a single Hubbard atom", "[ThreePointSusce
             for(auto index2 : {up_index, dn_index}) {
 
                 // Pairing operator
-                QuadraticOperator Delta(IndexInfo, HS, S, H, index1, index2, {false, false});
+                QuadraticOperator Delta(IndexInfo, HS, S, H, index1, index2, std::make_tuple(false, false));
                 Delta.prepare(HS);
                 Delta.compute();
 

--- a/test/3PSusc1siteTest.cpp
+++ b/test/3PSusc1siteTest.cpp
@@ -45,7 +45,7 @@ struct g_aux {
         std::transform(rho.begin(), rho.end(), rho.begin(), [Z](RealType w) { return w / Z; });
     }
 
-    static bool delta(RealType w1, RealType w2) { return std::abs(w1 - w2) < 1e-14 ? 1.0 : 0.0; };
+    static double delta(RealType w1, RealType w2) { return std::abs(w1 - w2) < 1e-14 ? 1.0 : 0.0; };
 
     ComplexType operator()(int i, int j, int k, RealType w1, RealType w2) const {
         if(std::abs(rho[k] - rho[i]) < 1e-14) {

--- a/test/3PSusc3siteTest.cpp
+++ b/test/3PSusc3siteTest.cpp
@@ -69,7 +69,7 @@ TEST_CASE("3-point susceptibilities of a small Hubbard cluster", "[ThreePointSus
 
     SECTION("Particle-particle channel") {
         // Pairing operator
-        QuadraticOperator Delta(IndexInfo, HS, S, H, C_up_index, C_dn_index, {false, false});
+        QuadraticOperator Delta(IndexInfo, HS, S, H, C_up_index, C_dn_index, std::make_tuple(false, false));
         Delta.prepare(HS);
         Delta.compute();
 

--- a/test/3PSusc3siteTest.cpp
+++ b/test/3PSusc3siteTest.cpp
@@ -1,0 +1,133 @@
+//
+// This file is part of pomerol, an exact diagonalization library aimed at
+// solving condensed matter models of interacting fermions.
+//
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+/// \file test/3PSusc3siteTest.cpp
+/// \brief 3-point susceptibilities of a small Hubbard cluster.
+/// \author Igor Krivenko (igor.s.krivenko@gmail.com)
+
+#include <pomerol/DensityMatrix.hpp>
+#include <pomerol/FieldOperatorContainer.hpp>
+#include <pomerol/Hamiltonian.hpp>
+#include <pomerol/HilbertSpace.hpp>
+#include <pomerol/IndexClassification.hpp>
+#include <pomerol/LatticePresets.hpp>
+#include <pomerol/Misc.hpp>
+#include <pomerol/MonomialOperator.hpp>
+#include <pomerol/ThreePointSusceptibility.hpp>
+
+#include "catch2/catch-pomerol.hpp"
+
+using namespace Pomerol;
+
+TEST_CASE("3-point susceptibilities of a small Hubbard cluster", "[ThreePointSusceptibility]") {
+    RealType U = 4.0;
+    RealType mu = 0.6 * U;
+    RealType t = 1.0;
+    RealType beta = 5.0;
+
+    using namespace LatticePresets;
+
+    auto HExpr = CoulombS("A", U, -mu) + CoulombS("B", U, -mu) + CoulombS("C", U, -mu);
+    HExpr += Hopping("A", "B", -t);
+    HExpr += Hopping("B", "C", -t);
+    HExpr += Hopping("C", "A", -t);
+    INFO("Hamiltonian\n" << HExpr);
+
+    auto IndexInfo = MakeIndexClassification(HExpr);
+    INFO("Indices\n" << IndexInfo);
+
+    auto HS = MakeHilbertSpace(IndexInfo, HExpr);
+    HS.compute();
+    StatesClassification S;
+    S.compute(HS);
+
+    Hamiltonian H(S);
+    H.prepare(HExpr, HS, MPI_COMM_WORLD);
+    H.compute(MPI_COMM_WORLD);
+    INFO("Energy levels " << H.getEigenValues());
+    INFO("The value of ground energy is " << H.getGroundEnergy());
+
+    DensityMatrix rho(S, H, beta);
+    rho.prepare();
+    rho.compute();
+
+    FieldOperatorContainer Operators(IndexInfo, HS, S, H);
+    Operators.prepareAll(HS);
+    Operators.computeAll();
+
+    ParticleIndex A_up_index = IndexInfo.getIndex("A", 0, up);
+    ParticleIndex A_dn_index = IndexInfo.getIndex("A", 0, down);
+    ParticleIndex C_up_index = IndexInfo.getIndex("C", 0, up);
+    ParticleIndex C_dn_index = IndexInfo.getIndex("C", 0, down);
+
+    SECTION("Particle-particle channel") {
+        // Pairing operator
+        QuadraticOperator Delta(IndexInfo, HS, S, H, C_up_index, C_dn_index, {false, false});
+        Delta.prepare(HS);
+        Delta.compute();
+
+        ThreePointSusceptibility chi3pp(S,
+                                        H,
+                                        Operators.getCreationOperator(A_up_index),
+                                        Operators.getCreationOperator(A_dn_index),
+                                        Delta,
+                                        rho);
+        chi3pp.prepare();
+        chi3pp.compute();
+
+        // Reference values from 'chi3cluster.py'
+        ComplexMatrixType chi3_ref(3, 3);
+        chi3_ref << 0.056123393380680404 - 0.027886788783494966 * I, 0.03544036019820439,
+            0.008008339386258077 - 0.0022610905291281 * I, 0.03544036019820439,
+            0.056123393380680404 + 0.027886788783494966 * I, 0.026205160724877802 + 0.020851328654297216 * I,
+            0.008008339386258187 - 0.002261090529127845 * I, 0.026205160724877885 + 0.020851328654297483 * I,
+            0.013637220898198006 + 0.012985397056265282 * I;
+
+        for(int n1 = -1; n1 <= 1; ++n1) {
+            for(int n2 = -1; n2 <= 1; ++n2) {
+                auto result = chi3pp(n1, n2);
+                auto ref = chi3_ref(n1 + 1, n2 + 1);
+                REQUIRE_THAT(result, IsCloseTo(ref, 1e-10));
+            }
+        }
+    }
+
+    SECTION("Particle-hole channel") {
+        // Density operator
+        QuadraticOperator N(IndexInfo, HS, S, H, C_dn_index, C_dn_index);
+        N.prepare(HS);
+        N.compute();
+
+        ThreePointSusceptibility chi3ph(S,
+                                        H,
+                                        Operators.getCreationOperator(A_up_index),
+                                        Operators.getAnnihilationOperator(A_up_index),
+                                        N,
+                                        rho);
+        chi3ph.prepare();
+        chi3ph.compute();
+
+        // Reference values from 'chi3cluster.py'
+        ComplexMatrixType chi3_ref(3, 3);
+        chi3_ref << -0.03377687240880357 + 0.6799848693219751 * I, -0.01589165211289571,
+            -0.010498942766103334 - 0.0019558762969712905 * I, -0.01589165211289571,
+            -0.03377687240880357 - 0.6799848693219751 * I, 0.028277168735633868 + 0.006544223759963227 * I,
+            -0.010498942766103213 - 0.001955876296971393 * I, 0.02827716873563382 + 0.006544223759962816 * I,
+            0.03857021454863498 - 0.6687150248684948 * I;
+
+        for(int n1 = -1; n1 <= 1; ++n1) {
+            for(int n2 = -1; n2 <= 1; ++n2) {
+                auto result = chi3ph(n1, n2);
+                auto ref = chi3_ref(n1 + 1, n2 + 1);
+                REQUIRE_THAT(result, IsCloseTo(ref, 1e-10));
+            }
+        }
+    }
+}

--- a/test/Anderson2PGFTest.cpp
+++ b/test/Anderson2PGFTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/AndersonComplexTest.cpp
+++ b/test/AndersonComplexTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/AndersonTest.cpp
+++ b/test/AndersonTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/BroadcastTest.cpp
+++ b/test/BroadcastTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ set(tests
     Vertex4Test
     SusceptibilityTest
     3PSusc1siteTest
+    3PSusc3siteTest
 )
 
 foreach(test ${tests})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ set(tests
     Anderson2PGFTest
     Vertex4Test
     SusceptibilityTest
+    3PSusc1siteTest
 )
 
 foreach(test ${tests})

--- a/test/GF1siteTest.cpp
+++ b/test/GF1siteTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/GF2siteTest.cpp
+++ b/test/GF2siteTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/GF4siteTest.cpp
+++ b/test/GF4siteTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/HamiltonianBosonsTest.cpp
+++ b/test/HamiltonianBosonsTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/HamiltonianTest.cpp
+++ b/test/HamiltonianTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/MPIDispatcherTest.cpp
+++ b/test/MPIDispatcherTest.cpp
@@ -35,7 +35,6 @@ struct dumb_task_type {
 };
 
 TEST_CASE("Test mpi_dispatcher", "[mpi_dispatcher]") {
-    std::random_device rd;
     std::mt19937 gen(100000);
     int comm_rank = pMPI::rank(MPI_COMM_WORLD);
     int const root = 0;

--- a/test/MPIDispatcherTest.cpp
+++ b/test/MPIDispatcherTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/SusceptibilityTest.cpp
+++ b/test/SusceptibilityTest.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/Vertex4Test.cpp
+++ b/test/Vertex4Test.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/catch2/catch-pomerol.hpp
+++ b/test/catch2/catch-pomerol.hpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/catch2/catch2-main.cpp
+++ b/test/catch2/catch2-main.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is part of pomerol, an exact diagonalization library aimed at
 # solving condensed matter models of interacting fermions.
 #
-# Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+# Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/tutorial/example2site.cpp
+++ b/tutorial/example2site.cpp
@@ -2,7 +2,7 @@
 // This file is part of pomerol, an exact diagonalization library aimed at
 // solving condensed matter models of interacting fermions.
 //
-// Copyright (C) 2016-2021 A. Antipov, I. Krivenko and contributors
+// Copyright (C) 2016-2022 A. Antipov, I. Krivenko and contributors
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
A new piece of functionality requested by @dominikkiese and @Wentzell, who also worked out the Lehmann representation of the added correlators.

The 3-point susceptibility in the Matsubara representation is defined according to
$$\chi^{(3)}(\omega_{n_1},\omega_{n_2}) = \int_0^\beta e^{-i\omega_{n_1}\tau_1} e^{-i\omega_{n_2}\tau_2} \chi^{(3)}(\tau_1, \tau_2) d\tau_1 d\tau_2,$$ where the imaginary time susceptibility can be defined in one of the following channels.
* Particle-particle channel: $\chi^{(3)}_{pp}(\tau_1,\tau_2) = Tr[\mathbb{T} \hat\rho c^\dagger_1(\tau_1) c_2(0) c^\dagger_3(\tau_2) c_4(0)]$;
* Particle-hole channel: $\chi^{(3)}_{ph}(\tau_1,\tau_2) = Tr[\mathbb{T} \hat\rho c^\dagger_1(\tau_1) c_2(\tau_2) c^\dagger_3(0) c_4(0)]$.

Following the usual scheme, $\chi^{(3)}$ calculations are performed by three new classes, `ThreePointSusceptibility`, `ThreePointSusceptibilityPart` and `ThreePointSusceptibilityContainer`. The user interface is also very similar to those of `GreensFunction` and `TwoParticleGF`.

Other notable changes in this PR:

* `QuadraticOperator` can now be a product of two creators or two annihilators. This change was needed because the constructor of $\chi^{(3)}_{pp}$ expects a precomputed quadratic operator $\Delta = c_2 c_4$;
* 2 new unit tests, `3PSusc1siteTest` and `3PSusc3siteTest`;
* Doxygen documentation of the new classes;
* Updated tutorial;
* Pomerol version bumped to 2.1.