### PR TITLE
Fix initHMatrix link issue and various smaller cmake issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ get_target_property(libcommute_INCLUDE_PATH libcommute
 message(STATUS "libcommute includes: ${libcommute_INCLUDE_PATH}")
 
 # MPI
-find_package(MPI 3.0 REQUIRED)
+find_package(MPI 3 REQUIRED)
 message(STATUS "MPI includes: ${MPI_CXX_INCLUDE_PATH}")
 message(STATUS "MPI C++ libs: ${MPI_CXX_LIBRARIES}")
 message(STATUS "MPI flags: ${MPI_CXX_COMPILE_FLAGS} ${MPI_C_COMPILE_FLAGS}")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -17,9 +17,11 @@ set(DOXYFILE_OUTPUT_DIR "${CMAKE_BINARY_DIR}/doc")
 include(UseDoxygen)
 
 # Install documentation
-include(GNUInstallDirs)
-install(DIRECTORY ${DOXYFILE_OUTPUT_DIR}/html
-        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+if(DOXYGEN_FOUND)
+  include(GNUInstallDirs)
+  install(DIRECTORY ${DOXYFILE_OUTPUT_DIR}/html
+          DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
-file(GLOB MD_FILES "${CMAKE_SOURCE_DIR}/*.md")
-install(FILES ${MD_FILES} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+  file(GLOB MD_FILES "${CMAKE_SOURCE_DIR}/*.md")
+  install(FILES ${MD_FILES} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,8 +58,7 @@ target_compile_options(${PROJECT_NAME} PUBLIC ${MPI_CXX_COMPILE_FLAGS}
 set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(OpenMP_CXX_FOUND)
-    target_compile_options(${PROJECT_NAME} PRIVATE ${CMAKE_CXX_FLAGS}
-                                                   ${OpenMP_CXX_FLAGS})
+    target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
     target_link_libraries(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
 endif()
 

--- a/src/pomerol/HamiltonianPart.cpp
+++ b/src/pomerol/HamiltonianPart.cpp
@@ -38,6 +38,8 @@ template <bool C> void HamiltonianPart::initHMatrix() {
     InnerQuantumState BlockSize = S.getBlockSize(Block);
     HMatrix = std::make_shared<MatrixType<C>>(BlockSize, BlockSize);
 }
+template void HamiltonianPart::initHMatrix<true>();
+template void HamiltonianPart::initHMatrix<false>();
 
 void HamiltonianPart::prepare() {
     if(getStatus() >= Prepared)


### PR DESCRIPTION
This PR fixes a link issue with clang-15
```
../src/libpomerol.so: undefined reference to `void Pomerol::HamiltonianPart::initHMatrix<false>()'
../src/libpomerol.so: undefined reference to `void Pomerol::HamiltonianPart::initHMatrix<true>()'
```
where the instantiations of the initHMatrix template member functions are not triggered due to inlining within the HamiltonianPart.cpp. It may instead be worth moving this function into the header to allow it to be inlined elsewhere.

This PR also fixes a number of smaller CMake issues

-  Do not add CMAKE_CXX_FLAGS in target_compile_options, this will be done automatically
-  Install doc only when doxygen was found
- Allow all MPI versions 3.x